### PR TITLE
Update bazel-bin filepath in 'Sample usage' section

### DIFF
--- a/magenta/scripts/convert_midi_dir_to_note_sequences.py
+++ b/magenta/scripts/convert_midi_dir_to_note_sequences.py
@@ -15,7 +15,7 @@ r""""Converts MIDIs to NoteSequence protos and writes TFRecord file.
 
 Sample usage:
   $ bazel build magenta:convert_midi_dir_to_note_sequences
-  $ bazel-bin/magenta/scripts/convert_midi_dir_to_note_sequences \
+  $ bazel-bin/magenta/convert_midi_dir_to_note_sequences \
     --midi_dir=/path/to/midi/dir \
     --output_file=/path/to/tfrecord/file \
     --recursive


### PR DESCRIPTION
After building the convert_midi_dir_to_note_sequences script, the resulting files are directly in bazel-bin/magenta (and not in bazel-bin/magenta/scripts).