### PR TITLE
Link to whole basic_rnn folder to show the readme plus the files

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ bazel build //magenta:convert_midi_dir_to_note_sequences
 
 To create your own melodies with TensorFlow, train a model on the dataset you built above and then use it to generate new sequences. Select a model below for further instructions.
 
-**[Basic RNN](magenta/models/basic_rnn/README.md)**: A simple recurrent neural network for predicting melodies.
+**[Basic RNN](magenta/models/basic_rnn)**: A simple recurrent neural network for predicting melodies.


### PR DESCRIPTION
When reading the readme for basic_rnn I had to stop and see where convert_sequences_to_melodies.py is, but if we instead link to the folder and not directly to it's readme, then those files will be visible right at the top. Provides good context for the readme, mirrors how all github repos are layed out.