### PR TITLE
import StringIO in both Python 2 & 3

### DIFF
--- a/magenta/lib/midi_io.py
+++ b/magenta/lib/midi_io.py
@@ -17,8 +17,12 @@ Input and output wrappers for converting between MIDI and other formats.
 """
 
 from collections import defaultdict
-from cStringIO import StringIO
 import sys
+if sys.version_info.major <= 2:
+  from cStringIO import StringIO
+else:
+  from io import StringIO
+
 
 # internal imports
 import pretty_midi


### PR DESCRIPTION
Python 3 removed StringIO and cStringIO modules. Instead there is
io module. From https://docs.python.org/3.0/whatsnew/3.0.html
"The StringIO and cStringIO modules are gone. Instead,
import the io module and use io.StringIO or io.BytesIO for text
and data respectively."