### PR TITLE
Disable basic_rnn_train_test.

### DIFF
--- a/magenta/models/BUILD
+++ b/magenta/models/BUILD
@@ -61,6 +61,7 @@ py_test(
     name = "basic_rnn_train_test",
     srcs = ["basic_rnn/basic_rnn_train_test.py"],
     srcs_version = "PY2AND3",
+    tags = ["notap"],
     data = [
         "basic_rnn/testdata/melodies.sample.tfrecord",
     ],


### PR DESCRIPTION
Should turn back on when the test doesn't time out.