### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
-/bazel-bin
-/bazel-genfiles
-/bazel-magenta
-/bazel-out
-/bazel-testlogs
+*.pyc
+/bazel-*


### PR DESCRIPTION
- Ignore all .pyc files
- Switch from specific bazel paths to just /bazel-*. This works better
  because the exact name of the bazel directory changes based on the
  name of the repo directory. For example, if you clone magenta into a
  directory called magenta-work, bazel will create a bazel-magenta-work
  directory.