### PR TITLE
Improve error reporting during MIDI conversion.

### DIFF
--- a/magenta/scripts/convert_midi_dir_to_note_sequences.py
+++ b/magenta/scripts/convert_midi_dir_to_note_sequences.py
@@ -74,10 +74,13 @@ def convert_directory(root_dir, sub_dir, sequence_writer, recursive=False):
       if recursive:
         recurse_sub_dirs.append(os.path.join(sub_dir, file_in_dir))
       continue
-    sequence = midi_io.midi_to_sequence_proto(
-        tf.gfile.FastGFile(full_file_path).read(),
-        continue_on_exception=True)
-    if sequence is None:
+    try:
+      sequence = midi_io.midi_to_sequence_proto(
+          tf.gfile.FastGFile(full_file_path).read())
+    except midi_io.MIDIConversionError as e:
+      tf.logging.warning(
+          "Could not parse MIDI file %s. It will be skipped. Error was: %s",
+          full_file_path, e)
       sequences_skipped += 1
       continue
     sequence.collection_name = os.path.basename(root_dir)
@@ -96,6 +99,8 @@ def convert_directory(root_dir, sub_dir, sequence_writer, recursive=False):
 
 
 def main(unused_argv):
+  tf.logging.set_verbosity(tf.logging.INFO)
+
   if not FLAGS.midi_dir:
     tf.logging.fatal("--midi_dir required")
     return

--- a/magenta/scripts/convert_midi_dir_to_note_sequences.py
+++ b/magenta/scripts/convert_midi_dir_to_note_sequences.py
@@ -79,7 +79,7 @@ def convert_directory(root_dir, sub_dir, sequence_writer, recursive=False):
           tf.gfile.FastGFile(full_file_path).read())
     except midi_io.MIDIConversionError as e:
       tf.logging.warning(
-          "Could not parse MIDI file %s. It will be skipped. Error was: %s",
+          'Could not parse MIDI file %s. It will be skipped. Error was: %s',
           full_file_path, e)
       sequences_skipped += 1
       continue
@@ -91,7 +91,7 @@ def convert_directory(root_dir, sub_dir, sequence_writer, recursive=False):
     sequences_written += 1
   tf.logging.info("Converted %d MIDI files in '%s'.", sequences_written,
                   dir_to_convert)
-  tf.logging.info("Coult not parse %d MIDI files.", sequences_skipped)
+  tf.logging.info('Coult not parse %d MIDI files.', sequences_skipped)
   for recurse_sub_dir in recurse_sub_dirs:
     sequences_written += convert_directory(
         root_dir, recurse_sub_dir, sequence_writer, recursive)
@@ -102,10 +102,10 @@ def main(unused_argv):
   tf.logging.set_verbosity(tf.logging.INFO)
 
   if not FLAGS.midi_dir:
-    tf.logging.fatal("--midi_dir required")
+    tf.logging.fatal('--midi_dir required')
     return
   if not FLAGS.output_file:
-    tf.logging.fatal("--output_file required")
+    tf.logging.fatal('--output_file required')
     return
 
   FLAGS.midi_dir = os.path.expanduser(FLAGS.midi_dir)


### PR DESCRIPTION
Always raise exceptions, push exception-handling logic to callers rather
than having chains of continue_on_exception args.

Log filenames of midi files with conversion errors.

Set default log level to INFO in convert_midi_dir_to_note_sequences.