### PR TITLE
Re-added a random primer when no melody or midi primer supplied in the command line

### DIFF
--- a/magenta/models/shared/melody_rnn_generate.py
+++ b/magenta/models/shared/melody_rnn_generate.py
@@ -127,7 +127,8 @@ def run_with_flags(melody_rnn_sequence_generator):
     os.makedirs(FLAGS.output_dir)
 
 
-#primer_sequence from written melody or given midi file or random note between midi #48 = 4C to midi #84 = 7C
+# primer_sequence must be set to either: primer_melody or primer_midi or midi #60 = 5C 
+# If set to midi #60 it will be converted to a random note in melody_rnn_sequence_generator.py
 
   primer_sequence = None
   if FLAGS.primer_melody:
@@ -138,8 +139,7 @@ def run_with_flags(melody_rnn_sequence_generator):
     primer_sequence = midi_io.midi_file_to_sequence_proto(FLAGS.primer_midi)
   else:  
     primer_melody = melodies_lib.MonophonicMelody()
-    myRand = random.randint(48,84)
-    primer_melody.from_event_list('['+str(myRand)+']')
+    primer_melody.from_event_list('[60]')
     primer_sequence = primer_melody.to_sequence()
 
   # Derive the total number of seconds to generate based on the BPM of the

--- a/magenta/models/shared/melody_rnn_generate.py
+++ b/magenta/models/shared/melody_rnn_generate.py
@@ -19,6 +19,7 @@ Uses flags to define operation.
 import ast
 import os
 import time
+import random
 
 # internal imports
 
@@ -125,6 +126,9 @@ def run_with_flags(melody_rnn_sequence_generator):
   if not os.path.exists(FLAGS.output_dir):
     os.makedirs(FLAGS.output_dir)
 
+
+#primer_sequence from written melody or given midi file or random note between midi #48 = 4C to midi #84 = 7C
+
   primer_sequence = None
   if FLAGS.primer_melody:
     primer_melody = melodies_lib.MonophonicMelody()
@@ -132,6 +136,11 @@ def run_with_flags(melody_rnn_sequence_generator):
     primer_sequence = primer_melody.to_sequence()
   elif FLAGS.primer_midi:
     primer_sequence = midi_io.midi_file_to_sequence_proto(FLAGS.primer_midi)
+  else:  
+    primer_melody = melodies_lib.MonophonicMelody()
+    myRand = random.randint(48,84)
+    primer_melody.from_event_list('['+str(myRand)+']')
+    primer_sequence = primer_melody.to_sequence()
 
   # Derive the total number of seconds to generate based on the BPM of the
   # priming sequence and the num_steps flag.

--- a/magenta/models/shared/melody_rnn_generate.py
+++ b/magenta/models/shared/melody_rnn_generate.py
@@ -127,9 +127,8 @@ def run_with_flags(melody_rnn_sequence_generator):
     os.makedirs(FLAGS.output_dir)
 
 
-# primer_sequence must be set to either: primer_melody or primer_midi or midi #60 = 5C 
+# primer_sequence must be set to something, either primer_melody or primer_midi or midi #60 = 5C 
 # If set to midi #60 it will be converted to a random note in melody_rnn_sequence_generator.py
-
   primer_sequence = None
   if FLAGS.primer_melody:
     primer_melody = melodies_lib.MonophonicMelody()

--- a/magenta/models/shared/melody_rnn_sequence_generator.py
+++ b/magenta/models/shared/melody_rnn_sequence_generator.py
@@ -120,7 +120,7 @@ class MelodyRnnSequenceGenerator(sequence_generator.BaseSequenceGenerator):
       melody = extracted_melodies[0]
     else:
       tf.logging.warn('No melodies were extracted from the priming sequence. '
-                      'Melodies will be generated from scratch.')
+                      'A single random note will be generated for priming. ')
       melody = melodies_lib.MonophonicMelody()
       melody.events = [
           random.randint(self._melody_encoder_decoder.min_note,


### PR DESCRIPTION
Address issue https://github.com/tensorflow/magenta/issues/121 recent update removed default behavior that supplied a random primer if a midi file or melody was not supplied in the command line. 