### PR TITLE
note_on 0 velocity message as note_off

### DIFF
--- a/magenta/interfaces/midi/midi.py
+++ b/magenta/interfaces/midi/midi.py
@@ -364,7 +364,17 @@ class MonoMidiHub(object):
     last_note = (self.captured_sequence.notes[-1] if
                  self.captured_sequence.notes else None)
     now = time.time()
-    if msg.type == 'note_on':
+    if msg.type == 'note_off' or (msg.type == 'note_on' and msg.velocity == 0):
+      if (last_note is None or last_note.pitch != msg.note or
+          last_note.end_time > 0):
+        # This is not the note we're looking for. Drop it.
+        return
+
+      last_note.end_time = now - self._sequence_start_time
+      self._outport.send(msg)
+      stdout_write_and_flush('.')
+
+    elif msg.type == 'note_on':
       if self._sequence_start_time is None:
         # This is the first note.
         # Find the sequence start time based on the start of the most recent
@@ -388,15 +398,7 @@ class MonoMidiHub(object):
       new_note.velocity = msg.velocity
       stdout_write_and_flush('.')
 
-    elif msg.type == 'note_off':
-      if (last_note is None or last_note.pitch != msg.note or
-          last_note.end_time > 0):
-        # This is not the note we're looking for. Drop it.
-        return
 
-      last_note.end_time = now - self._sequence_start_time
-      self._outport.send(msg)
-      stdout_write_and_flush('.')
 
   @serialized
   def start_capture(self, bpm):


### PR DESCRIPTION
Treats an incoming note_on MIDI message with 0 velocity as a note_off
message with the same note value (running status compatible)