### PR TITLE
metronome_channel flag

### DIFF
--- a/magenta/interfaces/midi/midi.py
+++ b/magenta/interfaces/midi/midi.py
@@ -264,7 +264,6 @@ class MonoMidiPlayer(threading.Thread):
     _outport: The Mido port for sending messages.
     _sequence: The monohponic, chronologically sorted NoteSequence to play.
     _stop_playback: A boolean specifying whether the playback should stop.
-    _bpm: The tempo in beats per minute. Copied from input sequence.
   Args:
     outport: The Mido port for sending messages.
     sequence: The monohponic, chronologically sorted NoteSequence to play.
@@ -540,7 +539,8 @@ def main(unused_argv):
     return
 
   if not 0 <= FLAGS.metronome_playback_velocity <= 127:
-    raise ValueError('The velocity must be an integer between 0 and 127')
+    print 'The velocity must be an integer between 0 and 127'
+    return
 
   generator = Generator(
       FLAGS.generator_name,

--- a/magenta/interfaces/midi/midi.py
+++ b/magenta/interfaces/midi/midi.py
@@ -449,7 +449,7 @@ class MonoMidiHub(object):
     self._capture_start_time = time.time()
     self._inport.callback = self._capture_message
     self._metronome = Metronome(self._outport, bpm, self._capture_start_time,
-                                _METRONOME_VELOCITY)
+                                _METRONOME_CAPTURE_VELOCITY)
 
     self._metronome.start()
 

--- a/magenta/interfaces/midi/midi.py
+++ b/magenta/interfaces/midi/midi.py
@@ -279,9 +279,8 @@ class MonoMidiPlayer(threading.Thread):
     self._stop_playback = False
     if not len(sequence.tempos) == 1:
       raise ValueError('The NoteSequence contains multiple tempos.')
-    bpm = sequence.tempos[0].bpm
-    self._metronome = Metronome(self._outport, bpm, time.time(),
-                                metronome_velocity)
+    self._metronome = Metronome(self._outport, sequence.tempos[0].bpm,
+                                time.time(), metronome_velocity)
     super(MonoMidiPlayer, self).__init__()
 
   def run(self):

--- a/magenta/interfaces/midi/midi.py
+++ b/magenta/interfaces/midi/midi.py
@@ -539,7 +539,7 @@ def main(unused_argv):
     return
 
   if not 0 <= FLAGS.metronome_playback_velocity <= 127:
-    print 'The velocity must be an integer between 0 and 127'
+    print 'The metronome_playback_velocity must be an integer between 0 and 127'
     return
 
   generator = Generator(

--- a/magenta/interfaces/midi/midi.py
+++ b/magenta/interfaces/midi/midi.py
@@ -277,10 +277,9 @@ class MonoMidiPlayer(threading.Thread):
     self._outport = outport
     self._sequence = sequence
     self._stop_playback = False
-    if len(sequence.tempos) == 1:
-      bpm = sequence.tempos[0].bpm
-    else:
+    if not len(sequence.tempos) == 1:
       raise ValueError('The NoteSequence contains multiple tempos.')
+    bpm = sequence.tempos[0].bpm
     self._metronome = Metronome(self._outport, bpm, time.time(),
                                 metronome_velocity)
     super(MonoMidiPlayer, self).__init__()


### PR DESCRIPTION
-Adds an flag option to define the MIDI channel the metronome messages
come in on (comes in on MIDI Channel 1 by default). Allows separating
generated content and click (for recording/monitoring)

-Ability to add metronome to playback of generated material

-Adds a flag option to define the mix amount of metronome click that is
heard during playback vs capture. By default, it is set to 0% so that
no click is heard unless flag is set.

-include default metronome velocity as a variable