### PR TITLE
Fixes and refactors for melody_encoder_decoders

### DIFF
--- a/magenta/lib/melodies_lib.py
+++ b/magenta/lib/melodies_lib.py
@@ -630,8 +630,8 @@ def extract_melodies(quantized_sequence,
 
       # Shorten melodies that are too long.
       if max_steps is not None and len(melody) > max_steps:
-          melody.set_length(max_steps - (max_steps % melody.steps_per_bar))
-          stats['melodies_shortened'].increment()
+        melody.set_length(max_steps - (max_steps % melody.steps_per_bar))
+        stats['melodies_shortened'].increment()
 
       # Require a certain number of unique pitches.
       note_histogram = melody.get_note_histogram()
@@ -744,11 +744,11 @@ class MelodyEncoderDecoder(object):
 
   @abc.abstractmethod
   def melody_to_input(self, melody, position):
-    """Returns the input vector for the event at the given position in the melody.
+    """Returns the input vector for the event at the given position.
 
     Args:
       melody: A MonophonicMelody object.
-      position: An integer event position.
+      position: An integer event position in the melody.
 
     Returns:
       An input vector, a self.input_size length list of floats.
@@ -761,7 +761,7 @@ class MelodyEncoderDecoder(object):
 
     Args:
       melody: A MonophonicMelody object.
-      position: An integer event position.
+      position: An integer event position in the melody.
 
     Returns:
       A label, an int in the range [0, self.num_classes).

--- a/magenta/lib/melodies_lib.py
+++ b/magenta/lib/melodies_lib.py
@@ -631,6 +631,13 @@ def extract_melodies(quantized_sequence,
       # Shorten melodies that are too long.
       if max_steps is not None and len(melody) > max_steps:
         melody.set_length(max_steps - (max_steps % melody.steps_per_bar))
+        for event in reversed(melody.events):
+          if event == NOTE_OFF:
+            break
+          elif event != NO_EVENT:
+            melody.events[-1] = NOTE_OFF
+            break
+
         stats['melodies_shortened'].increment()
 
       # Require a certain number of unique pitches.
@@ -780,7 +787,7 @@ class MelodyEncoderDecoder(object):
     melody.squash(self.min_note, self.max_note, self.transpose_to_key)
     inputs = []
     labels = []
-    for i in range(len(melody)):
+    for i in range(len(melody) - 1):
       inputs.append(self.melody_to_input(melody, i))
       labels.append(self.melody_to_label(melody, i + 1))
     return sequence_example_lib.make_sequence_example(inputs, labels)

--- a/magenta/lib/melodies_lib.py
+++ b/magenta/lib/melodies_lib.py
@@ -634,13 +634,13 @@ def extract_melodies(quantized_sequence,
 
       # Discard melodies that are too long.
       if max_steps_discard is not None and len(melody) > max_steps_discard:
-          stats['melodies_discarded_too_long'].increment()
-          continue
+        stats['melodies_discarded_too_long'].increment()
+        continue
 
       # Truncate melodies that are too long.
       if max_steps_truncate is not None and len(melody) > max_steps_truncate:
         melody.set_length(max_steps_truncate - (max_steps_truncate %
-                                                 melody.steps_per_bar))
+                                                melody.steps_per_bar))
         for event in reversed(melody.events):
           if event == NOTE_OFF:
             break

--- a/magenta/lib/melodies_lib.py
+++ b/magenta/lib/melodies_lib.py
@@ -393,8 +393,8 @@ class MonophonicMelody(object):
 
     # Strip final NOTE_OFF event.
     if self.events[-1] == NOTE_OFF:
-        del self.events[-1]
-    
+      del self.events[-1]
+
     # Round up end_step to a multiple of steps_per_bar
     self.set_length(len(self.events) + (-len(self.events) % steps_per_bar))
 
@@ -545,6 +545,7 @@ class MonophonicMelody(object):
       self.start_step = self.end_step - steps
     else:
       self.end_step = self.start_step + steps
+
 
 def extract_melodies(quantized_sequence,
                      min_bars=7,

--- a/magenta/lib/melodies_lib_test.py
+++ b/magenta/lib/melodies_lib_test.py
@@ -196,7 +196,7 @@ class MelodiesLibTest(tf.test.TestCase):
     expected = ([12, 11, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT,
                  NO_EVENT, NO_EVENT, NO_EVENT, 40, NO_EVENT, NO_EVENT, NO_EVENT,
                  NOTE_OFF, NO_EVENT, 55, NOTE_OFF, NO_EVENT, 52, NOTE_OFF] +
-                 [NO_EVENT] * 11)
+                [NO_EVENT] * 11)
     self.assertEqual(expected, list(melody))
     self.assertEqual(16, melody.steps_per_bar)
 
@@ -212,7 +212,7 @@ class MelodiesLibTest(tf.test.TestCase):
     expected = ([12, 11, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT,
                  NO_EVENT, NO_EVENT, NO_EVENT, 40, NO_EVENT, NO_EVENT, NO_EVENT,
                  NOTE_OFF, NO_EVENT, 55, NOTE_OFF, NO_EVENT, 52, NOTE_OFF] +
-                 [NO_EVENT] * 7)
+                [NO_EVENT] * 7)
     self.assertEqual(expected, list(melody))
     self.assertEqual(14, melody.steps_per_bar)
 
@@ -238,7 +238,7 @@ class MelodiesLibTest(tf.test.TestCase):
                                    ignore_polyphonic_notes=True)
     expected = ([19] + [NO_EVENT] * 3 + [19] + [NO_EVENT] * 11 + [NOTE_OFF] +
                 [NO_EVENT] * 15)
-        
+
     self.assertEqual(expected, list(melody))
     self.assertEqual(16, melody.steps_per_bar)
 
@@ -368,6 +368,19 @@ class MelodiesLibTest(tf.test.TestCase):
     melodies = [list(melody) for melody in melodies]
     self.assertEqual(expected, melodies)
 
+  def testExtractMelodiesMelodyTooLong(self):
+    self.quantized_sequence.steps_per_beat = 1
+    testing_lib.add_quantized_track(
+        self.quantized_sequence, 0,
+        [(12, 127, 2, 4), (14, 50, 6, 18)])
+    expected = [[NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
+                 NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NOTE_OFF]]
+    melodies, _ = melodies_lib.extract_melodies(
+        self.quantized_sequence, min_bars=1, max_steps=14, gap_bars=1,
+        min_unique_pitches=2, ignore_polyphonic_notes=True)
+    melodies = [list(melody) for melody in melodies]
+    self.assertEqual(expected, melodies)
+    
   def testExtractMelodiesTooFewPitches(self):
     # Test that extract_melodies discards melodies with too few pitches where
     # pitches are equivalent by octave.
@@ -600,7 +613,7 @@ class MelodyEncoderDecoderTest(tf.test.TestCase):
     melody.start_step = 9
     melody.end_step = 10
     melody.set_length(5, from_left=True)
-    self.assertListEqual([-2, -2, -2, -2, 60], melody.events)   
+    self.assertListEqual([-2, -2, -2, -2, 60], melody.events)
     self.assertEquals(5, melody.start_step)
     self.assertEquals(10, melody.end_step)
 

--- a/magenta/lib/melodies_lib_test.py
+++ b/magenta/lib/melodies_lib_test.py
@@ -608,7 +608,7 @@ class MelodyEncoderDecoderTest(tf.test.TestCase):
     melody.end_step = 10
     melody.set_length(5)
     self.assertListEqual([60, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT],
-                          melody.events)
+                         melody.events)
     self.assertEquals(9, melody.start_step)
     self.assertEquals(14, melody.end_step)
 
@@ -618,7 +618,7 @@ class MelodyEncoderDecoderTest(tf.test.TestCase):
     melody.end_step = 10
     melody.set_length(5, from_left=True)
     self.assertListEqual([NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, 60],
-                          melody.events)
+                         melody.events)
     self.assertEquals(5, melody.start_step)
     self.assertEquals(10, melody.end_step)
 

--- a/magenta/lib/melodies_lib_test.py
+++ b/magenta/lib/melodies_lib_test.py
@@ -193,9 +193,10 @@ class MelodiesLibTest(tf.test.TestCase):
     melody = melodies_lib.MonophonicMelody()
     melody.from_quantized_sequence(self.quantized_sequence,
                                    start_step=0, track=0)
-    expected = [12, 11, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT,
-                NO_EVENT, NO_EVENT, NO_EVENT, 40, NO_EVENT, NO_EVENT, NO_EVENT,
-                NOTE_OFF, NO_EVENT, 55, NOTE_OFF, NO_EVENT, 52, NOTE_OFF]
+    expected = ([12, 11, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT,
+                 NO_EVENT, NO_EVENT, NO_EVENT, 40, NO_EVENT, NO_EVENT, NO_EVENT,
+                 NOTE_OFF, NO_EVENT, 55, NOTE_OFF, NO_EVENT, 52, NOTE_OFF] +
+                 [NO_EVENT] * 11)
     self.assertEqual(expected, list(melody))
     self.assertEqual(16, melody.steps_per_bar)
 
@@ -208,9 +209,10 @@ class MelodiesLibTest(tf.test.TestCase):
     melody = melodies_lib.MonophonicMelody()
     melody.from_quantized_sequence(self.quantized_sequence,
                                    start_step=0, track=0)
-    expected = [12, 11, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT,
-                NO_EVENT, NO_EVENT, NO_EVENT, 40, NO_EVENT, NO_EVENT, NO_EVENT,
-                NOTE_OFF, NO_EVENT, 55, NOTE_OFF, NO_EVENT, 52, NOTE_OFF]
+    expected = ([12, 11, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT,
+                 NO_EVENT, NO_EVENT, NO_EVENT, 40, NO_EVENT, NO_EVENT, NO_EVENT,
+                 NOTE_OFF, NO_EVENT, 55, NOTE_OFF, NO_EVENT, 52, NOTE_OFF] +
+                 [NO_EVENT] * 7)
     self.assertEqual(expected, list(melody))
     self.assertEqual(14, melody.steps_per_bar)
 
@@ -234,8 +236,11 @@ class MelodiesLibTest(tf.test.TestCase):
     melody.from_quantized_sequence(self.quantized_sequence,
                                    start_step=0, track=0,
                                    ignore_polyphonic_notes=True)
-    expected = [19] + [NO_EVENT] * 3 + [19] + [NO_EVENT] * 11 + [NOTE_OFF]
+    expected = ([19] + [NO_EVENT] * 3 + [19] + [NO_EVENT] * 11 + [NOTE_OFF] +
+                [NO_EVENT] * 15)
+        
     self.assertEqual(expected, list(melody))
+    self.assertEqual(16, melody.steps_per_bar)
 
   def testFromNotesChord(self):
     testing_lib.add_quantized_track(
@@ -258,8 +263,10 @@ class MelodiesLibTest(tf.test.TestCase):
                                    start_step=0, track=0,
                                    ignore_polyphonic_notes=False)
     expected = [NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, 12,
-                NOTE_OFF, 11, NOTE_OFF]
+                NOTE_OFF, 11, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT,
+                NO_EVENT, NO_EVENT]
     self.assertEqual(expected, list(melody))
+    self.assertEqual(16, melody.steps_per_bar)
 
   def testFromNotesTimeOverlap(self):
     testing_lib.add_quantized_track(
@@ -295,8 +302,10 @@ class MelodiesLibTest(tf.test.TestCase):
                                    start_step=18, track=0,
                                    ignore_polyphonic_notes=False)
     expected = [NO_EVENT, NO_EVENT, NO_EVENT, 14, NOTE_OFF, 15, NO_EVENT,
-                NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NOTE_OFF]
+                NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NOTE_OFF,
+                NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT]
     self.assertEqual(expected, list(melody))
+    self.assertEqual(16, melody.start_step)
     self.assertEqual(32, melody.end_step)
 
   def testExtractMelodiesSimple(self):
@@ -310,7 +319,7 @@ class MelodiesLibTest(tf.test.TestCase):
     expected = [[NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 11,
                  NOTE_OFF],
                 [NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
-                 NO_EVENT, NOTE_OFF]]
+                 NO_EVENT, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT]]
     melodies, _ = melodies_lib.extract_melodies(
         self.quantized_sequence, min_bars=1, gap_bars=1, min_unique_pitches=2,
         ignore_polyphonic_notes=True)
@@ -334,8 +343,9 @@ class MelodiesLibTest(tf.test.TestCase):
     expected = [[NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 11,
                  NOTE_OFF],
                 [NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
-                 NO_EVENT, NOTE_OFF],
-                [NO_EVENT, 50, 52, NO_EVENT, NOTE_OFF]]
+                 NO_EVENT, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT],
+                [NO_EVENT, 50, 52, NO_EVENT, NOTE_OFF, NO_EVENT, NO_EVENT,
+                 NO_EVENT]]
     melodies, _ = melodies_lib.extract_melodies(
         self.quantized_sequence, min_bars=1, gap_bars=2, min_unique_pitches=2,
         ignore_polyphonic_notes=True)
@@ -351,7 +361,7 @@ class MelodiesLibTest(tf.test.TestCase):
         self.quantized_sequence, 1,
         [(12, 127, 2, 4), (14, 50, 6, 8)])
     expected = [[NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
-                 NO_EVENT, NOTE_OFF]]
+                 NO_EVENT, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT]]
     melodies, _ = melodies_lib.extract_melodies(
         self.quantized_sequence, min_bars=2, gap_bars=1, min_unique_pitches=2,
         ignore_polyphonic_notes=True)
@@ -370,7 +380,7 @@ class MelodiesLibTest(tf.test.TestCase):
         self.quantized_sequence, 1,
         [(12, 100, 0, 1), (13, 100, 1, 2), (18, 100, 2, 3),
          (25, 100, 3, 4), (26, 100, 4, 5)])
-    expected = [[12, 13, 18, 25, 26, NOTE_OFF]]
+    expected = [[12, 13, 18, 25, 26, NOTE_OFF, NO_EVENT, NO_EVENT]]
     melodies, _ = melodies_lib.extract_melodies(
         self.quantized_sequence, min_bars=1, gap_bars=1, min_unique_pitches=4,
         ignore_polyphonic_notes=True)
@@ -385,8 +395,10 @@ class MelodiesLibTest(tf.test.TestCase):
     testing_lib.add_quantized_track(
         self.quantized_sequence, 1,
         [(12, 100, 100, 101), (13, 100, 102, 104)])
-    expected = [[NO_EVENT, NO_EVENT, 12, NOTE_OFF, 13, NO_EVENT, NOTE_OFF],
-                [12, NOTE_OFF, 13, NO_EVENT, NOTE_OFF]]
+    expected = [[NO_EVENT, NO_EVENT, 12, NOTE_OFF, 13, NO_EVENT, NOTE_OFF,
+                 NO_EVENT],
+                [12, NOTE_OFF, 13, NO_EVENT, NOTE_OFF, NO_EVENT, NO_EVENT,
+                 NO_EVENT]]
     melodies, _ = melodies_lib.extract_melodies(
         self.quantized_sequence, min_bars=1, gap_bars=1, min_unique_pitches=2,
         ignore_polyphonic_notes=True)
@@ -418,7 +430,7 @@ class MelodiesLibTest(tf.test.TestCase):
     self.assertEqual(stats_dict['melodies_discarded_too_few_pitches'].count, 1)
     self.assertEqual(
         stats_dict['melody_lengths_in_bars'].counters,
-        {float('-inf'): 0, 0: 1, 1: 0, 2: 1, 10: 1, 20: 0, 30: 0, 40: 0, 50: 0,
+        {float('-inf'): 0, 0: 0, 1: 1, 2: 1, 10: 1, 20: 0, 30: 0, 40: 0, 50: 0,
          100: 0, 200: 0, 500: 0})
 
 
@@ -438,16 +450,18 @@ class OneHotEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
   def num_classes(self):
     return self._num_classes
 
-  def melody_to_input(self, melody):
+  def melody_to_input(self, melody, position):
     input_ = [0.0] * self._input_size
-    index = (melody.events[-1] + NUM_SPECIAL_EVENTS if melody.events[-1] < 0
-             else melody.events[-1] - self.min_note + NUM_SPECIAL_EVENTS)
+    index = (melody.events[position] + NUM_SPECIAL_EVENTS
+             if melody.events[position] < 0
+             else melody.events[position] - self.min_note + NUM_SPECIAL_EVENTS)
     input_[index] = 1.0
     return input_
 
-  def melody_to_label(self, melody):
-    return (melody.events[-1] + NUM_SPECIAL_EVENTS if melody.events[-1] < 0
-            else melody.events[-1] - self.min_note + NUM_SPECIAL_EVENTS)
+  def melody_to_label(self, melody, position):
+    return (melody.events[position] + NUM_SPECIAL_EVENTS
+            if melody.events[position] < 0
+            else melody.events[position] - self.min_note + NUM_SPECIAL_EVENTS)
 
   def class_index_to_melody_event(self, class_index, melody):
     return (class_index - NUM_SPECIAL_EVENTS if class_index < NUM_SPECIAL_EVENTS
@@ -574,14 +588,40 @@ class MelodyEncoderDecoderTest(tf.test.TestCase):
     events = [60]
     melody = melodies_lib.MonophonicMelody()
     melody.from_event_list(events)
+    melody.start_step = 9
+    melody.end_step = 10
     melody.set_length(5)
     self.assertListEqual([60, -2, -2, -2, -2], melody.events)
+    self.assertEquals(9, melody.start_step)
+    self.assertEquals(14, melody.end_step)
+
+    melody = melodies_lib.MonophonicMelody()
+    melody.from_event_list(events)
+    melody.start_step = 9
+    melody.end_step = 10
+    melody.set_length(5, from_left=True)
+    self.assertListEqual([-2, -2, -2, -2, 60], melody.events)   
+    self.assertEquals(5, melody.start_step)
+    self.assertEquals(10, melody.end_step)
 
     events = [60, -1, -1, -2]
     melody = melodies_lib.MonophonicMelody()
     melody.from_event_list(events)
+    melody.start_step = 0
+    melody.end_step = 4
     melody.set_length(3)
     self.assertListEqual([60, -1, -1], melody.events)
+    self.assertEquals(0, melody.start_step)
+    self.assertEquals(3, melody.end_step)
+
+    melody = melodies_lib.MonophonicMelody()
+    melody.from_event_list(events)
+    melody.start_step = 0
+    melody.end_step = 4
+    melody.set_length(3, from_left=True)
+    self.assertListEqual([-1, -1, -2], melody.events)
+    self.assertEquals(1, melody.start_step)
+    self.assertEquals(4, melody.end_step)
 
 if __name__ == '__main__':
   tf.test.main()

--- a/magenta/lib/melodies_lib_test.py
+++ b/magenta/lib/melodies_lib_test.py
@@ -380,7 +380,7 @@ class MelodiesLibTest(tf.test.TestCase):
         min_unique_pitches=2, ignore_polyphonic_notes=True)
     melodies = [list(melody) for melody in melodies]
     self.assertEqual(expected, melodies)
-    
+
   def testExtractMelodiesTooFewPitches(self):
     # Test that extract_melodies discards melodies with too few pitches where
     # pitches are equivalent by octave.

--- a/magenta/lib/melodies_lib_test.py
+++ b/magenta/lib/melodies_lib_test.py
@@ -372,12 +372,16 @@ class MelodiesLibTest(tf.test.TestCase):
     self.quantized_sequence.steps_per_beat = 1
     testing_lib.add_quantized_track(
         self.quantized_sequence, 0,
+        [(12, 127, 2, 4), (14, 50, 6, 15)])
+    testing_lib.add_quantized_track(
+        self.quantized_sequence, 1,
         [(12, 127, 2, 4), (14, 50, 6, 18)])
     expected = [[NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
                  NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NOTE_OFF]]
     melodies, _ = melodies_lib.extract_melodies(
-        self.quantized_sequence, min_bars=1, max_steps=14, gap_bars=1,
-        min_unique_pitches=2, ignore_polyphonic_notes=True)
+        self.quantized_sequence, min_bars=1, max_steps_truncate=14,
+        max_steps_discard=18, gap_bars=1, min_unique_pitches=2,
+        ignore_polyphonic_notes=True)
     melodies = [list(melody) for melody in melodies]
     self.assertEqual(expected, melodies)
 

--- a/magenta/lib/melodies_lib_test.py
+++ b/magenta/lib/melodies_lib_test.py
@@ -236,8 +236,7 @@ class MelodiesLibTest(tf.test.TestCase):
     melody.from_quantized_sequence(self.quantized_sequence,
                                    start_step=0, track=0,
                                    ignore_polyphonic_notes=True)
-    expected = ([19] + [NO_EVENT] * 3 + [19] + [NO_EVENT] * 11 + [NOTE_OFF] +
-                [NO_EVENT] * 15)
+    expected = ([19] + [NO_EVENT] * 3 + [19] + [NO_EVENT] * 11)
 
     self.assertEqual(expected, list(melody))
     self.assertEqual(16, melody.steps_per_bar)
@@ -312,14 +311,14 @@ class MelodiesLibTest(tf.test.TestCase):
     self.quantized_sequence.steps_per_beat = 1
     testing_lib.add_quantized_track(
         self.quantized_sequence, 0,
-        [(12, 100, 2, 4), (11, 1, 6, 7)])
+        [(12, 100, 2, 4), (11, 1, 6, 8)])
     testing_lib.add_quantized_track(
         self.quantized_sequence, 1,
-        [(12, 127, 2, 4), (14, 50, 6, 8)])
+        [(12, 127, 2, 4), (14, 50, 6, 9)])
     expected = [[NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 11,
-                 NOTE_OFF],
+                 NO_EVENT],
                 [NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
-                 NO_EVENT, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT]]
+                 NO_EVENT, NO_EVENT, NOTE_OFF, NO_EVENT, NO_EVENT]]
     melodies, _ = melodies_lib.extract_melodies(
         self.quantized_sequence, min_bars=1, gap_bars=1, min_unique_pitches=2,
         ignore_polyphonic_notes=True)
@@ -335,16 +334,16 @@ class MelodiesLibTest(tf.test.TestCase):
     self.quantized_sequence.steps_per_beat = 1
     testing_lib.add_quantized_track(
         self.quantized_sequence, 0,
-        [(12, 100, 2, 4), (11, 1, 6, 7)])
+        [(12, 100, 2, 4), (11, 1, 6, 11)])
     testing_lib.add_quantized_track(
         self.quantized_sequence, 1,
         [(12, 127, 2, 4), (14, 50, 6, 8),
-         (50, 100, 33, 37), (52, 100, 34, 36)])
+         (50, 100, 33, 37), (52, 100, 34, 37)])
     expected = [[NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 11,
-                 NOTE_OFF],
+                 NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NOTE_OFF],
                 [NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
-                 NO_EVENT, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT],
-                [NO_EVENT, 50, 52, NO_EVENT, NOTE_OFF, NO_EVENT, NO_EVENT,
+                 NO_EVENT],
+                [NO_EVENT, 50, 52, NO_EVENT, NO_EVENT, NOTE_OFF, NO_EVENT,
                  NO_EVENT]]
     melodies, _ = melodies_lib.extract_melodies(
         self.quantized_sequence, min_bars=1, gap_bars=2, min_unique_pitches=2,
@@ -359,9 +358,9 @@ class MelodiesLibTest(tf.test.TestCase):
         [(12, 127, 2, 4), (14, 50, 6, 7)])
     testing_lib.add_quantized_track(
         self.quantized_sequence, 1,
-        [(12, 127, 2, 4), (14, 50, 6, 8)])
+        [(12, 127, 2, 4), (14, 50, 6, 9)])
     expected = [[NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
-                 NO_EVENT, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT]]
+                 NO_EVENT, NO_EVENT, NOTE_OFF, NO_EVENT, NO_EVENT]]
     melodies, _ = melodies_lib.extract_melodies(
         self.quantized_sequence, min_bars=2, gap_bars=1, min_unique_pitches=2,
         ignore_polyphonic_notes=True)
@@ -411,10 +410,10 @@ class MelodiesLibTest(tf.test.TestCase):
         [(12, 100, 102, 103), (13, 100, 104, 106)])
     testing_lib.add_quantized_track(
         self.quantized_sequence, 1,
-        [(12, 100, 100, 101), (13, 100, 102, 104)])
+        [(12, 100, 100, 101), (13, 100, 102, 105)])
     expected = [[NO_EVENT, NO_EVENT, 12, NOTE_OFF, 13, NO_EVENT, NOTE_OFF,
                  NO_EVENT],
-                [12, NOTE_OFF, 13, NO_EVENT, NOTE_OFF, NO_EVENT, NO_EVENT,
+                [12, NOTE_OFF, 13, NO_EVENT, NO_EVENT, NOTE_OFF, NO_EVENT,
                  NO_EVENT]]
     melodies, _ = melodies_lib.extract_melodies(
         self.quantized_sequence, min_bars=1, gap_bars=1, min_unique_pitches=2,
@@ -608,7 +607,8 @@ class MelodyEncoderDecoderTest(tf.test.TestCase):
     melody.start_step = 9
     melody.end_step = 10
     melody.set_length(5)
-    self.assertListEqual([60, -2, -2, -2, -2], melody.events)
+    self.assertListEqual([60, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT],
+                          melody.events)
     self.assertEquals(9, melody.start_step)
     self.assertEquals(14, melody.end_step)
 
@@ -617,17 +617,18 @@ class MelodyEncoderDecoderTest(tf.test.TestCase):
     melody.start_step = 9
     melody.end_step = 10
     melody.set_length(5, from_left=True)
-    self.assertListEqual([-2, -2, -2, -2, 60], melody.events)
+    self.assertListEqual([NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, 60],
+                          melody.events)
     self.assertEquals(5, melody.start_step)
     self.assertEquals(10, melody.end_step)
 
-    events = [60, -1, -1, -2]
+    events = [60, NO_EVENT, NO_EVENT, NOTE_OFF]
     melody = melodies_lib.MonophonicMelody()
     melody.from_event_list(events)
     melody.start_step = 0
     melody.end_step = 4
     melody.set_length(3)
-    self.assertListEqual([60, -1, -1], melody.events)
+    self.assertListEqual([60, NO_EVENT, NO_EVENT], melody.events)
     self.assertEquals(0, melody.start_step)
     self.assertEquals(3, melody.end_step)
 
@@ -636,7 +637,7 @@ class MelodyEncoderDecoderTest(tf.test.TestCase):
     melody.start_step = 0
     melody.end_step = 4
     melody.set_length(3, from_left=True)
-    self.assertListEqual([-1, -1, -2], melody.events)
+    self.assertListEqual([NO_EVENT, NO_EVENT, NOTE_OFF], melody.events)
     self.assertEquals(1, melody.start_step)
     self.assertEquals(4, melody.end_step)
 

--- a/magenta/lib/melodies_lib_test.py
+++ b/magenta/lib/melodies_lib_test.py
@@ -195,8 +195,7 @@ class MelodiesLibTest(tf.test.TestCase):
                                    start_step=0, track=0)
     expected = ([12, 11, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT,
                  NO_EVENT, NO_EVENT, NO_EVENT, 40, NO_EVENT, NO_EVENT, NO_EVENT,
-                 NOTE_OFF, NO_EVENT, 55, NOTE_OFF, NO_EVENT, 52, NOTE_OFF] +
-                [NO_EVENT] * 11)
+                 NOTE_OFF, NO_EVENT, 55, NOTE_OFF, NO_EVENT, 52])
     self.assertEqual(expected, list(melody))
     self.assertEqual(16, melody.steps_per_bar)
 
@@ -211,8 +210,7 @@ class MelodiesLibTest(tf.test.TestCase):
                                    start_step=0, track=0)
     expected = ([12, 11, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT,
                  NO_EVENT, NO_EVENT, NO_EVENT, 40, NO_EVENT, NO_EVENT, NO_EVENT,
-                 NOTE_OFF, NO_EVENT, 55, NOTE_OFF, NO_EVENT, 52, NOTE_OFF] +
-                [NO_EVENT] * 7)
+                 NOTE_OFF, NO_EVENT, 55, NOTE_OFF, NO_EVENT, 52])
     self.assertEqual(expected, list(melody))
     self.assertEqual(14, melody.steps_per_bar)
 
@@ -262,8 +260,7 @@ class MelodiesLibTest(tf.test.TestCase):
                                    start_step=0, track=0,
                                    ignore_polyphonic_notes=False)
     expected = [NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, 12,
-                NOTE_OFF, 11, NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT,
-                NO_EVENT, NO_EVENT]
+                NOTE_OFF, 11]
     self.assertEqual(expected, list(melody))
     self.assertEqual(16, melody.steps_per_bar)
 
@@ -278,7 +275,7 @@ class MelodiesLibTest(tf.test.TestCase):
                                    ignore_polyphonic_notes=False)
     expected = [NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, 12, NO_EVENT, NO_EVENT,
                 NO_EVENT, 13, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, 11,
-                NO_EVENT, NOTE_OFF]
+                NO_EVENT]
     self.assertEqual(expected, list(melody))
 
   def testFromNotesStepsPerBar(self):
@@ -301,24 +298,22 @@ class MelodiesLibTest(tf.test.TestCase):
                                    start_step=18, track=0,
                                    ignore_polyphonic_notes=False)
     expected = [NO_EVENT, NO_EVENT, NO_EVENT, 14, NOTE_OFF, 15, NO_EVENT,
-                NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NOTE_OFF,
                 NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT]
     self.assertEqual(expected, list(melody))
     self.assertEqual(16, melody.start_step)
-    self.assertEqual(32, melody.end_step)
+    self.assertEqual(27, melody.end_step)
 
   def testExtractMelodiesSimple(self):
     self.quantized_sequence.steps_per_beat = 1
     testing_lib.add_quantized_track(
         self.quantized_sequence, 0,
-        [(12, 100, 2, 4), (11, 1, 6, 8)])
+        [(12, 100, 2, 4), (11, 1, 6, 7)])
     testing_lib.add_quantized_track(
         self.quantized_sequence, 1,
         [(12, 127, 2, 4), (14, 50, 6, 9)])
-    expected = [[NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 11,
-                 NO_EVENT],
+    expected = [[NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 11],
                 [NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
-                 NO_EVENT, NO_EVENT, NOTE_OFF, NO_EVENT, NO_EVENT]]
+                 NO_EVENT, NO_EVENT]]
     melodies, _ = melodies_lib.extract_melodies(
         self.quantized_sequence, min_bars=1, gap_bars=1, min_unique_pitches=2,
         ignore_polyphonic_notes=True)
@@ -340,11 +335,10 @@ class MelodiesLibTest(tf.test.TestCase):
         [(12, 127, 2, 4), (14, 50, 6, 8),
          (50, 100, 33, 37), (52, 100, 34, 37)])
     expected = [[NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 11,
-                 NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NOTE_OFF],
+                 NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT],
                 [NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
                  NO_EVENT],
-                [NO_EVENT, 50, 52, NO_EVENT, NO_EVENT, NOTE_OFF, NO_EVENT,
-                 NO_EVENT]]
+                [NO_EVENT, 50, 52, NO_EVENT, NO_EVENT]]
     melodies, _ = melodies_lib.extract_melodies(
         self.quantized_sequence, min_bars=1, gap_bars=2, min_unique_pitches=2,
         ignore_polyphonic_notes=True)
@@ -360,10 +354,33 @@ class MelodiesLibTest(tf.test.TestCase):
         self.quantized_sequence, 1,
         [(12, 127, 2, 4), (14, 50, 6, 9)])
     expected = [[NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
-                 NO_EVENT, NO_EVENT, NOTE_OFF, NO_EVENT, NO_EVENT]]
+                 NO_EVENT, NO_EVENT]]
     melodies, _ = melodies_lib.extract_melodies(
         self.quantized_sequence, min_bars=2, gap_bars=1, min_unique_pitches=2,
         ignore_polyphonic_notes=True)
+    melodies = [list(melody) for melody in melodies]
+    self.assertEqual(expected, melodies)
+
+  def testExtractMelodiesPadEnd(self):
+    self.quantized_sequence.steps_per_beat = 1
+    testing_lib.add_quantized_track(
+        self.quantized_sequence, 0,
+        [(12, 127, 2, 4), (14, 50, 6, 7)])
+    testing_lib.add_quantized_track(
+        self.quantized_sequence, 1,
+        [(12, 127, 2, 4), (14, 50, 6, 8)])
+    testing_lib.add_quantized_track(
+        self.quantized_sequence, 2,
+        [(12, 127, 2, 4), (14, 50, 6, 9)])
+    expected = [[NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
+                 NOTE_OFF],
+                [NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
+                 NO_EVENT],                 
+                [NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
+                 NO_EVENT, NO_EVENT, NOTE_OFF, NO_EVENT, NO_EVENT]]
+    melodies, _ = melodies_lib.extract_melodies(
+        self.quantized_sequence, min_bars=1, gap_bars=1, min_unique_pitches=2,
+        ignore_polyphonic_notes=True, pad_end=True)
     melodies = [list(melody) for melody in melodies]
     self.assertEqual(expected, melodies)
 
@@ -375,12 +392,31 @@ class MelodiesLibTest(tf.test.TestCase):
     testing_lib.add_quantized_track(
         self.quantized_sequence, 1,
         [(12, 127, 2, 4), (14, 50, 6, 18)])
-    expected = [[NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
-                 NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NOTE_OFF]]
+    expected = [[NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14] +
+                [NO_EVENT] * 7,
+                [NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14] +
+                [NO_EVENT] * 7]
     melodies, _ = melodies_lib.extract_melodies(
         self.quantized_sequence, min_bars=1, max_steps_truncate=14,
         max_steps_discard=18, gap_bars=1, min_unique_pitches=2,
         ignore_polyphonic_notes=True)
+    melodies = [list(melody) for melody in melodies]
+    self.assertEqual(expected, melodies)
+
+  def testExtractMelodiesMelodyTooLongWithPad(self):
+    self.quantized_sequence.steps_per_beat = 1
+    testing_lib.add_quantized_track(
+        self.quantized_sequence, 0,
+        [(12, 127, 2, 4), (14, 50, 6, 15)])
+    testing_lib.add_quantized_track(
+        self.quantized_sequence, 1,
+        [(12, 127, 2, 4), (14, 50, 6, 18)])
+    expected = [[NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
+                 NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT, NO_EVENT]]
+    melodies, _ = melodies_lib.extract_melodies(
+        self.quantized_sequence, min_bars=1, max_steps_truncate=14,
+        max_steps_discard=18, gap_bars=1, min_unique_pitches=2,
+        ignore_polyphonic_notes=True, pad_end=True)
     melodies = [list(melody) for melody in melodies]
     self.assertEqual(expected, melodies)
 
@@ -396,7 +432,7 @@ class MelodiesLibTest(tf.test.TestCase):
         self.quantized_sequence, 1,
         [(12, 100, 0, 1), (13, 100, 1, 2), (18, 100, 2, 3),
          (25, 100, 3, 4), (26, 100, 4, 5)])
-    expected = [[12, 13, 18, 25, 26, NOTE_OFF, NO_EVENT, NO_EVENT]]
+    expected = [[12, 13, 18, 25, 26]]
     melodies, _ = melodies_lib.extract_melodies(
         self.quantized_sequence, min_bars=1, gap_bars=1, min_unique_pitches=4,
         ignore_polyphonic_notes=True)
@@ -411,10 +447,8 @@ class MelodiesLibTest(tf.test.TestCase):
     testing_lib.add_quantized_track(
         self.quantized_sequence, 1,
         [(12, 100, 100, 101), (13, 100, 102, 105)])
-    expected = [[NO_EVENT, NO_EVENT, 12, NOTE_OFF, 13, NO_EVENT, NOTE_OFF,
-                 NO_EVENT],
-                [12, NOTE_OFF, 13, NO_EVENT, NO_EVENT, NOTE_OFF, NO_EVENT,
-                 NO_EVENT]]
+    expected = [[NO_EVENT, NO_EVENT, 12, NOTE_OFF, 13, NO_EVENT],
+                [12, NOTE_OFF, 13, NO_EVENT, NO_EVENT]]
     melodies, _ = melodies_lib.extract_melodies(
         self.quantized_sequence, min_bars=1, gap_bars=1, min_unique_pitches=2,
         ignore_polyphonic_notes=True)
@@ -446,7 +480,7 @@ class MelodiesLibTest(tf.test.TestCase):
     self.assertEqual(stats_dict['melodies_discarded_too_few_pitches'].count, 1)
     self.assertEqual(
         stats_dict['melody_lengths_in_bars'].counters,
-        {float('-inf'): 0, 0: 0, 1: 1, 2: 1, 10: 1, 20: 0, 30: 0, 40: 0, 50: 0,
+        {float('-inf'): 0, 0: 1, 1: 0, 2: 1, 10: 1, 20: 0, 30: 0, 40: 0, 50: 0,
          100: 0, 200: 0, 500: 0})
 
 

--- a/magenta/lib/melodies_lib_test.py
+++ b/magenta/lib/melodies_lib_test.py
@@ -375,7 +375,7 @@ class MelodiesLibTest(tf.test.TestCase):
     expected = [[NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
                  NOTE_OFF],
                 [NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
-                 NO_EVENT],                 
+                 NO_EVENT],
                 [NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14,
                  NO_EVENT, NO_EVENT, NOTE_OFF, NO_EVENT, NO_EVENT]]
     melodies, _ = melodies_lib.extract_melodies(

--- a/magenta/models/attention_rnn/attention_rnn_encoder_decoder.py
+++ b/magenta/models/attention_rnn/attention_rnn_encoder_decoder.py
@@ -155,7 +155,7 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
     last_3_note_melody = melodies_lib.MonophonicMelody()
     last_3_note_melody.from_event_list(list(last_3_notes))
     key_histogram = last_3_note_melody.get_major_key_histogram()
-     max_val = max(key_histogram)
+    max_val = max(key_histogram)
     for i, key_val in enumerate(key_histogram):
       if key_val == max_val:
         input_[self.note_range + 14 + NOTES_PER_OCTAVE + i] = 1.0

--- a/magenta/models/attention_rnn/attention_rnn_encoder_decoder.py
+++ b/magenta/models/attention_rnn/attention_rnn_encoder_decoder.py
@@ -186,12 +186,12 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
         melody.events[position] == NO_EVENT):
       return self.num_model_events + 1
 
-   # If the last event repeated N bars ago.
-   for i, lookback_distance in reversed(list(enumerate(LOOKBACK_DISTANCES))):
-     lookback_position = position - lookback_distance
-     if (lookback_position >= 0 and
-         melody.events[position] == melody.events[lookback_position]):
-       return self.note_range + 1 + i
+    # If the last event repeated N bars ago.
+    for i, lookback_distance in reversed(list(enumerate(LOOKBACK_DISTANCES))):
+      lookback_position = position - lookback_distance
+      if (lookback_position >= 0 and
+          melody.events[position] == melody.events[lookback_position]):
+        return self.note_range + 1 + i
 
     # If last event was a note-off event.
     if melody.events[position] == NOTE_OFF:

--- a/magenta/models/attention_rnn/attention_rnn_encoder_decoder.py
+++ b/magenta/models/attention_rnn/attention_rnn_encoder_decoder.py
@@ -184,7 +184,7 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
     """
     if (position < LOOKBACK_DISTANCES[-1] and
         melody.events[position] == NO_EVENT):
-      return self.note_range + len(LOOKBACK_DISTANCE) + 1
+      return self.note_range + len(LOOKBACK_DISTANCES) + 1
 
     # If the last event repeated N bars ago.
     for i, lookback_distance in reversed(list(enumerate(LOOKBACK_DISTANCES))):

--- a/magenta/models/attention_rnn/attention_rnn_encoder_decoder.py
+++ b/magenta/models/attention_rnn/attention_rnn_encoder_decoder.py
@@ -191,7 +191,7 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
       lookback_position = position - lookback_distance
       if (lookback_position >= 0 and
           melody.events[position] == melody.events[lookback_position]):
-        return self.note_range + 1 + i
+        return self.note_range + 2 + i
 
     # If last event was a note-off event.
     if melody.events[position] == NOTE_OFF:

--- a/magenta/models/attention_rnn/attention_rnn_encoder_decoder.py
+++ b/magenta/models/attention_rnn/attention_rnn_encoder_decoder.py
@@ -186,7 +186,7 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
         melody.events[position] == NO_EVENT):
       return self.num_model_events + 1
 
-   # If the last event repeated N bars ago. 
+   # If the last event repeated N bars ago.
    for i, lookback_distance in reversed(list(enumerate(LOOKBACK_DISTANCES))):
       lookback_position = position - lookback_distance
       if (lookback_position >= 0 and
@@ -223,7 +223,7 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
         if len(melody) < lookback_distance:
           return NO_EVENT
         return melody.events[-lookback_distance]
-      
+
     # Note-off event.
     if class_index == self.note_range + 1:
       return NOTE_OFF

--- a/magenta/models/attention_rnn/attention_rnn_encoder_decoder.py
+++ b/magenta/models/attention_rnn/attention_rnn_encoder_decoder.py
@@ -35,6 +35,9 @@ NUM_SPECIAL_INPUTS = 14 + NOTES_PER_OCTAVE * 2
 NUM_SPECIAL_CLASSES = 2
 NUM_BINARY_TIME_COUNTERS = 7
 
+# Must be sorted in ascending order.
+LOOKBACK_DISTANCES = [STEPS_PER_BAR, STEPS_PER_BAR * 2]
+
 
 class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
   """A MelodyEncoderDecoder specific to the attention RNN model.
@@ -57,8 +60,8 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
   def num_classes(self):
     return self.note_range + NUM_SPECIAL_EVENTS + NUM_SPECIAL_CLASSES
 
-  def melody_to_input(self, melody):
-    """Returns the input vector for the last event in the melody.
+  def melody_to_input(self, melody, position):
+    """Returns the input vector for the given position in the melody.
 
     Returns a self.input_size length list of floats. Assuming MIN_NOTE = 48
     and MAX_NOTE = 84, then self.input_size = 74. Each index represents a
@@ -79,6 +82,7 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
 
     Args:
       melody: A melodies_lib.MonophonicMelody object.
+      position: An integer position in the melody.
 
     Returns:
       An input vector, an self.input_size length list of floats.
@@ -87,7 +91,9 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
     is_attack = False
     is_ascending = None
     last_3_notes = collections.deque(maxlen=3)
-    for note in melody.events:
+    sub_melody = melodies_lib.MonophonicMelody()
+    sub_melody.from_event_list(melody.events[:position + 1])
+    for note in sub_melody:
       if note == NO_EVENT:
         is_attack = False
       elif note == NOTE_OFF:
@@ -122,46 +128,42 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
     if is_ascending is not None:
       input_[self.note_range + 3] = 1.0 if is_ascending else -1.0
 
-    # The last event is repeating 1 bar ago.
-    if (len(melody) >= STEPS_PER_BAR + 1 and
-        melody.events[-1] == melody.events[-(STEPS_PER_BAR + 1)]):
-      input_[self.note_range + 4] = 1.0
-
-    # The last event is repeating 2 bars ago.
-    if (len(melody) >= 2 * STEPS_PER_BAR + 1 and
-        melody.events[-1] == melody.events[-(2 * STEPS_PER_BAR + 1)]):
-      input_[self.note_range + 5] = 1.0
+    # Last event is repeating N bars ago.
+    for i, lookback_distance in enumerate(LOOKBACK_DISTANCES):
+      lookback_position = position - lookback_distance
+      if (lookback_position >= 0 and
+          melody.events[position] == melody.events[lookback_position]):
+        input_[self.note_range + 4 + i] = 1.0
 
     # Binary time counter giving the metric location of the *next* note.
-    n = len(melody)
+    n = len(sub_melody)
     for i in range(NUM_BINARY_TIME_COUNTERS):
       input_[self.note_range + 6 + i] = 1.0 if (n / 2 ** i) % 2 else -1.0
 
     # The next event is the start of a bar.
-    if len(melody) % STEPS_PER_BAR == 0:
+    if len(sub_melody) % STEPS_PER_BAR == 0:
       input_[self.note_range + 13] = 1.0
 
     # The keys the current melody is in.
-    key_histogram = melody.get_major_key_histogram()
+    key_histogram = sub_melody.get_major_key_histogram()
     max_val = max(key_histogram)
     for i, key_val in enumerate(key_histogram):
       if key_val == max_val:
         input_[self.note_range + 14 + i] = 1.0
 
     # The keys the last 3 notes are in.
-    melody_events_backup = melody.events
-    melody.events = list(last_3_notes)
-    key_histogram = melody.get_major_key_histogram()
-    max_val = max(key_histogram)
+    last_3_note_melody = melodies_lib.MonophonicMelody()
+    last_3_note_melody.from_event_list(list(last_3_notes))
+    key_histogram = last_3_note_melody.get_major_key_histogram()
+     max_val = max(key_histogram)
     for i, key_val in enumerate(key_histogram):
       if key_val == max_val:
         input_[self.note_range + 14 + NOTES_PER_OCTAVE + i] = 1.0
-    melody.events = melody_events_backup
 
     return input_
 
-  def melody_to_label(self, melody):
-    """Returns the label for the last event in the melody.
+  def melody_to_label(self, melody, position):
+    """Returns the label for the given position in the melody.
 
     Returns an int the range [0, self.num_classes). Assuming MIN_NOTE = 48
     and MAX_NOTE = 84, then self.num_classes = 40.
@@ -175,33 +177,32 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
 
     Args:
       melody: A melodies_lib.MonophonicMelody object.
+      position: An integer position in the melody.
 
     Returns:
       A label, an int.
     """
+    if (position < LOOKBACK_DISTANCES[-1] and
+        melody.events[position] == NO_EVENT):
+      return self.num_model_events + 1
 
-    # If the last event repeated 2 bars ago.
-    if ((len(melody.events) <= 2 * STEPS_PER_BAR and
-         melody.events[-1] == NO_EVENT) or
-        (len(melody.events) > 2 * STEPS_PER_BAR and
-         melody.events[-1] == melody.events[-(2 * STEPS_PER_BAR + 1)])):
-      return self.note_range + 3
-
-    # If the last event repeated 1 bar ago.
-    if (len(melody.events) > STEPS_PER_BAR and
-        melody.events[-1] == melody.events[-(STEPS_PER_BAR + 1)]):
-      return self.note_range + 2
+   # If the last event repeated N bars ago. 
+   for i, lookback_distance in reversed(list(enumerate(LOOKBACK_DISTANCES))):
+      lookback_position = position - lookback_distance
+      if (lookback_position >= 0 and
+          melody.events[position] == melody.events[lookback_position]):
+        return self.note_range + 1 + i
 
     # If last event was a note-off event.
-    if melody.events[-1] == NOTE_OFF:
+    if melody.events[position] == NOTE_OFF:
       return self.note_range + 1
 
     # If last event was a no event.
-    if melody.events[-1] == NO_EVENT:
+    if melody.events[position] == NO_EVENT:
       return self.note_range
 
     # If last event was a note-on event, the pitch of that note.
-    return melody.events[-1] - self.min_note
+    return melody.events[position] - self.min_note
 
   def class_index_to_melody_event(self, class_index, melody):
     """Returns the melody event for the given class index.
@@ -216,18 +217,13 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
     Returns:
       A melodies_lib.MonophonicMelody event value.
     """
-    # Repeat 1 bar ago.
-    if class_index == self.note_range + 3:
-      if len(melody) < 2 * STEPS_PER_BAR:
-        return NO_EVENT
-      return melody.events[-(2 * STEPS_PER_BAR)]
-
-    # Repeat 2 bars ago.
-    if class_index == self.note_range + 2:
-      if len(melody) < STEPS_PER_BAR:
-        return NO_EVENT
-      return melody.events[-STEPS_PER_BAR]
-
+    # Repeat N bars ago.
+    for i, lookback_distance in reversed(list(enumerate(LOOKBACK_DISTANCES))):
+      if class_index == self.num_model_events + i:
+        if len(melody) < lookback_distance:
+          return NO_EVENT
+        return melody.events[-lookback_distance]
+      
     # Note-off event.
     if class_index == self.note_range + 1:
       return NOTE_OFF

--- a/magenta/models/attention_rnn/attention_rnn_encoder_decoder.py
+++ b/magenta/models/attention_rnn/attention_rnn_encoder_decoder.py
@@ -82,7 +82,7 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
 
     Args:
       melody: A melodies_lib.MonophonicMelody object.
-      position: An integer position in the melody.
+      position: An integer event position in the melody.
 
     Returns:
       An input vector, an self.input_size length list of floats.
@@ -177,7 +177,7 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
 
     Args:
       melody: A melodies_lib.MonophonicMelody object.
-      position: An integer position in the melody.
+      position: An integer event position in the melody.
 
     Returns:
       A label, an int.
@@ -188,10 +188,10 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
 
    # If the last event repeated N bars ago.
    for i, lookback_distance in reversed(list(enumerate(LOOKBACK_DISTANCES))):
-      lookback_position = position - lookback_distance
-      if (lookback_position >= 0 and
-          melody.events[position] == melody.events[lookback_position]):
-        return self.note_range + 1 + i
+     lookback_position = position - lookback_distance
+     if (lookback_position >= 0 and
+         melody.events[position] == melody.events[lookback_position]):
+       return self.note_range + 1 + i
 
     # If last event was a note-off event.
     if melody.events[position] == NOTE_OFF:

--- a/magenta/models/attention_rnn/attention_rnn_encoder_decoder.py
+++ b/magenta/models/attention_rnn/attention_rnn_encoder_decoder.py
@@ -184,7 +184,7 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
     """
     if (position < LOOKBACK_DISTANCES[-1] and
         melody.events[position] == NO_EVENT):
-      return self.num_model_events + 1
+      return self.note_range + len(LOOKBACK_DISTANCE) + 1
 
     # If the last event repeated N bars ago.
     for i, lookback_distance in reversed(list(enumerate(LOOKBACK_DISTANCES))):

--- a/magenta/models/basic_rnn/basic_rnn_encoder_decoder.py
+++ b/magenta/models/basic_rnn/basic_rnn_encoder_decoder.py
@@ -78,39 +78,41 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
       return model_event - NUM_SPECIAL_EVENTS
     return model_event - NUM_SPECIAL_EVENTS + self.min_note
 
-  def melody_to_input(self, melody):
-    """Returns the input vector for the last event in the melody.
+  def melody_to_input(self, melody, position):
+    """Returns the input vector for the given position in the melody.
 
-    Returns a one-hot vector for the last event in the melody mapped to the
+    Returns a one-hot vector for the given position in the melody mapped to the
     model's event range. 0 = no event, 1 = note-off event,
     [2, self._num_model_events) = note-on event for that pitch relative to the
     [self._min_note, self._max_note) range.
 
     Args:
       melody: A MonophonicMelody object.
+      position: An integer position in the melody.
 
     Returns:
       An input vector, a list of floats.
     """
     input_ = [0.0] * self.input_size
-    input_[self.melody_event_to_model_event(melody.events[-1])] = 1.0
+    input_[self.melody_event_to_model_event(melody.events[position])] = 1.0
     return input_
 
-  def melody_to_label(self, melody):
-    """Returns the label for the last event in the melody.
+  def melody_to_label(self, melody, position):
+    """Returns the label for the given position in the melody.
 
-    Returns the zero-based index value for the last event in the melody
+    Returns the zero-based index value for the given position in the melody
     mapped to the model's event range. 0 = no event, 1 = note-off event,
     [2, self._num_model_events) = note-on event for that pitch relative to the
     [self._min_note, self._max_note) range.
 
     Args:
       melody: A MonophonicMelody object.
+      position: An integer position in the melody.
 
     Returns:
       A label, an int.
     """
-    return self.melody_event_to_model_event(melody.events[-1])
+    return self.melody_event_to_model_event(melody.events[position])
 
   def class_index_to_melody_event(self, class_index, melody):
     """Returns the melody event for the given class index.

--- a/magenta/models/basic_rnn/basic_rnn_encoder_decoder.py
+++ b/magenta/models/basic_rnn/basic_rnn_encoder_decoder.py
@@ -88,7 +88,7 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
 
     Args:
       melody: A MonophonicMelody object.
-      position: An integer position in the melody.
+      position: An integer event position in the melody.
 
     Returns:
       An input vector, a list of floats.
@@ -107,7 +107,7 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
 
     Args:
       melody: A MonophonicMelody object.
-      position: An integer position in the melody.
+      position: An integer event position in the melody.
 
     Returns:
       A label, an int.

--- a/magenta/models/lookback_rnn/lookback_rnn_encoder_decoder.py
+++ b/magenta/models/lookback_rnn/lookback_rnn_encoder_decoder.py
@@ -118,8 +118,8 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
     input_ = [0.0] * self.input_size
 
     # Last event.
-    model_event = sef.melody_event_to_model_event(melody_events[position])
-    input_[modle_event] = 1.0
+    model_event = self.melody_event_to_model_event(melody.events[position])
+    input_[model_event] = 1.0
 
     # Next event if repeating N positions ago.
     for i, lookback_distance in enumerate(LOOKBACK_DISTANCES):

--- a/magenta/models/lookback_rnn/lookback_rnn_encoder_decoder.py
+++ b/magenta/models/lookback_rnn/lookback_rnn_encoder_decoder.py
@@ -161,6 +161,7 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
 
     Args:
       melody: A melodies_lib.MonophonicMelody object.
+      position: An integer position in the melody.
 
     Returns:
       A label, an int.
@@ -168,7 +169,7 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
     if (position < LOOKBACK_DISTANCES[-1] and
         melody.events[position] == NO_EVENT):
       return self.num_model_events + 1
-    
+
     # If last step repeated N bars ago.
     for i, lookback_distance in reversed(list(enumerate(LOOKBACK_DISTANCES))):
       lookback_position = position - lookback_distance

--- a/magenta/models/lookback_rnn/lookback_rnn_encoder_decoder.py
+++ b/magenta/models/lookback_rnn/lookback_rnn_encoder_decoder.py
@@ -117,9 +117,13 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
     """
     input_ = [0.0] * self.input_size
 
-     # Event N positions ago.
-    for i, lookback_distance in enumerate([0] + LOOKBACK_DISTANCES):
-      lookback_position = position - lookback_distance
+    # Last event.
+    model_event = sef.melody_event_to_model_event(melody_events[position])
+    input_[modle_event] = 1.0
+
+    # Next event if repeating N positions ago.
+    for i, lookback_distance in enumerate(LOOKBACK_DISTANCES):
+      lookback_position = position - lookback_distance + 1
       if lookback_position < 0:
         melody_event = NO_EVENT
       else:
@@ -168,7 +172,7 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
     """
     if (position < LOOKBACK_DISTANCES[-1] and
         melody.events[position] == NO_EVENT):
-      return self.num_model_events + 1
+      return self.num_model_events + len(LOOKBACK_DISTANCES)  - 1
 
     # If last step repeated N bars ago.
     for i, lookback_distance in reversed(list(enumerate(LOOKBACK_DISTANCES))):

--- a/magenta/models/lookback_rnn/lookback_rnn_encoder_decoder.py
+++ b/magenta/models/lookback_rnn/lookback_rnn_encoder_decoder.py
@@ -172,7 +172,7 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
     """
     if (position < LOOKBACK_DISTANCES[-1] and
         melody.events[position] == NO_EVENT):
-      return self.num_model_events + len(LOOKBACK_DISTANCES)  - 1
+      return self.num_model_events + len(LOOKBACK_DISTANCES) - 1
 
     # If last step repeated N bars ago.
     for i, lookback_distance in reversed(list(enumerate(LOOKBACK_DISTANCES))):

--- a/magenta/models/lookback_rnn/lookback_rnn_encoder_decoder.py
+++ b/magenta/models/lookback_rnn/lookback_rnn_encoder_decoder.py
@@ -30,6 +30,9 @@ NUM_SPECIAL_INPUTS = 7
 NUM_SPECIAL_LABELS = 2
 NUM_BINARY_TIME_COUNTERS = 5
 
+# Must be sorted in ascending order.
+LOOKBACK_DISTANCES = [STEPS_PER_BAR, STEPS_PER_BAR * 2]
+
 
 class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
   """A MelodyEncoderDecoder specific to the lookback RNN model.
@@ -86,8 +89,8 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
       return model_event - NUM_SPECIAL_EVENTS
     return model_event - NUM_SPECIAL_EVENTS + self.min_note
 
-  def melody_to_input(self, melody):
-    """Returns the input vector for the last event in the melody.
+  def melody_to_input(self, melody, position):
+    """Returns the input vector for the given position in the melody.
 
     Returns a self.input_size length list of floats. Assuming MIN_NOTE = 48
     and MAX_NOTE = 84, self.input_size will = 121. Each index represents a
@@ -107,57 +110,45 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
 
     Args:
       melody: A melodies_lib.MonophonicMelody object.
+      position: An integer position in the melody.
 
     Returns:
       An input vector, an self.input_size length list of floats.
     """
     input_ = [0.0] * self.input_size
 
-    # Last event.
-    model_event = self.melody_event_to_model_event(
-        melody.events[-1] if len(melody) >= 1 else NO_EVENT)
-    input_[model_event] = 1.0
-
-    # Next event if repeating 1 bar ago.
-    if len(melody) < STEPS_PER_BAR:
-      melody_event = NO_EVENT
-    else:
-      melody_event = melody.events[-STEPS_PER_BAR]
-    model_event = self.melody_event_to_model_event(melody_event)
-    input_[self.num_model_events + model_event] = 1.0
-
-    # Next event if repeating 2 bars ago.
-    if len(melody) < STEPS_PER_BAR * 2:
-      melody_event = NO_EVENT
-    else:
-      melody_event = melody.events[-STEPS_PER_BAR * 2]
-    model_event = self.melody_event_to_model_event(melody_event)
-    input_[2 * self.num_model_events + model_event] = 1.0
+     # Event N positions ago.
+    for i, lookback_distance in enumerate([0] + LOOKBACK_DISTANCES):
+      lookback_position = position - lookback_distance
+      if lookback_position < 0:
+        melody_event = NO_EVENT
+      else:
+        melody_event = melody.events[lookback_position]
+      model_event = self.melody_event_to_model_event(melody_event)
+      input_[i * self.num_model_events + model_event] = 1.0
 
     # Binary time counter giving the metric location of the *next* note.
-    n = len(melody)
+    n = position + 1
     for i in range(NUM_BINARY_TIME_COUNTERS):
       input_[3 * self.num_model_events + i] = 1.0 if (n / 2 ** i) % 2 else -1.0
 
-    # Last event is repeating 1 bar ago.
-    if (len(melody) >= STEPS_PER_BAR + 1 and
-        melody.events[-1] == melody.events[-(STEPS_PER_BAR + 1)]):
-      input_[3 * self.num_model_events + 5] = 1.0
-
-    # Last event is repeating 2 bars ago.
-    if (len(melody) >= 2 * STEPS_PER_BAR + 1 and
-        melody.events[-1] == melody.events[-(2 * STEPS_PER_BAR + 1)]):
-      input_[3 * self.num_model_events + 6] = 1.0
+    # Last event is repeating N bars ago.
+    for i, lookback_distance in enumerate(LOOKBACK_DISTANCES):
+      lookback_position = position - lookback_distance
+      if (lookback_position >= 0 and
+          melody.events[position] == melody.events[lookback_position]):
+        input_[3 * self.num_model_events + 5 + i] = 1.0
 
     return input_
 
-  def melody_to_label(self, melody):
-    """Returns the label for the last event in the melody.
+  def melody_to_label(self, melody, position):
+    """Returns the label for the given position in the melody.
 
     Returns an int the range [0, self.num_classes). Indices in the range
     [0, self.num_model_events) map to standard midi events. Indices
     self.num_model_events and self.num_model_events + 1 are signals to repeat
-    events from earlier in the melody.
+    events from earlier in the melody. More distant repeats are selected first
+    and standard midi events are selected last.
 
     Assuming MIN_NOTE = 48 and MAX_NOTE = 84, then self.num_classes = 40,
     self.num_model_events = 38, and the values will be as follows.
@@ -174,20 +165,20 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
     Returns:
       A label, an int.
     """
-    # If last step repeated 2 bars ago.
-    if ((len(melody.events) <= 2 * STEPS_PER_BAR and
-         melody.events[-1] == NO_EVENT) or
-        (len(melody.events) > 2 * STEPS_PER_BAR and
-         melody.events[-1] == melody.events[-(2 * STEPS_PER_BAR + 1)])):
+    if (position < LOOKBACK_DISTANCES[-1] and
+        melody.events[position] == NO_EVENT):
       return self.num_model_events + 1
+    
+    # If last step repeated N bars ago.
+    for i, lookback_distance in reversed(list(enumerate(LOOKBACK_DISTANCES))):
+      lookback_position = position - lookback_distance
+      if (lookback_position >= 0 and
+          melody.events[position] == melody.events[lookback_position]):
+        return self.num_model_events + 1 + i
 
-    # If last step repeated 1 bar ago.
-    if (len(melody.events) > STEPS_PER_BAR and
-        melody.events[-1] == melody.events[-(STEPS_PER_BAR + 1)]):
-      return self.num_model_events
-
-    # If last step didn't repeat 1 or 2 bars ago, use the specific event.
-    return self.melody_event_to_model_event(melody.events[-1])
+    # If last step didn't repeat at one of the lookback positions, use the
+    # specific event.
+    return self.melody_event_to_model_event(melody.events[position])
 
   def class_index_to_melody_event(self, class_index, melody):
     """Returns the melody event for the given class index.
@@ -202,17 +193,12 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
     Returns:
       A melodies_lib.MonophonicMelody event value.
     """
-    # Repeat 1 bar ago.
-    if class_index == self.num_model_events + 1:
-      if len(melody) < 2 * STEPS_PER_BAR:
-        return NO_EVENT
-      return melody.events[-(2 * STEPS_PER_BAR)]
-
-    # Repeat 2 bars ago.
-    if class_index == self.num_model_events:
-      if len(melody) < STEPS_PER_BAR:
-        return NO_EVENT
-      return melody.events[-STEPS_PER_BAR]
+    # Repeat N bar ago.
+    for i, lookback_distance in reversed(list(enumerate(LOOKBACK_DISTANCES))):
+      if class_index == self.num_model_events + i:
+        if len(melody) < lookback_distance:
+          return NO_EVENT
+        return melody.events[-lookback_distance]
 
     # Return the melody event for that class index.
     return self.model_event_to_melody_event(class_index)

--- a/magenta/models/lookback_rnn/lookback_rnn_encoder_decoder.py
+++ b/magenta/models/lookback_rnn/lookback_rnn_encoder_decoder.py
@@ -24,14 +24,14 @@ MIN_NOTE = 48  # Inclusive
 MAX_NOTE = 84  # Exclusive
 TRANSPOSE_TO_KEY = 0  # C Major
 
+# Must be sorted in ascending order.
+LOOKBACK_DISTANCES = [STEPS_PER_BAR, STEPS_PER_BAR * 2]
+
 # The number of special input indices and label values other than the events
 # in the note range.
 NUM_SPECIAL_INPUTS = 7
-NUM_SPECIAL_LABELS = 2
+NUM_SPECIAL_LABELS = len(LOOKBACK_DISTANCES)
 NUM_BINARY_TIME_COUNTERS = 5
-
-# Must be sorted in ascending order.
-LOOKBACK_DISTANCES = [STEPS_PER_BAR, STEPS_PER_BAR * 2]
 
 
 class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
@@ -179,7 +179,7 @@ class MelodyEncoderDecoder(melodies_lib.MelodyEncoderDecoder):
       lookback_position = position - lookback_distance
       if (lookback_position >= 0 and
           melody.events[position] == melody.events[lookback_position]):
-        return self.num_model_events + 1 + i
+        return self.num_model_events + i
 
     # If last step didn't repeat at one of the lookback positions, use the
     # specific event.

--- a/magenta/pipelines/pipelines_common_test.py
+++ b/magenta/pipelines/pipelines_common_test.py
@@ -74,17 +74,16 @@ class PipelineUnitsCommonTest(tf.test.TestCase):
         quantized_sequence, 1,
         [(12, 127, 2, 4), (14, 50, 6, 8)])
     expected_events = [
-        [NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 11, NOTE_OFF],
-        [NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14, NO_EVENT,
-         NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT]]
+        [NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 11],
+        [NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14, NO_EVENT]]
     expected_melodies = []
     for events_list in expected_events:
       melody = melodies_lib.MonophonicMelody()
       melody.from_event_list(events_list)
       melody.steps_per_bar = 4
       expected_melodies.append(melody)
-    expected_melodies[0].end_step = 8
-    expected_melodies[1].end_step = 12
+    expected_melodies[0].end_step = 7
+    expected_melodies[1].end_step = 8
 
     unit = pipelines_common.MonophonicMelodyExtractor(
         min_bars=1, min_unique_pitches=1, gap_bars=1)

--- a/magenta/pipelines/pipelines_common_test.py
+++ b/magenta/pipelines/pipelines_common_test.py
@@ -76,7 +76,7 @@ class PipelineUnitsCommonTest(tf.test.TestCase):
     expected_events = [
         [NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 11, NOTE_OFF],
         [NO_EVENT, NO_EVENT, 12, NO_EVENT, NOTE_OFF, NO_EVENT, 14, NO_EVENT,
-         NOTE_OFF]]
+         NOTE_OFF, NO_EVENT, NO_EVENT, NO_EVENT]]
     expected_melodies = []
     for events_list in expected_events:
       melody = melodies_lib.MonophonicMelody()


### PR DESCRIPTION
-Modify melody encoder/decoder code to avoid destroying encoded/decoded melodies while also avoiding unnecessary copies. 
-Adds  optional NO_EVENT padding to end of extracted melodies to complete bars.
-Adds max_steps_truncate and max_argument_discard arguments for melody extractor that shorten/discard melodies that are too long.
-Removes final NOTE_OFF events from extracted melodies.
-Refactors some melody encoder/decoder code for re-use.