### PR TITLE
End melody end note

### DIFF
--- a/magenta/lib/melodies_lib.py
+++ b/magenta/lib/melodies_lib.py
@@ -420,11 +420,15 @@ class MonophonicMelody(object):
       length += -len(self.events) % steps_per_bar
     self.set_length(length)
 
-  def from_event_list(self, events, start_step=0):
+  def from_event_list(self, events, start_step=0,
+                      steps_per_bar=DEFAULT_STEPS_PER_BAR,
+                      steps_per_beat=DEFAULT_STEPS_PER_BEAT):
     """Populate self with a list of event values."""
     self.events = list(events)
     self._start_step = start_step
     self._end_step = start_step + len(self)
+    self._steps_per_bar = steps_per_bar
+    self._steps_per_beat = steps_per_beat
 
   def to_sequence(self,
                   velocity=100,

--- a/magenta/pipelines/pipelines_common_test.py
+++ b/magenta/pipelines/pipelines_common_test.py
@@ -79,12 +79,8 @@ class PipelineUnitsCommonTest(tf.test.TestCase):
     expected_melodies = []
     for events_list in expected_events:
       melody = melodies_lib.MonophonicMelody()
-      melody.from_event_list(events_list)
-      melody.steps_per_bar = 4
+      melody.from_event_list(events_list, steps_per_beat=1, steps_per_bar=4)
       expected_melodies.append(melody)
-    expected_melodies[0].end_step = 7
-    expected_melodies[1].end_step = 8
-
     unit = pipelines_common.MonophonicMelodyExtractor(
         min_bars=1, min_unique_pitches=1, gap_bars=1)
     self._unit_transform_test(unit, quantized_sequence, expected_melodies)


### PR DESCRIPTION
Modifies MonophonicMelody.to_sequence to treat the end of the melody as a NOTE_OFF event. Adds tests for to_sequence. Makes class attributes private.