### PR TITLE
check for oversized time signature denominator

### DIFF
--- a/magenta/lib/midi_io.py
+++ b/magenta/lib/midi_io.py
@@ -89,7 +89,12 @@ def midi_to_sequence_proto(midi_data):
     time_signature = sequence.time_signatures.add()
     time_signature.time = midi_time.time
     time_signature.numerator = midi_time.numerator
-    time_signature.denominator = midi_time.denominator
+    try:
+      # Denominator can be too large for int32.
+      time_signature.denominator = midi_time.denominator
+    except ValueError:
+      raise MIDIConversionError('Invalid time signature denominator %d' %
+                                midi_time.denominator)
 
   # Populate key signatures.
   for midi_key in midi.key_signature_changes:


### PR DESCRIPTION
Check for bad time signature denominator values in MIDI.

MIDI represents the denominator of a time signature as 2 raised to a one-byte value.  As such, it is possible, though uncommon and likely due to corrupt data, for the denominator to exceed the maximum value of an int32.  In this case, raise a MIDIConversionError.