### PR TITLE
update readme files with Docker path notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ ready to run. It will also map port 6006 of the host machine to the container so
 you can view TensorBoard servers that run within the container.
 
 This also maps the directory ```/tmp/magenta``` on the host machine to
-```/magenta-data``` within the Docker session. **WARNING**: only data saved in
-```/magenta-data``` will persist across Docker sessions.
+```/magenta-data``` within the Docker session. Windows users can change 
+```/tmp/magenta``` to a path such as ```C:/magenta```, and Mac users can 
+use a path to their user home folder such as ```~/magenta```. **WARNING**: 
+only data saved in ```/magenta-data``` will persist across Docker sessions.
 
 The Docker image also includes several pre-trained models in
 ```/magenta/models```. For example, to generate some MIDI files using the
@@ -38,6 +40,11 @@ bazel run //magenta/models/lookback_rnn:lookback_rnn_generate -- \
 --num_steps=128 \
 --primer_melody="[60]"
 ```
+
+**NOTE**: Verify that the ```--output_dir``` path matches the path you 
+mapped as your shared folder when running the ```docker run``` command. This
+example command presupposes that you are using ```/magenta-data``` as your 
+shared folder from the example ```docker run``` command above.
 
 One downside to the Docker container is that it is isolated from the host. If
 you want to listen to a generated MIDI file, you'll need to copy it to the host

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ you can view TensorBoard servers that run within the container.
 
 This also maps the directory ```/tmp/magenta``` on the host machine to
 ```/magenta-data``` within the Docker session. Windows users can change 
-```/tmp/magenta``` to a path such as ```C:/magenta```, and Mac users can 
-use a path to their user home folder such as ```~/magenta```. **WARNING**: 
+```/tmp/magenta``` to a path such as ```C:/magenta```, and Mac and Linux users 
+can use a path relative to their home folder such as ```~/magenta```. **WARNING**: 
 only data saved in ```/magenta-data``` will persist across Docker sessions.
 
 The Docker image also includes several pre-trained models in

--- a/magenta/models/attention_rnn/README.md
+++ b/magenta/models/attention_rnn/README.md
@@ -8,7 +8,7 @@ First, set up your [Magenta environment](https://github.com/tensorflow/magenta/b
 
 ## Pre-trained
 
-If you want to get started right away, you can use a model that we've pre-trained on thousands of MIDI files. Download the [attention_rnn bundle](http://download.magenta.tensorflow.org/models/attention_rnn.mag).
+If you want to get started right away, you can use a model that we've pre-trained on thousands of MIDI files. Download the [attention_rnn bundle](http://download.magenta.tensorflow.org/models/attention_rnn.mag). If you're using the Magenta Docker Container, the ```attention_rnn.mag``` file will be located at ```/magenta-models/attention_rnn.mag``` and you can assign that path as your ```BUNDLE_PATH``` in the next step.
 
 ### Generate a melody
 

--- a/magenta/models/basic_rnn/README.md
+++ b/magenta/models/basic_rnn/README.md
@@ -12,7 +12,7 @@ First, set up your [Magenta environment](https://github.com/tensorflow/magenta/b
 
 ## Pre-trained
 
-If you want to get started right away, you can use a model that we've pre-trained on thousands of MIDI files. Download the [basic_rnn bundle](http://download.magenta.tensorflow.org/models/basic_rnn.mag).
+If you want to get started right away, you can use a model that we've pre-trained on thousands of MIDI files. Download the [basic_rnn bundle](http://download.magenta.tensorflow.org/models/basic_rnn.mag). If you're using the Magenta Docker Container, the ```basic_rnn.mag``` file will be located at ```/magenta-models/basic_rnn.mag``` and you can assign that path as your ```BUNDLE_PATH``` in the next step.
 
 ### Generate a melody
 

--- a/magenta/models/lookback_rnn/README.md
+++ b/magenta/models/lookback_rnn/README.md
@@ -8,7 +8,7 @@ First, set up your [Magenta environment](https://github.com/tensorflow/magenta/b
 
 ## Pre-trained
 
-If you want to get started right away, you can use a model that we've pre-trained on thousands of MIDI files. Download the [lookback_rnn bundle](http://download.magenta.tensorflow.org/models/lookback_rnn.mag).
+If you want to get started right away, you can use a model that we've pre-trained on thousands of MIDI files. Download the [lookback_rnn bundle](http://download.magenta.tensorflow.org/models/lookback_rnn.mag). If you're using the Magenta Docker Container, the ```lookback_rnn.mag``` file will be located at ```/magenta-models/lookback_rnn.mag``` and you can assign that path as your ```BUNDLE_PATH``` in the next step.
 
 ### Generate a melody
 


### PR DESCRIPTION
- added notes for windows and mac users on main readme re: shared folder paths
- added note to main readme to verify the output_dir flag matches their defined shared folders from the docker run command
- added notes on basic_rnn, lookback_rnn, and attention_rnn readme's noting that the .mag files are already present on the Docker container