### PR TITLE
When restoring a metagraph, construct a new graph.

### DIFF
--- a/magenta/models/shared/melody_rnn_sequence_generator.py
+++ b/magenta/models/shared/melody_rnn_sequence_generator.py
@@ -77,9 +77,10 @@ class MelodyRnnSequenceGenerator(magenta.music.BaseSequenceGenerator):
 
   def _initialize_with_checkpoint_and_metagraph(self, checkpoint_filename,
                                                 metagraph_filename):
-    self._session = tf.Session()
-    new_saver = tf.train.import_meta_graph(metagraph_filename)
-    new_saver.restore(self._session, checkpoint_filename)
+    with tf.Graph().as_default():
+      self._session = tf.Session()
+      new_saver = tf.train.import_meta_graph(metagraph_filename)
+      new_saver.restore(self._session, checkpoint_filename)
 
   def _write_checkpoint_with_metagraph(self, checkpoint_filename):
     with self._session.graph.as_default():


### PR DESCRIPTION
Makes sure that bundles are restored into their own graph instead of
just using the default graph, which can cause problems if you load
multiple bundles in the same Python session.