### PR TITLE
use beam search to generate melodies

### DIFF
--- a/magenta/models/melody_rnn/BUILD
+++ b/magenta/models/melody_rnn/BUILD
@@ -78,6 +78,7 @@ py_library(
         ":melody_rnn_config",
         ":melody_rnn_graph",
         "//magenta",
+        # numpy dep
         # tensorflow dep
     ],
 )

--- a/magenta/models/melody_rnn/melody_rnn_generate.py
+++ b/magenta/models/melody_rnn/melody_rnn_generate.py
@@ -128,15 +128,6 @@ def get_bundle():
   return magenta.music.read_bundle_file(bundle_file)
 
 
-def get_beam_search_params():
-  """Get the beam search parameters to use."""
-  return {
-    'beam_size': FLAGS.beam_size,
-    'branch_factor': FLAGS.branch_factor,
-    'steps_per_iteration': FLAGS.steps_per_iteration
-  }
-
-
 def _steps_to_seconds(steps, qpm):
   """Converts steps to seconds.
 
@@ -215,6 +206,10 @@ def run_with_flags(generator):
         start_time=0,
         end_time=total_seconds)
   generator_options.args['temperature'].float_value = FLAGS.temperature
+  generator_options.args['beam_size'].int_value = FLAGS.beam_size
+  generator_options.args['branch_factor'].int_value = FLAGS.branch_factor
+  generator_options.args[
+      'steps_per_iteration'].int_value = FLAGS.steps_per_iteration
   tf.logging.debug('input_sequence: %s', input_sequence)
   tf.logging.debug('generator_options: %s', generator_options)
 
@@ -239,8 +234,7 @@ def main(unused_argv):
       config=melody_rnn_config.config_from_flags(),
       steps_per_quarter=FLAGS.steps_per_quarter,
       checkpoint=get_checkpoint(),
-      bundle=get_bundle(),
-      **get_beam_search_params())
+      bundle=get_bundle())
 
   if FLAGS.save_generator_bundle:
     bundle_filename = os.path.expanduser(FLAGS.bundle_file)

--- a/magenta/models/melody_rnn/melody_rnn_graph_test.py
+++ b/magenta/models/melody_rnn/melody_rnn_graph_test.py
@@ -51,11 +51,6 @@ class MelodyRNNGraphTest(tf.test.TestCase):
     g = melody_rnn_graph.build_graph('generate', self.config)
     self.assertTrue(isinstance(g, tf.Graph))
 
-  def testBuildGenerateGraphWithTemp(self):
-    self.config.hparams.temperature = 1.1
-    g = melody_rnn_graph.build_graph('generate', self.config)
-    self.assertTrue(isinstance(g, tf.Graph))
-
   def testBuildGraphWithAttention(self):
     self.config.hparams.attn_length = 10
     g = melody_rnn_graph.build_graph(

--- a/magenta/music/events_lib.py
+++ b/magenta/music/events_lib.py
@@ -423,6 +423,9 @@ class EventsEncoderDecoder(object):
       event_sequences: A list of EventSequence objects.
       softmax: A list of softmax probability vectors. The list of softmaxes
           should be the same length as the list of event_sequences.
+
+    Returns:
+      A python list of chosen class indices, one for each event sequence.
     """
     num_classes = len(softmax[0][0])
     chosen_classes = []

--- a/magenta/music/events_lib.py
+++ b/magenta/music/events_lib.py
@@ -425,7 +425,10 @@ class EventsEncoderDecoder(object):
           should be the same length as the list of event_sequences.
     """
     num_classes = len(softmax[0][0])
+    chosen_classes = []
     for i in xrange(len(event_sequences)):
       chosen_class = np.random.choice(num_classes, p=softmax[i][-1])
       event = self.class_index_to_event(chosen_class, event_sequences[i])
       event_sequences[i].append_event(event)
+      chosen_classes.append(chosen_class)
+    return chosen_classes


### PR DESCRIPTION
Modifies the melody generation to use beam search instead of taking "greedy" steps.  This version of beam search uses three parameters:

_beam_size_: The number of melodies to include in the "beam"; the current active set.  When using a pre-trained bundle, this parameter must match the bundle's generation batch size.

_branch_factor_: The number of new melodies to generate per active melody in each beam search iteration.  All but the _beam_size_ melodies with highest likelihood will then be discarded.

_steps_per_iteration_: The number of melody steps to generate per beam search iteration.

When all three of these parameters have value 1, the generation matches the old "greedy" behavior.