### PR TITLE
replace music21 chord symbol functions with custom ones

### DIFF
--- a/magenta/music/BUILD
+++ b/magenta/music/BUILD
@@ -50,7 +50,6 @@ py_library(
     srcs = ["chord_symbols_lib.py"],
     srcs_version = "PY2AND3",
     deps = [
-        "@music21//:music21",
         # tensorflow dep
     ],
 )

--- a/magenta/music/chord_symbols_lib.py
+++ b/magenta/music/chord_symbols_lib.py
@@ -147,81 +147,124 @@ class BasicChordSymbolFunctions(ChordSymbolFunctions):
   # Mapping from scale degree to offset in half steps.
   _DEGREE_OFFSETS = {1: 0, 2: 2, 3: 4, 4: 5, 5: 7, 6: 9, 7: 11}
 
-  # Dictionary mapping MusicXML chord kind to abbreviations and scale degrees.
-  _CHORD_KINDS = {
-      # triads
-      'major':                  (['', 'maj', 'M'],
-                                    ['1', '3', '5']),
-      'minor':                  (['m', 'min', '-'],
-                                    ['1', 'b3', '5']),
-      'augmented':              (['+', 'aug'],
-                                    ['1', '3', '#5']),
-      'diminished':             (['o', 'dim'],
-                                    ['1', 'b3', 'b5']),
+  # List of chord kinds with abbreviations and scale degrees. Scale degrees are
+  # represented as strings here a) for human readability, and b) because the
+  # number of semitones is insufficient when the chords have scale degree
+  # modifications.
+  _CHORD_KINDS = [
+      # major triad
+      (['', 'maj', 'M'],
+          ['1', '3', '5']),
 
-      # sevenths
-      'dominant':               (['7'],
-                                    ['1', '3', '5', 'b7']),
-      'major-seventh':          (['maj7', 'M7'],
-                                    ['1', '3', '5', '7']),
-      'minor-seventh':          (['m7', 'min7', '-7'],
-                                     ['1', 'b3', '5', 'b7']),
-      'diminished-seventh':     (['o7', 'dim7'],
-                                     ['1', 'b3', 'b5', 'bb7']),
-      'augmented-seventh':      (['+7', 'aug7'],
-                                     ['1', '3', '#5', 'b7']),
-      'half-diminished':        (['m7b5', '-7b5', '/o', '/o7'],
-                                     ['1', 'b3', 'b5', 'b7']),
-      'major-minor':            (['mmaj7', 'mM7', 'minmaj7', 'minM7', '-maj7', '-M7'],
-                                     ['1', 'b3', '5', '7']),
+      # minor triad
+      (['m', 'min', '-'],
+          ['1', 'b3', '5']),
 
-      # sixths
-      'major-sixth':            (['6'],
-                                     ['1', '3', '5', '6']),
-      'minor-sixth':            (['m6', 'min6', '-6'],
-                                     ['1', 'b3', '5', '6']),
+      # augmented triad
+      (['+', 'aug'],
+          ['1', '3', '#5']),
 
-      # ninths
-      'dominant-ninth':         (['9'],
-                                     ['1', '3', '5', 'b7', '9']),
-      'major-ninth':            (['maj9', 'M9'],
-                                     ['1', '3', '5', '7', '9']),
-      'minor-ninth':            (['m9', 'min9', '-9'],
-                                     ['1', 'b3', '5', 'b7', '9']),
+      # diminished triad
+      (['o', 'dim'],
+          ['1', 'b3', 'b5']),
 
-      # elevenths
-      'dominant-11th':          (['11'],
-                                     ['1', '3', '5', 'b7', '9', '11']),
-      'major-11th':             (['maj11', 'M11'],
-                                     ['1', '3', '5', '7', '9', '11']),
-      'minor-11th':             (['m11', 'min11', '-11'],
-                                     ['1', 'b3', '5', 'b7', '9', '11']),
+      # dominant 7th
+      (['7'],
+          ['1', '3', '5', 'b7']),
 
-      # thirteenths
-      'dominant-13th':          (['13'],
-                                     ['1', '3', '5', 'b7', '9', '11', '13']),
-      'major-13th':             (['maj13', 'M13'],
-                                     ['1', '3', '5', '7', '9', '11', '13']),
-      'minor-13th':             (['m13', 'min13', '-13'],
-                                     ['1', 'b3', '5', 'b7', '9', '11', '13']),
+      # major 7th
+      (['maj7', 'M7'],
+          ['1', '3', '5', '7']),
 
-      # suspended
-      'suspended-second':       (['sus2'],
-                                     ['1', '2', '5']),
-      'suspended-fourth':       (['sus', 'sus4'],
-                                     ['1', '4', '5']),
+      # minor 7th
+      (['m7', 'min7', '-7'],
+          ['1', 'b3', '5', 'b7']),
 
-      # other
-      'pedal':                  (['ped'],
-                                     ['1']),
-      'power':                  (['5'],
-                                     ['1', '5'])
-  }
+      # diminished 7th
+      (['o7', 'dim7'],
+          ['1', 'b3', 'b5', 'bb7']),
+
+      # augmented 7th
+      (['+7', 'aug7'],
+          ['1', '3', '#5', 'b7']),
+
+      # half-diminished
+      (['m7b5', '-7b5', '/o', '/o7'],
+          ['1', 'b3', 'b5', 'b7']),
+
+      # minor triad with major 7th
+      (['mmaj7', 'mM7', 'minmaj7', 'minM7', '-maj7', '-M7',
+        'm(maj7)', 'm(M7)', 'min(maj7)', 'min(M7)', '-(maj7)', '-(M7)'],
+          ['1', 'b3', '5', '7']),
+
+      # major 6th
+      (['6'],
+          ['1', '3', '5', '6']),
+
+      # minor 6th
+      (['m6', 'min6', '-6'],
+          ['1', 'b3', '5', '6']),
+
+      # dominant 9th
+      (['9'],
+          ['1', '3', '5', 'b7', '9']),
+
+      # major 9th
+      (['maj9', 'M9'],
+          ['1', '3', '5', '7', '9']),
+
+      # minor 9th
+      (['m9', 'min9', '-9'],
+          ['1', 'b3', '5', 'b7', '9']),
+
+      # 6/9 chord
+      (['6/9'],
+          ['1', '3', '5', '6', '9']),
+
+      # dominant 11th
+      (['11'],
+          ['1', '3', '5', 'b7', '9', '11']),
+
+      # major 11th
+      (['maj11', 'M11'],
+          ['1', '3', '5', '7', '9', '11']),
+
+      # minor 11th
+      (['m11', 'min11', '-11'],
+          ['1', 'b3', '5', 'b7', '9', '11']),
+
+      # dominant 13th
+      (['13'],
+          ['1', '3', '5', 'b7', '9', '11', '13']),
+
+      # major 13th
+      (['maj13', 'M13'],
+          ['1', '3', '5', '7', '9', '11', '13']),
+
+      # minor 13th
+      (['m13', 'min13', '-13'],
+          ['1', 'b3', '5', 'b7', '9', '11', '13']),
+
+      # suspended 2nd
+      (['sus2'],
+          ['1', '2', '5']),
+
+      # suspended 4th
+      (['sus', 'sus4'],
+          ['1', '4', '5']),
+
+      # pedal point
+      (['ped'],
+          ['1']),
+
+      # power chord
+      (['5'],
+          ['1', '5'])
+  ]
 
   # Dictionary mapping chord kind abbreviations to names and scale degrees.
-  _CHORD_KINDS_BY_ABBREV = dict((abbrev, (kind, degrees))
-                                for kind, (abbrevs, degrees)
-                                in _CHORD_KINDS.items()
+  _CHORD_KINDS_BY_ABBREV = dict((abbrev, degrees)
+                                for abbrevs, degrees in _CHORD_KINDS
                                 for abbrev in abbrevs)
 
   # Function to add a scale degree.
@@ -266,7 +309,7 @@ class BasicChordSymbolFunctions(ChordSymbolFunctions):
   _ROOT_PATTERN = '[A-G](?:#*|b*)(?![#b])'
   _CHORD_KIND_PATTERN = '|'.join(re.escape(abbrev)
                                  for abbrev in _CHORD_KINDS_BY_ABBREV)
-  _MODIFICATIONS_PATTERN = '(?:(?:%s)[0-9]+)*' % '|'.join(
+  _MODIFICATIONS_PATTERN = '(?:\(?(?:%s)[0-9]+\)?)*' % '|'.join(
       re.escape(mod) for mod in _DEGREE_MODIFICATIONS)
   _BASS_PATTERN = '|/%s' % _ROOT_PATTERN
 
@@ -287,7 +330,7 @@ class BasicChordSymbolFunctions(ChordSymbolFunctions):
   _SCALE_DEGREE_REGEX = re.compile(_SCALE_DEGREE_PATTERN)
 
   # Regular expression for a single scale degree modification.
-  _MODIFICATION_PATTERN = '(%s)([0-9]+)' % '|'.join(
+  _MODIFICATION_PATTERN = '\(?(%s)([0-9]+)\)?' % '|'.join(
       re.escape(mod) for mod in _DEGREE_MODIFICATIONS)
   _MODIFICATION_REGEX = re.compile(_MODIFICATION_PATTERN)
 
@@ -302,14 +345,14 @@ class BasicChordSymbolFunctions(ChordSymbolFunctions):
     return self._parse_pitch_class(root_str)
 
   def _parse_degree(self, degree_str):
-    """Parse scale degree from string (from internal chord kind dictionary)."""
+    """Parse scale degree from string (from internal kind representation)."""
     match = self._SCALE_DEGREE_REGEX.match(degree_str)
     alter, degree = match.groups()
     return int(degree), len(alter) * (1 if '#' in alter else -1)
 
   def _parse_kind(self, kind_str):
     """Parse chord kind from string, returning a scale degree dictionary."""
-    _, degrees = self._CHORD_KINDS_BY_ABBREV[kind_str]
+    degrees = self._CHORD_KINDS_BY_ABBREV[kind_str]
     # Here we make the assumption that each scale degree can be present in a
     # chord at most once. This is not generally true, as e.g. a chord could
     # contain both b9 and #9.
@@ -466,7 +509,7 @@ class BasicChordSymbolFunctions(ChordSymbolFunctions):
     return self._pitch_class_to_midi(bass_step, bass_alter)
 
   def chord_symbol_quality(self, figure):
-    """Return the quality (major, minor, dimished, augmented) of a chord."""
+    """Return the quality (major, minor, diminished, augmented) of a chord."""
     _, degrees, _ = self._parse_chord_symbol(figure)
     if 1 not in degrees or 3 not in degrees or 5 not in degrees:
       return CHORD_QUALITY_OTHER

--- a/magenta/music/chord_symbols_lib.py
+++ b/magenta/music/chord_symbols_lib.py
@@ -154,112 +154,112 @@ class BasicChordSymbolFunctions(ChordSymbolFunctions):
   _CHORD_KINDS = [
       # major triad
       (['', 'maj', 'M'],
-          ['1', '3', '5']),
+       ['1', '3', '5']),
 
       # minor triad
       (['m', 'min', '-'],
-          ['1', 'b3', '5']),
+       ['1', 'b3', '5']),
 
       # augmented triad
       (['+', 'aug'],
-          ['1', '3', '#5']),
+       ['1', '3', '#5']),
 
       # diminished triad
       (['o', 'dim'],
-          ['1', 'b3', 'b5']),
+       ['1', 'b3', 'b5']),
 
       # dominant 7th
       (['7'],
-          ['1', '3', '5', 'b7']),
+       ['1', '3', '5', 'b7']),
 
       # major 7th
       (['maj7', 'M7'],
-          ['1', '3', '5', '7']),
+       ['1', '3', '5', '7']),
 
       # minor 7th
       (['m7', 'min7', '-7'],
-          ['1', 'b3', '5', 'b7']),
+       ['1', 'b3', '5', 'b7']),
 
       # diminished 7th
       (['o7', 'dim7'],
-          ['1', 'b3', 'b5', 'bb7']),
+       ['1', 'b3', 'b5', 'bb7']),
 
       # augmented 7th
       (['+7', 'aug7'],
-          ['1', '3', '#5', 'b7']),
+       ['1', '3', '#5', 'b7']),
 
       # half-diminished
       (['m7b5', '-7b5', '/o', '/o7'],
-          ['1', 'b3', 'b5', 'b7']),
+       ['1', 'b3', 'b5', 'b7']),
 
       # minor triad with major 7th
       (['mmaj7', 'mM7', 'minmaj7', 'minM7', '-maj7', '-M7',
         'm(maj7)', 'm(M7)', 'min(maj7)', 'min(M7)', '-(maj7)', '-(M7)'],
-          ['1', 'b3', '5', '7']),
+       ['1', 'b3', '5', '7']),
 
       # major 6th
       (['6'],
-          ['1', '3', '5', '6']),
+       ['1', '3', '5', '6']),
 
       # minor 6th
       (['m6', 'min6', '-6'],
-          ['1', 'b3', '5', '6']),
+       ['1', 'b3', '5', '6']),
 
       # dominant 9th
       (['9'],
-          ['1', '3', '5', 'b7', '9']),
+       ['1', '3', '5', 'b7', '9']),
 
       # major 9th
       (['maj9', 'M9'],
-          ['1', '3', '5', '7', '9']),
+       ['1', '3', '5', '7', '9']),
 
       # minor 9th
       (['m9', 'min9', '-9'],
-          ['1', 'b3', '5', 'b7', '9']),
+       ['1', 'b3', '5', 'b7', '9']),
 
       # 6/9 chord
       (['6/9'],
-          ['1', '3', '5', '6', '9']),
+       ['1', '3', '5', '6', '9']),
 
       # dominant 11th
       (['11'],
-          ['1', '3', '5', 'b7', '9', '11']),
+       ['1', '3', '5', 'b7', '9', '11']),
 
       # major 11th
       (['maj11', 'M11'],
-          ['1', '3', '5', '7', '9', '11']),
+       ['1', '3', '5', '7', '9', '11']),
 
       # minor 11th
       (['m11', 'min11', '-11'],
-          ['1', 'b3', '5', 'b7', '9', '11']),
+       ['1', 'b3', '5', 'b7', '9', '11']),
 
       # dominant 13th
       (['13'],
-          ['1', '3', '5', 'b7', '9', '11', '13']),
+       ['1', '3', '5', 'b7', '9', '11', '13']),
 
       # major 13th
       (['maj13', 'M13'],
-          ['1', '3', '5', '7', '9', '11', '13']),
+       ['1', '3', '5', '7', '9', '11', '13']),
 
       # minor 13th
       (['m13', 'min13', '-13'],
-          ['1', 'b3', '5', 'b7', '9', '11', '13']),
+       ['1', 'b3', '5', 'b7', '9', '11', '13']),
 
       # suspended 2nd
       (['sus2'],
-          ['1', '2', '5']),
+       ['1', '2', '5']),
 
       # suspended 4th
       (['sus', 'sus4'],
-          ['1', '4', '5']),
+       ['1', '4', '5']),
 
       # pedal point
       (['ped'],
-          ['1']),
+       ['1']),
 
       # power chord
       (['5'],
-          ['1', '5'])
+       ['1', '5'])
   ]
 
   # Dictionary mapping chord kind abbreviations to names and scale degrees.
@@ -268,7 +268,7 @@ class BasicChordSymbolFunctions(ChordSymbolFunctions):
                                 for abbrev in abbrevs)
 
   # Function to add a scale degree.
-  def _add_scale_degree(degrees, degree, alter):
+  def _add_scale_degree(self, degrees, degree, alter):
     if degree in degrees:
       raise ChordSymbolException('Scale degree already in chord: %d' % degree)
     if degree == 7:
@@ -276,13 +276,13 @@ class BasicChordSymbolFunctions(ChordSymbolFunctions):
     degrees[degree] = alter
 
   # Function to remove a scale degree.
-  def _subtract_scale_degree(degrees, degree, unused_alter):
+  def _subtract_scale_degree(self, degrees, degree, unused_alter):
     if degree not in degrees:
       raise ChordSymbolException('Scale degree not in chord: %d' % degree)
     del degrees[degree]
 
   # Function to alter (or add) a scale degree.
-  def _alter_scale_degree(degrees, degree, alter):
+  def _alter_scale_degree(self, degrees, degree, alter):
     if degree in degrees:
       degrees[degree] += alter
     else:
@@ -293,23 +293,24 @@ class BasicChordSymbolFunctions(ChordSymbolFunctions):
   # types to aid in parsing, as each of the three basic operations has its own
   # requirements on the scale degree operand:
   #
-  # Addition can accept altered and unaltered scale degrees.
-  # Subtraction can only accept unaltered scale degrees.
-  # Alteration can only accept altered scale degrees.
+  #  - Addition can accept altered and unaltered scale degrees.
+  #  - Subtraction can only accept unaltered scale degrees.
+  #  - Alteration can only accept altered scale degrees.
+
   _DEGREE_MODIFICATIONS = {
-      'add':  (_add_scale_degree, 0),
+      'add': (_add_scale_degree, 0),
       'add#': (_add_scale_degree, 1),
       'addb': (_add_scale_degree, -1),
-      'no':   (_subtract_scale_degree, 0),
-      '#':    (_alter_scale_degree, 1),
-      'b':    (_alter_scale_degree, -1)
+      'no': (_subtract_scale_degree, 0),
+      '#': (_alter_scale_degree, 1),
+      'b': (_alter_scale_degree, -1)
   }
 
   # Regular expression patterns for chord symbol parts.
-  _ROOT_PATTERN = '[A-G](?:#*|b*)(?![#b])'
+  _ROOT_PATTERN = r'[A-G](?:#*|b*)(?![#b])'
   _CHORD_KIND_PATTERN = '|'.join(re.escape(abbrev)
                                  for abbrev in _CHORD_KINDS_BY_ABBREV)
-  _MODIFICATIONS_PATTERN = '(?:\(?(?:%s)[0-9]+\)?)*' % '|'.join(
+  _MODIFICATIONS_PATTERN = r'(?:\(?(?:%s)[0-9]+\)?)*' % '|'.join(
       re.escape(mod) for mod in _DEGREE_MODIFICATIONS)
   _BASS_PATTERN = '|/%s' % _ROOT_PATTERN
 
@@ -322,15 +323,15 @@ class BasicChordSymbolFunctions(ChordSymbolFunctions):
   _CHORD_SYMBOL_REGEX = re.compile(_CHORD_SYMBOL_PATTERN)
 
   # Regular expression for a single pitch class.
-  _PITCH_CLASS_PATTERN = '([A-G])(#*|b*)$'
+  _PITCH_CLASS_PATTERN = r'([A-G])(#*|b*)$'
   _PITCH_CLASS_REGEX = re.compile(_PITCH_CLASS_PATTERN)
 
   # Regular expression for a single scale degree.
-  _SCALE_DEGREE_PATTERN = '(#*|b*)([0-9]+)$'
+  _SCALE_DEGREE_PATTERN = r'(#*|b*)([0-9]+)$'
   _SCALE_DEGREE_REGEX = re.compile(_SCALE_DEGREE_PATTERN)
 
   # Regular expression for a single scale degree modification.
-  _MODIFICATION_PATTERN = '\(?(%s)([0-9]+)\)?' % '|'.join(
+  _MODIFICATION_PATTERN = r'\(?(%s)([0-9]+)\)?' % '|'.join(
       re.escape(mod) for mod in _DEGREE_MODIFICATIONS)
   _MODIFICATION_REGEX = re.compile(_MODIFICATION_PATTERN)
 
@@ -364,6 +365,16 @@ class BasicChordSymbolFunctions(ChordSymbolFunctions):
     This returns a list of function-degree-alteration triples. The function,
     when applied to the list of scale degrees, the degree to modify, and the
     alteration, performs the modification.
+
+    Args:
+      modifications_str: A string containing the scale degree modifications to
+          apply to a chord, in standard chord symbol format.
+
+    Returns:
+      A Python list of scale degree modification tuples, each of which contains
+      a) a function that applies the modification, b) the integer scale degree
+      to which to apply the modifications, and c) the number of semitones in the
+      modification.
     """
     modifications = []
     while modifications_str:
@@ -385,7 +396,7 @@ class BasicChordSymbolFunctions(ChordSymbolFunctions):
   def _apply_modifications(self, degrees, modifications):
     """Apply scale degree modifications to a scale degree dictionary."""
     for mod_fn, degree, alter in modifications:
-      mod_fn(degrees, degree, alter)
+      mod_fn(self, degrees, degree, alter)
 
   def _split_chord_symbol(self, figure):
     """Split a chord symbol into root, kind, degree modifications, and bass."""
@@ -401,12 +412,19 @@ class BasicChordSymbolFunctions(ChordSymbolFunctions):
     This converts the chord symbol string to a tuple representation with the
     following components:
 
-    Root: A tuple containing scale step and alteration.
-    Degrees: A dictionary where the keys are integer scale degrees, and values
-        are integer alterations. For example, if 9 -> -1 is in the dictionary,
-        the chord contains a b9.
-    Bass: A tuple containins scale step and alteration. If bass is unspecified,
-        the chord root is used.
+      Root: A tuple containing scale step and alteration.
+      Degrees: A dictionary where the keys are integer scale degrees, and values
+          are integer alterations. For example, if 9 -> -1 is in the dictionary,
+          the chord contains a b9.
+      Bass: A tuple containins scale step and alteration. If bass is
+          unspecified, the chord root is used.
+
+    Args:
+      figure: A chord symbol figure string.
+
+    Returns:
+      A tuple containing the chord root pitch class, scale degrees, and
+      bass pitch class.
     """
     root_str, kind_str, modifications_str, bass_str = self._split_chord_symbol(
         figure)
@@ -469,7 +487,7 @@ class BasicChordSymbolFunctions(ChordSymbolFunctions):
 
     if bass:
       # Bass exists, transpose it.
-      bass_step, bass_alter = bass
+      bass_step, bass_alter = bass  # pylint: disable=unpacking-non-sequence
       transposed_bass_step, transposed_bass_alter = self._transpose_pitch_class(
           bass_step, bass_alter, transpose_amount)
       transposed_bass_str = '/' + self._pitch_class_to_string(
@@ -502,7 +520,7 @@ class BasicChordSymbolFunctions(ChordSymbolFunctions):
     root_str, _, _, bass_str = self._split_chord_symbol(figure)
     bass = self._parse_bass(bass_str)
     if bass:
-      bass_step, bass_alter = bass
+      bass_step, bass_alter = bass  # pylint: disable=unpacking-non-sequence
     else:
       # Bass is the same as root.
       bass_step, bass_alter = self._parse_root(root_str)

--- a/magenta/music/chord_symbols_lib.py
+++ b/magenta/music/chord_symbols_lib.py
@@ -14,8 +14,7 @@
 """Utility functions for working with chord symbols."""
 
 import abc
-import music21
-import tensorflow as tf
+import re
 
 # chord quality enum
 CHORD_QUALITY_MAJOR = 0
@@ -36,8 +35,9 @@ class ChordSymbolFunctions(object):
   interpretation of chord symbol strings:
 
   `transpose_chord_symbol` transposes a chord symbol a given number of steps.
-  `chord_symbol_midi_pitches` returns a list of MIDI pitches in a chord.
+  `chord_symbol_pitches` returns a list of pitch classes in a chord.
   `chord_symbol_root` returns the root pitch class of a chord.
+  `chord_symbol_bass` returns the bass pitch class of a chord.
   `chord_symbol_quality` returns the "quality" of a chord.
   """
   __metaclass__ = abc.ABCMeta
@@ -47,12 +47,12 @@ class ChordSymbolFunctions(object):
     """Returns the default implementation of ChordSymbolFunctions.
 
     Currently the default (and only) implementation of ChordSymbolFunctions is
-    Music21ChordSymbolFunctions.
+    BasicChordSymbolFunctions.
 
     Returns:
       A ChordSymbolFunctions object.
     """
-    return Music21ChordSymbolFunctions()
+    return BasicChordSymbolFunctions()
 
   @abc.abstractmethod
   def transpose_chord_symbol(self, figure, transpose_amount):
@@ -71,14 +71,17 @@ class ChordSymbolFunctions(object):
     pass
 
   @abc.abstractmethod
-  def chord_symbol_midi_pitches(self, figure):
-    """Return the pitches of a chord as MIDI note values.
+  def chord_symbol_pitches(self, figure):
+    """Return the pitch classes contained in a chord.
+
+    This will generally include the root pitch class, but not the bass if it is
+    not otherwise one of the pitches in the chord.
 
     Args:
       figure: The chord symbol figure string for which pitches are computed.
 
     Returns:
-      A python list of pitches as integer MIDI note values.
+      A python list of integer pitch class values.
 
     Raises:
       ChordSymbolException: If the given chord symbol cannot be interpreted.
@@ -90,10 +93,25 @@ class ChordSymbolFunctions(object):
     """Return the root pitch class of a chord.
 
     Args:
-      figure: The chord symbol figure string for which pitches are computed.
+      figure: The chord symbol figure string for which the root is computed.
 
     Returns:
       The pitch class of the chord root, an integer between 0 and 11 inclusive.
+
+    Raises:
+      ChordSymbolException: If the given chord symbol cannot be interpreted.
+    """
+    pass
+
+  @abc.abstractmethod
+  def chord_symbol_bass(self, figure):
+    """Return the bass pitch class of a chord.
+
+    Args:
+      figure: The chord symbol figure string for which the bass is computed.
+
+    Returns:
+      The pitch class of the chord bass, an integer between 0 and 11 inclusive.
 
     Raises:
       ChordSymbolException: If the given chord symbol cannot be interpreted.
@@ -109,7 +127,7 @@ class ChordSymbolFunctions(object):
 
     Returns:
       One of CHORD_QUALITY_MAJOR, CHORD_QUALITY_MINOR, CHORD_QUALITY_AUGMENTED,
-      CHORD_QUALITY_DIMINISHED, or CHORD_QUALITY_UNKNOWN.
+      CHORD_QUALITY_DIMINISHED, or CHORD_QUALITY_OTHER.
 
     Raises:
       ChordSymbolException: If the given chord symbol cannot be interpreted.
@@ -117,86 +135,349 @@ class ChordSymbolFunctions(object):
     pass
 
 
-class Music21ChordSymbolFunctions(ChordSymbolFunctions):
-  """A class that uses music21 to interpret chord symbol strings."""
+class BasicChordSymbolFunctions(ChordSymbolFunctions):
+  """Functions for parsing and interpreting chord symbol figure strings."""
 
-  # music21 returns this ugly string when it can't parse a chord.
-  _MUSIC21_UNIDENTIFIED_CHORD = 'Chord Symbol Cannot Be Identified'
+  # Intervals between scale steps.
+  _STEPS_ABOVE = {'A': 2, 'B': 1, 'C': 2, 'D': 2, 'E': 1, 'F': 2, 'G': 2}
 
-  # Mapping from strings returned by music21 to chord quality enum values.
-  _music21_chord_quality_mapping = {
-      'major': CHORD_QUALITY_MAJOR,
-      'minor': CHORD_QUALITY_MINOR,
-      'augmented': CHORD_QUALITY_AUGMENTED,
-      'diminished': CHORD_QUALITY_DIMINISHED
+  # Scale steps to MIDI mapping.
+  _STEPS_MIDI = {'C': 0, 'D': 2, 'E': 4, 'F': 5, 'G': 7, 'A': 9, 'B': 11}
+
+  # Mapping from scale degree to offset in half steps.
+  _DEGREE_OFFSETS = {1: 0, 2: 2, 3: 4, 4: 5, 5: 7, 6: 9, 7: 11}
+
+  # Dictionary mapping MusicXML chord kind to abbreviations and scale degrees.
+  _CHORD_KINDS = {
+      # triads
+      'major':                  (['', 'maj', 'M'],
+                                    ['1', '3', '5']),
+      'minor':                  (['m', 'min', '-'],
+                                    ['1', 'b3', '5']),
+      'augmented':              (['+', 'aug'],
+                                    ['1', '3', '#5']),
+      'diminished':             (['o', 'dim'],
+                                    ['1', 'b3', 'b5']),
+
+      # sevenths
+      'dominant':               (['7'],
+                                    ['1', '3', '5', 'b7']),
+      'major-seventh':          (['maj7', 'M7'],
+                                    ['1', '3', '5', '7']),
+      'minor-seventh':          (['m7', 'min7', '-7'],
+                                     ['1', 'b3', '5', 'b7']),
+      'diminished-seventh':     (['o7', 'dim7'],
+                                     ['1', 'b3', 'b5', 'bb7']),
+      'augmented-seventh':      (['+7', 'aug7'],
+                                     ['1', '3', '#5', 'b7']),
+      'half-diminished':        (['m7b5', '-7b5', '/o', '/o7'],
+                                     ['1', 'b3', 'b5', 'b7']),
+      'major-minor':            (['mmaj7', 'mM7', 'minmaj7', 'minM7', '-maj7', '-M7'],
+                                     ['1', 'b3', '5', '7']),
+
+      # sixths
+      'major-sixth':            (['6'],
+                                     ['1', '3', '5', '6']),
+      'minor-sixth':            (['m6', 'min6', '-6'],
+                                     ['1', 'b3', '5', '6']),
+
+      # ninths
+      'dominant-ninth':         (['9'],
+                                     ['1', '3', '5', 'b7', '9']),
+      'major-ninth':            (['maj9', 'M9'],
+                                     ['1', '3', '5', '7', '9']),
+      'minor-ninth':            (['m9', 'min9', '-9'],
+                                     ['1', 'b3', '5', 'b7', '9']),
+
+      # elevenths
+      'dominant-11th':          (['11'],
+                                     ['1', '3', '5', 'b7', '9', '11']),
+      'major-11th':             (['maj11', 'M11'],
+                                     ['1', '3', '5', '7', '9', '11']),
+      'minor-11th':             (['m11', 'min11', '-11'],
+                                     ['1', 'b3', '5', 'b7', '9', '11']),
+
+      # thirteenths
+      'dominant-13th':          (['13'],
+                                     ['1', '3', '5', 'b7', '9', '11', '13']),
+      'major-13th':             (['maj13', 'M13'],
+                                     ['1', '3', '5', '7', '9', '11', '13']),
+      'minor-13th':             (['m13', 'min13', '-13'],
+                                     ['1', 'b3', '5', 'b7', '9', '11', '13']),
+
+      # suspended
+      'suspended-second':       (['sus2'],
+                                     ['1', '2', '5']),
+      'suspended-fourth':       (['sus', 'sus4'],
+                                     ['1', '4', '5']),
+
+      # other
+      'pedal':                  (['ped'],
+                                     ['1']),
+      'power':                  (['5'],
+                                     ['1', '5'])
   }
 
-  def __init__(self):
-    """Construct a Music21ChordSymbolFunctions object."""
-    self._music21_chord_symbol_dict = {}
+  # Dictionary mapping chord kind abbreviations to names and scale degrees.
+  _CHORD_KINDS_BY_ABBREV = dict((abbrev, (kind, degrees))
+                                for kind, (abbrevs, degrees)
+                                in _CHORD_KINDS.items()
+                                for abbrev in abbrevs)
 
-  def _to_music21_chord_symbol(self, figure):
-    """Return a music21.harmony.ChordSymbol object instantiated with `figure`.
+  # Function to add a scale degree.
+  def _add_scale_degree(degrees, degree, alter):
+    if degree in degrees:
+      raise ChordSymbolException('Scale degree already in chord: %d' % degree)
+    if degree == 7:
+      alter -= 1
+    degrees[degree] = alter
 
-    Since this operation can be slow and chord symbols are often repeated many
-    times in a single score, we also memoize the mapping.
+  # Function to remove a scale degree.
+  def _subtract_scale_degree(degrees, degree, unused_alter):
+    if degree not in degrees:
+      raise ChordSymbolException('Scale degree not in chord: %d' % degree)
+    del degrees[degree]
 
-    Args:
-      figure: The chord symbol figure string.
+  # Function to alter (or add) a scale degree.
+  def _alter_scale_degree(degrees, degree, alter):
+    if degree in degrees:
+      degrees[degree] += alter
+    else:
+      degrees[degree] = alter
 
-    Returns:
-      A music21.harmony.ChordSymbol object.
+  # Scale degree modifications. There are three basic types of modifications:
+  # addition, subtraction, and alteration. These have been expanded into six
+  # types to aid in parsing, as each of the three basic operations has its own
+  # requirements on the scale degree operand:
+  #
+  # Addition can accept altered and unaltered scale degrees.
+  # Subtraction can only accept unaltered scale degrees.
+  # Alteration can only accept altered scale degrees.
+  _DEGREE_MODIFICATIONS = {
+      'add':  (_add_scale_degree, 0),
+      'add#': (_add_scale_degree, 1),
+      'addb': (_add_scale_degree, -1),
+      'no':   (_subtract_scale_degree, 0),
+      '#':    (_alter_scale_degree, 1),
+      'b':    (_alter_scale_degree, -1)
+  }
 
-    Raises:
-      ChordSymbolException: If the chord fails to be parsed by music21.
+  # Regular expression patterns for chord symbol parts.
+  _ROOT_PATTERN = '[A-G](?:#*|b*)(?![#b])'
+  _CHORD_KIND_PATTERN = '|'.join(re.escape(abbrev)
+                                 for abbrev in _CHORD_KINDS_BY_ABBREV)
+  _MODIFICATIONS_PATTERN = '(?:(?:%s)[0-9]+)*' % '|'.join(
+      re.escape(mod) for mod in _DEGREE_MODIFICATIONS)
+  _BASS_PATTERN = '|/%s' % _ROOT_PATTERN
+
+  # Regular expression for full chord symbol.
+  _CHORD_SYMBOL_PATTERN = ''.join('(%s)' % pattern for pattern in [
+      _ROOT_PATTERN,            # root pitch class
+      _CHORD_KIND_PATTERN,      # chord kind
+      _MODIFICATIONS_PATTERN,   # scale degree modifications
+      _BASS_PATTERN]) + '$'     # bass pitch class
+  _CHORD_SYMBOL_REGEX = re.compile(_CHORD_SYMBOL_PATTERN)
+
+  # Regular expression for a single pitch class.
+  _PITCH_CLASS_PATTERN = '([A-G])(#*|b*)$'
+  _PITCH_CLASS_REGEX = re.compile(_PITCH_CLASS_PATTERN)
+
+  # Regular expression for a single scale degree.
+  _SCALE_DEGREE_PATTERN = '(#*|b*)([0-9]+)$'
+  _SCALE_DEGREE_REGEX = re.compile(_SCALE_DEGREE_PATTERN)
+
+  # Regular expression for a single scale degree modification.
+  _MODIFICATION_PATTERN = '(%s)([0-9]+)' % '|'.join(
+      re.escape(mod) for mod in _DEGREE_MODIFICATIONS)
+  _MODIFICATION_REGEX = re.compile(_MODIFICATION_PATTERN)
+
+  def _parse_pitch_class(self, pitch_class_str):
+    """Parse pitch class from string, returning scale step and alteration."""
+    match = re.match(self._PITCH_CLASS_REGEX, pitch_class_str)
+    step, alter = match.groups()
+    return step, len(alter) * (1 if '#' in alter else -1)
+
+  def _parse_root(self, root_str):
+    """Parse chord root from string."""
+    return self._parse_pitch_class(root_str)
+
+  def _parse_degree(self, degree_str):
+    """Parse scale degree from string (from internal chord kind dictionary)."""
+    match = self._SCALE_DEGREE_REGEX.match(degree_str)
+    alter, degree = match.groups()
+    return int(degree), len(alter) * (1 if '#' in alter else -1)
+
+  def _parse_kind(self, kind_str):
+    """Parse chord kind from string, returning a scale degree dictionary."""
+    _, degrees = self._CHORD_KINDS_BY_ABBREV[kind_str]
+    # Here we make the assumption that each scale degree can be present in a
+    # chord at most once. This is not generally true, as e.g. a chord could
+    # contain both b9 and #9.
+    return dict(self._parse_degree(degree_str) for degree_str in degrees)
+
+  def _parse_modifications(self, modifications_str):
+    """Parse scale degree modifications from string.
+
+    This returns a list of function-degree-alteration triples. The function,
+    when applied to the list of scale degrees, the degree to modify, and the
+    alteration, performs the modification.
     """
+    modifications = []
+    while modifications_str:
+      match = self._MODIFICATION_REGEX.match(modifications_str)
+      type_str, degree_str = match.groups()
+      mod_fn, alter = self._DEGREE_MODIFICATIONS[type_str]
+      modifications.append((mod_fn, int(degree_str), alter))
+      modifications_str = modifications_str[match.end():]
+      assert match.end() > 0
+    return modifications
 
-    if figure in self._music21_chord_symbol_dict:
-      return self._music21_chord_symbol_dict[figure]
+  def _parse_bass(self, bass_str):
+    """Parse bass, returning scale step and alteration or None if no bass."""
+    if bass_str:
+      return self._parse_pitch_class(bass_str[1:])
+    else:
+      return None
 
-    try:
-      cs = music21.harmony.ChordSymbol(figure)
-      self._music21_chord_symbol_dict[figure] = cs
-      return cs
-    except:  # pylint: disable=bare-except
-      pass
+  def _apply_modifications(self, degrees, modifications):
+    """Apply scale degree modifications to a scale degree dictionary."""
+    for mod_fn, degree, alter in modifications:
+      mod_fn(degrees, degree, alter)
 
-    try:
-      # music21 seems to have a hard time parsing some chord symbol figure
-      # strings it itself produces! It sometimes produces strings like
-      # "C7 add b9" or "G7 alter #5", and then can't re-parse them. In these
-      # cases, let's try again with just the basic chord.
-      cs = music21.harmony.ChordSymbol(figure.split()[0])
-      self._music21_chord_symbol_dict[figure] = cs
-      tf.logging.warn('Failed to parse chord symbol %s, '
-                      'interpreting as %s', figure, figure.split()[0])
-      return cs
-    except:
-      raise ChordSymbolException('unable to parse chord symbol: %s'
-                                 % figure)
+  def _split_chord_symbol(self, figure):
+    """Split a chord symbol into root, kind, degree modifications, and bass."""
+    match = self._CHORD_SYMBOL_REGEX.match(figure)
+    if not match:
+      raise ChordSymbolException('Unable to parse chord symbol: %s' % figure)
+    root_str, kind_str, modifications_str, bass_str = match.groups()
+    return root_str, kind_str, modifications_str, bass_str
+
+  def _parse_chord_symbol(self, figure):
+    """Parse a chord symbol string.
+
+    This converts the chord symbol string to a tuple representation with the
+    following components:
+
+    Root: A tuple containing scale step and alteration.
+    Degrees: A dictionary where the keys are integer scale degrees, and values
+        are integer alterations. For example, if 9 -> -1 is in the dictionary,
+        the chord contains a b9.
+    Bass: A tuple containins scale step and alteration. If bass is unspecified,
+        the chord root is used.
+    """
+    root_str, kind_str, modifications_str, bass_str = self._split_chord_symbol(
+        figure)
+
+    root = self._parse_root(root_str)
+    degrees = self._parse_kind(kind_str)
+    modifications = self._parse_modifications(modifications_str)
+    bass = self._parse_bass(bass_str)
+
+    # Apply scale degree modifications.
+    self._apply_modifications(degrees, modifications)
+
+    return root, degrees, bass or root
+
+  def _transpose_pitch_class(self, step, alter, transpose_amount):
+    """Transposes a chord symbol figure string by the given amount."""
+    transpose_amount %= 12
+    if transpose_amount == 0:
+      return step, alter
+
+    # Transpose up as many steps as we can.
+    while transpose_amount >= self._STEPS_ABOVE[step]:
+      transpose_amount -= self._STEPS_ABOVE[step]
+      step = chr(ord('A') + (ord(step) - ord('A') + 1) % 7)
+
+    if transpose_amount > 0:
+      if alter >= 0:
+        # Transpose up one more step and remove sharps (or add flats).
+        alter -= self._STEPS_ABOVE[step] - transpose_amount
+        step = chr(ord('A') + (ord(step) - ord('A') + 1) % 7)
+      else:
+        # Remove flats.
+        alter += transpose_amount
+
+    return step, alter
+
+  def _pitch_class_to_string(self, step, alter):
+    """Convert a pitch class scale step and alteration to string."""
+    return step + abs(alter) * ('#' if alter >= 0 else 'b')
+
+  def _pitch_class_to_midi(self, step, alter):
+    """Convert a pitch class scale step and alteration to MIDI note."""
+    return (self._STEPS_MIDI[step] + alter) % 12
 
   def transpose_chord_symbol(self, figure, transpose_amount):
-    chord_symbol = self._to_music21_chord_symbol(figure)
-    transposed_figure = chord_symbol.transpose(transpose_amount).findFigure()
-    if transposed_figure == self._MUSIC21_UNIDENTIFIED_CHORD:
-      # music21 just returns error text instead of throwing.
-      raise ChordSymbolException('unable to parse chord symbol: %s'
-                                 % figure)
-    else:
-      return transposed_figure
+    """Transposes a chord symbol figure string by the given amount."""
+    # Split chord symbol into root, kind, modifications, and bass.
+    root_str, kind_str, modifications_str, bass_str = self._split_chord_symbol(
+        figure)
 
-  def chord_symbol_midi_pitches(self, figure):
-    chord_symbol = self._to_music21_chord_symbol(figure)
-    return [pitch.midi for pitch in chord_symbol.pitches]
+    # Parse and transpose the root.
+    root_step, root_alter = self._parse_root(root_str)
+    transposed_root_step, transposed_root_alter = self._transpose_pitch_class(
+        root_step, root_alter, transpose_amount)
+    transposed_root_str = self._pitch_class_to_string(
+        transposed_root_step, transposed_root_alter)
+
+    # Parse bass.
+    bass = self._parse_bass(bass_str)
+
+    if bass:
+      # Bass exists, transpose it.
+      bass_step, bass_alter = bass
+      transposed_bass_step, transposed_bass_alter = self._transpose_pitch_class(
+          bass_step, bass_alter, transpose_amount)
+      transposed_bass_str = '/' + self._pitch_class_to_string(
+          transposed_bass_step, transposed_bass_alter)
+    else:
+      # No bass.
+      transposed_bass_str = bass_str
+
+    return '%s%s%s%s' % (transposed_root_str, kind_str, modifications_str,
+                         transposed_bass_str)
+
+  def chord_symbol_pitches(self, figure):
+    """Return the pitch classes contained in a chord."""
+    root, degrees, _ = self._parse_chord_symbol(figure)
+    root_step, root_alter = root
+    root_pitch = self._pitch_class_to_midi(root_step, root_alter)
+    normalized_degrees = [((degree - 1) % 7 + 1, alter)
+                          for degree, alter in degrees.items()]
+    return [(root_pitch + self._DEGREE_OFFSETS[degree] + alter) % 12
+            for degree, alter in normalized_degrees]
 
   def chord_symbol_root(self, figure):
-    chord_symbol = self._to_music21_chord_symbol(figure)
-    return chord_symbol.root().pitchClass
+    """Return the root pitch class of a chord."""
+    root_str, _, _, _ = self._split_chord_symbol(figure)
+    root_step, root_alter = self._parse_root(root_str)
+    return self._pitch_class_to_midi(root_step, root_alter)
+
+  def chord_symbol_bass(self, figure):
+    """Return the bass pitch class of a chord."""
+    root_str, _, _, bass_str = self._split_chord_symbol(figure)
+    bass = self._parse_bass(bass_str)
+    if bass:
+      bass_step, bass_alter = bass
+    else:
+      # Bass is the same as root.
+      bass_step, bass_alter = self._parse_root(root_str)
+    return self._pitch_class_to_midi(bass_step, bass_alter)
 
   def chord_symbol_quality(self, figure):
-    chord_symbol = self._to_music21_chord_symbol(figure)
-    quality_string = chord_symbol.quality
-    if quality_string not in self._music21_chord_quality_mapping:
+    """Return the quality (major, minor, dimished, augmented) of a chord."""
+    _, degrees, _ = self._parse_chord_symbol(figure)
+    if 1 not in degrees or 3 not in degrees or 5 not in degrees:
       return CHORD_QUALITY_OTHER
+    triad = degrees[1], degrees[3], degrees[5]
+    if triad == (0, 0, 0):
+      return CHORD_QUALITY_MAJOR
+    elif triad == (0, -1, 0):
+      return CHORD_QUALITY_MINOR
+    elif triad == (0, 0, 1):
+      return CHORD_QUALITY_AUGMENTED
+    elif triad == (0, -1, -1):
+      return CHORD_QUALITY_DIMINISHED
     else:
-      return self._music21_chord_quality_mapping[quality_string]
+      return CHORD_QUALITY_OTHER

--- a/magenta/music/chord_symbols_lib_test.py
+++ b/magenta/music/chord_symbols_lib_test.py
@@ -34,7 +34,7 @@ class ChordSymbolFunctionsTest(tf.test.TestCase):
     # Test basic triads.
     figure = self.chord_symbol_functions.transpose_chord_symbol('C', 2)
     self.assertEqual('D', figure)
-    figure = self.chord_symbol_functions.transpose_chord_symbol('A-m', -3)
+    figure = self.chord_symbol_functions.transpose_chord_symbol('Abm', -3)
     self.assertEqual('Fm', figure)
     figure = self.chord_symbol_functions.transpose_chord_symbol('F#', 0)
     self.assertEqual('F#', figure)
@@ -44,31 +44,19 @@ class ChordSymbolFunctionsTest(tf.test.TestCase):
     self.assertEqual('Go7', figure)
     figure = self.chord_symbol_functions.transpose_chord_symbol('D+', -3)
     self.assertEqual('B+', figure)
-    figure = self.chord_symbol_functions.transpose_chord_symbol('F-9/A-', 2)
-    self.assertEqual('G-9/B-', figure)
+    figure = self.chord_symbol_functions.transpose_chord_symbol('Fb9/Ab', 2)
+    self.assertEqual('Gb9/Bb', figure)
 
-  def testMidiPitches(self):
-    # Check that pitch classes are correct.
-    pitches = self.chord_symbol_functions.chord_symbol_midi_pitches('Am')
+  def testPitches(self):
+    pitches = self.chord_symbol_functions.chord_symbol_pitches('Am')
     pitch_classes = set(pitch % 12 for pitch in pitches)
     self.assertEqual(set([0, 4, 9]), pitch_classes)
-    pitches = self.chord_symbol_functions.chord_symbol_midi_pitches('D7b9')
+    pitches = self.chord_symbol_functions.chord_symbol_pitches('D7b9')
     pitch_classes = set(pitch % 12 for pitch in pitches)
     self.assertEqual(set([0, 2, 3, 6, 9]), pitch_classes)
-    pitches = self.chord_symbol_functions.chord_symbol_midi_pitches('Fm7b5')
+    pitches = self.chord_symbol_functions.chord_symbol_pitches('F/o')
     pitch_classes = set(pitch % 12 for pitch in pitches)
     self.assertEqual(set([3, 5, 8, 11]), pitch_classes)
-
-    # Check that bass notes are correct.
-    pitches = self.chord_symbol_functions.chord_symbol_midi_pitches('B-7')
-    bass_pitch_class = min(pitches) % 12
-    self.assertEqual(10, bass_pitch_class)
-    pitches = self.chord_symbol_functions.chord_symbol_midi_pitches('A/G')
-    bass_pitch_class = min(pitches) % 12
-    self.assertEqual(7, bass_pitch_class)
-    pitches = self.chord_symbol_functions.chord_symbol_midi_pitches('F#dim7')
-    bass_pitch_class = min(pitches) % 12
-    self.assertEqual(6, bass_pitch_class)
 
   def testRoot(self):
     root = self.chord_symbol_functions.chord_symbol_root('Dm9')
@@ -77,8 +65,18 @@ class ChordSymbolFunctionsTest(tf.test.TestCase):
     self.assertEqual(4, root)
     root = self.chord_symbol_functions.chord_symbol_root('Bsus2')
     self.assertEqual(11, root)
-    root = self.chord_symbol_functions.chord_symbol_root('A-maj7')
+    root = self.chord_symbol_functions.chord_symbol_root('Abmaj7')
     self.assertEqual(8, root)
+
+  def testBass(self):
+    bass = self.chord_symbol_functions.chord_symbol_bass('Dm9')
+    self.assertEqual(2, bass)
+    bass = self.chord_symbol_functions.chord_symbol_bass('E/G#')
+    self.assertEqual(8, bass)
+    bass = self.chord_symbol_functions.chord_symbol_bass('Bsus2/A')
+    self.assertEqual(9, bass)
+    bass = self.chord_symbol_functions.chord_symbol_bass('Abm7/Cb')
+    self.assertEqual(11, bass)
 
   def testQuality(self):
     # Test major chords.
@@ -86,21 +84,21 @@ class ChordSymbolFunctionsTest(tf.test.TestCase):
     self.assertEqual(CHORD_QUALITY_MAJOR, quality)
     quality = self.chord_symbol_functions.chord_symbol_quality('E7#9')
     self.assertEqual(CHORD_QUALITY_MAJOR, quality)
-    quality = self.chord_symbol_functions.chord_symbol_quality('Fadd2/E-')
+    quality = self.chord_symbol_functions.chord_symbol_quality('Fadd2/Eb')
     self.assertEqual(CHORD_QUALITY_MAJOR, quality)
 
     # Test minor chords.
-    quality = self.chord_symbol_functions.chord_symbol_quality('C#m9')
+    quality = self.chord_symbol_functions.chord_symbol_quality('C#-9')
     self.assertEqual(CHORD_QUALITY_MINOR, quality)
-    quality = self.chord_symbol_functions.chord_symbol_quality('Gm7/B-')
+    quality = self.chord_symbol_functions.chord_symbol_quality('Gm7/Bb')
     self.assertEqual(CHORD_QUALITY_MINOR, quality)
-    quality = self.chord_symbol_functions.chord_symbol_quality('C-mM7')
+    quality = self.chord_symbol_functions.chord_symbol_quality('Cbmmaj7')
     self.assertEqual(CHORD_QUALITY_MINOR, quality)
 
     # Test augmented chords.
     quality = self.chord_symbol_functions.chord_symbol_quality('D+/A#')
     self.assertEqual(CHORD_QUALITY_AUGMENTED, quality)
-    quality = self.chord_symbol_functions.chord_symbol_quality('Aaug')
+    quality = self.chord_symbol_functions.chord_symbol_quality('A+')
     self.assertEqual(CHORD_QUALITY_AUGMENTED, quality)
 
     # Test diminished chords.
@@ -112,7 +110,7 @@ class ChordSymbolFunctionsTest(tf.test.TestCase):
     # Test other chords.
     quality = self.chord_symbol_functions.chord_symbol_quality('G5')
     self.assertEqual(CHORD_QUALITY_OTHER, quality)
-    quality = self.chord_symbol_functions.chord_symbol_quality('B-sus2')
+    quality = self.chord_symbol_functions.chord_symbol_quality('Bbsus2')
     self.assertEqual(CHORD_QUALITY_OTHER, quality)
     quality = self.chord_symbol_functions.chord_symbol_quality('Dsus')
     self.assertEqual(CHORD_QUALITY_OTHER, quality)

--- a/magenta/music/chord_symbols_lib_test.py
+++ b/magenta/music/chord_symbols_lib_test.py
@@ -73,7 +73,6 @@ class ChordSymbolFunctionsTest(tf.test.TestCase):
     pitch_classes = set(pitch % 12 for pitch in pitches)
     self.assertEqual(set([3, 7, 9, 11]), pitch_classes)
 
-
   def testRoot(self):
     root = self.chord_symbol_functions.chord_symbol_root('Dm9')
     self.assertEqual(2, root)

--- a/magenta/music/chord_symbols_lib_test.py
+++ b/magenta/music/chord_symbols_lib_test.py
@@ -40,6 +40,8 @@ class ChordSymbolFunctionsTest(tf.test.TestCase):
     self.assertEqual('F#', figure)
     figure = self.chord_symbol_functions.transpose_chord_symbol('Cbb', 6)
     self.assertEqual('Fb', figure)
+    figure = self.chord_symbol_functions.transpose_chord_symbol('C#', -5)
+    self.assertEqual('G#', figure)
 
     # Test more complex chords.
     figure = self.chord_symbol_functions.transpose_chord_symbol('Co7', 7)

--- a/magenta/music/chord_symbols_lib_test.py
+++ b/magenta/music/chord_symbols_lib_test.py
@@ -38,6 +38,8 @@ class ChordSymbolFunctionsTest(tf.test.TestCase):
     self.assertEqual('Fm', figure)
     figure = self.chord_symbol_functions.transpose_chord_symbol('F#', 0)
     self.assertEqual('F#', figure)
+    figure = self.chord_symbol_functions.transpose_chord_symbol('Cbb', 6)
+    self.assertEqual('Fb', figure)
 
     # Test more complex chords.
     figure = self.chord_symbol_functions.transpose_chord_symbol('Co7', 7)
@@ -46,6 +48,10 @@ class ChordSymbolFunctionsTest(tf.test.TestCase):
     self.assertEqual('B+', figure)
     figure = self.chord_symbol_functions.transpose_chord_symbol('Fb9/Ab', 2)
     self.assertEqual('Gb9/Bb', figure)
+    figure = self.chord_symbol_functions.transpose_chord_symbol('A6/9', -7)
+    self.assertEqual('D6/9', figure)
+    figure = self.chord_symbol_functions.transpose_chord_symbol('E7(add#9)', 0)
+    self.assertEqual('E7(add#9)', figure)
 
   def testPitches(self):
     pitches = self.chord_symbol_functions.chord_symbol_pitches('Am')
@@ -57,6 +63,16 @@ class ChordSymbolFunctionsTest(tf.test.TestCase):
     pitches = self.chord_symbol_functions.chord_symbol_pitches('F/o')
     pitch_classes = set(pitch % 12 for pitch in pitches)
     self.assertEqual(set([3, 5, 8, 11]), pitch_classes)
+    pitches = self.chord_symbol_functions.chord_symbol_pitches('C-(M7)')
+    pitch_classes = set(pitch % 12 for pitch in pitches)
+    self.assertEqual(set([0, 3, 7, 11]), pitch_classes)
+    pitches = self.chord_symbol_functions.chord_symbol_pitches('E##13')
+    pitch_classes = set(pitch % 12 for pitch in pitches)
+    self.assertEqual(set([1, 3, 4, 6, 8, 10, 11]), pitch_classes)
+    pitches = self.chord_symbol_functions.chord_symbol_pitches('G(add2)(#5)')
+    pitch_classes = set(pitch % 12 for pitch in pitches)
+    self.assertEqual(set([3, 7, 9, 11]), pitch_classes)
+
 
   def testRoot(self):
     root = self.chord_symbol_functions.chord_symbol_root('Dm9')
@@ -67,6 +83,10 @@ class ChordSymbolFunctionsTest(tf.test.TestCase):
     self.assertEqual(11, root)
     root = self.chord_symbol_functions.chord_symbol_root('Abmaj7')
     self.assertEqual(8, root)
+    root = self.chord_symbol_functions.chord_symbol_root('D##5(add6)')
+    self.assertEqual(4, root)
+    root = self.chord_symbol_functions.chord_symbol_root('F(b7)(#9)(b13)')
+    self.assertEqual(5, root)
 
   def testBass(self):
     bass = self.chord_symbol_functions.chord_symbol_bass('Dm9')
@@ -77,6 +97,10 @@ class ChordSymbolFunctionsTest(tf.test.TestCase):
     self.assertEqual(9, bass)
     bass = self.chord_symbol_functions.chord_symbol_bass('Abm7/Cb')
     self.assertEqual(11, bass)
+    bass = self.chord_symbol_functions.chord_symbol_bass('C#6/9/E#')
+    self.assertEqual(5, bass)
+    bass = self.chord_symbol_functions.chord_symbol_bass('G/o')
+    self.assertEqual(7, bass)
 
   def testQuality(self):
     # Test major chords.
@@ -86,6 +110,10 @@ class ChordSymbolFunctionsTest(tf.test.TestCase):
     self.assertEqual(CHORD_QUALITY_MAJOR, quality)
     quality = self.chord_symbol_functions.chord_symbol_quality('Fadd2/Eb')
     self.assertEqual(CHORD_QUALITY_MAJOR, quality)
+    quality = self.chord_symbol_functions.chord_symbol_quality('C6/9/Bb')
+    self.assertEqual(CHORD_QUALITY_MAJOR, quality)
+    quality = self.chord_symbol_functions.chord_symbol_quality('Gmaj13')
+    self.assertEqual(CHORD_QUALITY_MAJOR, quality)
 
     # Test minor chords.
     quality = self.chord_symbol_functions.chord_symbol_quality('C#-9')
@@ -94,17 +122,29 @@ class ChordSymbolFunctionsTest(tf.test.TestCase):
     self.assertEqual(CHORD_QUALITY_MINOR, quality)
     quality = self.chord_symbol_functions.chord_symbol_quality('Cbmmaj7')
     self.assertEqual(CHORD_QUALITY_MINOR, quality)
+    quality = self.chord_symbol_functions.chord_symbol_quality('A-(M7)')
+    self.assertEqual(CHORD_QUALITY_MINOR, quality)
+    quality = self.chord_symbol_functions.chord_symbol_quality('Bbmin')
+    self.assertEqual(CHORD_QUALITY_MINOR, quality)
 
     # Test augmented chords.
     quality = self.chord_symbol_functions.chord_symbol_quality('D+/A#')
     self.assertEqual(CHORD_QUALITY_AUGMENTED, quality)
     quality = self.chord_symbol_functions.chord_symbol_quality('A+')
     self.assertEqual(CHORD_QUALITY_AUGMENTED, quality)
+    quality = self.chord_symbol_functions.chord_symbol_quality('G7(#5)')
+    self.assertEqual(CHORD_QUALITY_AUGMENTED, quality)
+    quality = self.chord_symbol_functions.chord_symbol_quality('Faug(add2)')
+    self.assertEqual(CHORD_QUALITY_AUGMENTED, quality)
 
     # Test diminished chords.
     quality = self.chord_symbol_functions.chord_symbol_quality('Am7b5')
     self.assertEqual(CHORD_QUALITY_DIMINISHED, quality)
     quality = self.chord_symbol_functions.chord_symbol_quality('Edim7')
+    self.assertEqual(CHORD_QUALITY_DIMINISHED, quality)
+    quality = self.chord_symbol_functions.chord_symbol_quality('Bb/o')
+    self.assertEqual(CHORD_QUALITY_DIMINISHED, quality)
+    quality = self.chord_symbol_functions.chord_symbol_quality('Fo')
     self.assertEqual(CHORD_QUALITY_DIMINISHED, quality)
 
     # Test other chords.
@@ -113,6 +153,8 @@ class ChordSymbolFunctionsTest(tf.test.TestCase):
     quality = self.chord_symbol_functions.chord_symbol_quality('Bbsus2')
     self.assertEqual(CHORD_QUALITY_OTHER, quality)
     quality = self.chord_symbol_functions.chord_symbol_quality('Dsus')
+    self.assertEqual(CHORD_QUALITY_OTHER, quality)
+    quality = self.chord_symbol_functions.chord_symbol_quality('E(no3)')
     self.assertEqual(CHORD_QUALITY_OTHER, quality)
 
 

--- a/magenta/music/chords_encoder_decoder_test.py
+++ b/magenta/music/chords_encoder_decoder_test.py
@@ -45,7 +45,7 @@ class MajorMinorChordOneHotEncodingTest(tf.test.TestCase):
     self.assertEquals(6, index)
 
     # minor 9th
-    index = self.enc.encode_event('A-m9')
+    index = self.enc.encode_event('Abm9')
     self.assertEquals(21, index)
 
   def testEncodeThirdlessChord(self):
@@ -55,7 +55,7 @@ class MajorMinorChordOneHotEncodingTest(tf.test.TestCase):
 
     # power chord
     with self.assertRaises(chords_encoder_decoder.ChordEncodingException):
-      self.enc.encode_event('B-5')
+      self.enc.encode_event('Bb5')
 
   def testDecodeNoChord(self):
     figure = self.enc.decode_event(0)

--- a/magenta/music/chords_lib.py
+++ b/magenta/music/chords_lib.py
@@ -368,6 +368,9 @@ class BasicChordRenderer(ChordRenderer):
       velocity: The MIDI note velocity to use.
       instrument: The MIDI instrument to use.
       program: The MIDI program to use.
+      octave: The octave in which to render chord notes. If the bass note is not
+          otherwise part of the chord, it will not be rendered in this octave.
+      bass_octave: The octave in which to render chord bass notes.
       chord_symbol_functions: ChordSymbolFunctions object with which to perform
           the actual transposition of chord symbol strings.
     """

--- a/magenta/music/chords_lib_test.py
+++ b/magenta/music/chords_lib_test.py
@@ -136,8 +136,8 @@ class ChordsLibTest(tf.test.TestCase):
     quantized_sequence.total_quantized_steps = 2
     chord_progressions, _ = chords_lib.extract_chords(quantized_sequence,
                                                       all_transpositions=True)
-    expected = zip([NO_CHORD] * 12, ['G-', 'G', 'A-', 'A', 'B-', 'B',
-                                     'C', 'D-', 'D', 'E-', 'E', 'F'])
+    expected = zip([NO_CHORD] * 12, ['Gb', 'G', 'Ab', 'A', 'Bb', 'B',
+                                     'C', 'Db', 'D', 'Eb', 'E', 'F'])
     self.assertEqual(expected, [tuple(chords) for chords in chord_progressions])
 
   def testExtractChordsForMelodies(self):

--- a/magenta/music/chords_lib_test.py
+++ b/magenta/music/chords_lib_test.py
@@ -46,10 +46,10 @@ class ChordsLibTest(tf.test.TestCase):
 
   def testTranspose(self):
     # Transpose ChordProgression with basic triads.
-    events = ['Cm', 'F', 'B-', 'E-']
+    events = ['Cm', 'F', 'Bb', 'Eb']
     chords = chords_lib.ChordProgression(events)
     chords.transpose(transpose_amount=7)
-    expected = ['Gm', 'C', 'F', 'B-']
+    expected = ['Gm', 'C', 'F', 'Bb']
     self.assertEqual(expected, list(chords))
 
     # Transpose ChordProgression with more complex chords.
@@ -60,7 +60,7 @@ class ChordsLibTest(tf.test.TestCase):
     self.assertEqual(expected, list(chords))
 
     # Transpose ChordProgression containing NO_CHORD.
-    events = ['C', 'B-', NO_CHORD, 'F', 'C']
+    events = ['C', 'Bb', NO_CHORD, 'F', 'C']
     chords = chords_lib.ChordProgression(events)
     chords.transpose(transpose_amount=4)
     expected = ['E', 'D', NO_CHORD, 'A', 'E']

--- a/magenta/protobuf/music.proto
+++ b/magenta/protobuf/music.proto
@@ -286,7 +286,15 @@ message NoteSequence {
     enum TextAnnotationType {
       // Unknown annotation type.
       UNKNOWN = 0;
-      // Chord symbol as used in lead sheets.
+      // Chord symbol as used in lead sheets. We treat text as the "ground
+      // truth" format for chord symbols, as the semantic interpretation of
+      // a chord symbol is often fuzzy. We defer this interpretation to
+      // individual models, each of which can translate chord symbol strings
+      // into model input in whatever way is deemed most appropriate for that
+      // model.
+      //
+      // Some examples of chord symbol text we consider reasonable: 'C#', 'A7',
+      // 'Fm7b5', 'N.C.', 'G(no3)', 'C/Bb', 'D-9(b5)', 'Gadd2', 'Abm(maj7)'.
       CHORD_SYMBOL = 1;
     }
   }


### PR DESCRIPTION
This removes the music21 dependency for chord symbol functions, e.g. finding the root pitch class of a chord symbol string, transposing a chord symbol string, etc.

These custom functions are designed to handle human-readable chord symbol figure strings as might be found in the wild.  Of course I have no expectation that it will handle everything.

There are a few fundamental differences from music21:

1) I do not use "-" to indicate flat.  In music21-ese, "B-" is a B-flat major chord.
2) Because of (1), "-" can be used to indicate a minor chord.  So "B-" is B minor.

I don't think we should merge this until the MusicXML parser from jsawruk has been merged, as I'll also want to add functionality to his MusicXML parser to process chords and convert them to NoteSequence annotations.  I'm happy to address any comments now, though.
