### PR TITLE
Split model and sequence generation code

### DIFF
--- a/magenta/models/melody_rnn/BUILD
+++ b/magenta/models/melody_rnn/BUILD
@@ -65,7 +65,9 @@ py_library(
     srcs = ["melody_rnn_model.py"],
     srcs_version = "PY2AND3",
     deps = [
+        ":melody_rnn_graph",
         "//magenta",
+        # tensorflow dep
     ],
 )
 
@@ -76,7 +78,7 @@ py_library(
     visibility = ["//magenta/interfaces:generator_interfaces"],
     deps = [
         ":melody_rnn_config",
-        ":melody_rnn_graph",
+        ":melody_rnn_model",
         "//magenta",
         # numpy dep
         # tensorflow dep
@@ -108,7 +110,6 @@ py_test(
     ],
 )
 
-
 py_binary(
     name = "melody_rnn_train",
     srcs = ["melody_rnn_train.py"],
@@ -128,10 +129,11 @@ py_binary(
     srcs = ["melody_rnn_generate.py"],
     srcs_version = "PY2AND3",
     visibility = [
-        "//magenta/tools/pip:__subpackages__"
+        "//magenta/tools/pip:__subpackages__",
     ],
     deps = [
         ":melody_rnn_config",
+        ":melody_rnn_model",
         ":melody_rnn_sequence_generator",
         "//magenta",
         # tensorflow dep

--- a/magenta/models/melody_rnn/BUILD
+++ b/magenta/models/melody_rnn/BUILD
@@ -80,8 +80,6 @@ py_library(
         ":melody_rnn_config",
         ":melody_rnn_model",
         "//magenta",
-        # numpy dep
-        # tensorflow dep
     ],
 )
 

--- a/magenta/models/melody_rnn/melody_rnn_generate.py
+++ b/magenta/models/melody_rnn/melody_rnn_generate.py
@@ -176,7 +176,8 @@ def run_with_flags(generator):
     if primer_sequence.tempos and primer_sequence.tempos[0].qpm:
       qpm = primer_sequence.tempos[0].qpm
   else:
-    # No priming sequence specified. Default to a single note of middle C.
+    tf.logging.warning(
+        'No priming sequence specified. Defaulting to a single middle C.')
     primer_melody = magenta.music.Melody([60])
     primer_sequence = primer_melody.to_sequence(qpm=qpm)
 

--- a/magenta/models/melody_rnn/melody_rnn_generate.py
+++ b/magenta/models/melody_rnn/melody_rnn_generate.py
@@ -27,6 +27,7 @@ import tensorflow as tf
 import magenta
 
 from magenta.models.melody_rnn import melody_rnn_config
+from magenta.models.melody_rnn import melody_rnn_model
 from magenta.models.melody_rnn import melody_rnn_sequence_generator
 from magenta.protobuf import generator_pb2
 from magenta.protobuf import music_pb2
@@ -174,6 +175,10 @@ def run_with_flags(generator):
         FLAGS.primer_midi)
     if primer_sequence.tempos and primer_sequence.tempos[0].qpm:
       qpm = primer_sequence.tempos[0].qpm
+  else:
+    # No priming sequence specified. Default to a single note of middle C.
+    primer_melody = magenta.music.Melody([60])
+    primer_sequence = primer_melody.to_sequence(qpm=qpm)
 
   # Derive the total number of seconds to generate based on the QPM of the
   # priming sequence and the num_steps flag.
@@ -231,7 +236,8 @@ def run_with_flags(generator):
 def main(unused_argv):
   """Saves bundle or runs generator based on flags."""
   generator = melody_rnn_sequence_generator.MelodyRnnSequenceGenerator(
-      config=melody_rnn_config.config_from_flags(),
+      melody_rnn_model=melody_rnn_model.MelodyRnnModel(
+          melody_rnn_config.config_from_flags()),
       steps_per_quarter=FLAGS.steps_per_quarter,
       checkpoint=get_checkpoint(),
       bundle=get_bundle())

--- a/magenta/models/melody_rnn/melody_rnn_generate.py
+++ b/magenta/models/melody_rnn/melody_rnn_generate.py
@@ -236,7 +236,7 @@ def run_with_flags(generator):
 def main(unused_argv):
   """Saves bundle or runs generator based on flags."""
   generator = melody_rnn_sequence_generator.MelodyRnnSequenceGenerator(
-      melody_rnn_model=melody_rnn_model.MelodyRnnModel(
+      model=melody_rnn_model.MelodyRnnModel(
           melody_rnn_config.config_from_flags()),
       steps_per_quarter=FLAGS.steps_per_quarter,
       checkpoint=get_checkpoint(),

--- a/magenta/models/melody_rnn/melody_rnn_generate.py
+++ b/magenta/models/melody_rnn/melody_rnn_generate.py
@@ -235,9 +235,10 @@ def run_with_flags(generator):
 
 def main(unused_argv):
   """Saves bundle or runs generator based on flags."""
+  config = melody_rnn_config.config_from_flags()
   generator = melody_rnn_sequence_generator.MelodyRnnSequenceGenerator(
-      model=melody_rnn_model.MelodyRnnModel(
-          melody_rnn_config.config_from_flags()),
+      model=melody_rnn_model.MelodyRnnModel(config),
+      details=config.details,
       steps_per_quarter=FLAGS.steps_per_quarter,
       checkpoint=get_checkpoint(),
       bundle=get_bundle())

--- a/magenta/models/melody_rnn/melody_rnn_model.py
+++ b/magenta/models/melody_rnn/melody_rnn_model.py
@@ -20,11 +20,10 @@ import heapq
 
 import numpy as np
 from six.moves import range  # pylint: disable=redefined-builtin
-
 import tensorflow as tf
-import magenta.music as mm
 
 from magenta.models.melody_rnn import melody_rnn_graph
+import magenta.music as mm
 
 
 class MelodyRnnModelException(Exception):
@@ -111,23 +110,29 @@ class MelodyRnnModel(mm.BaseModel):
   def _beam_search(self, melody, num_steps, temperature, beam_size,
                    branch_factor, steps_per_iteration):
     """Generates a melody using beam search.
+
     Initially, the beam is filled with `beam_size` copies of the initial
     melody.
+
     Each iteration, the beam is pruned to contain only the `beam_size` melodies
     with highest likelihood. Then `branch_factor` new melodies are generated
     for each melody in the beam. These new melodies are formed by extending
     each melody in the beam by `steps_per_iteration` steps. So between a
     branching and a pruning phase, there will be `beam_size` * `branch_factor`
     active melodies.
+
     Prior to the first "real" iteration, an initial branch generation will take
     place. This is for two reasons:
+
     1) The RNN model needs to be "primed" with the initial melody.
     2) The desired total number of steps `num_steps` might not be a multiple of
        `steps_per_iteration`, so the initial branching generates melody steps
        such that all subsequent iterations can generate `steps_per_iteration`
        steps.
+
     After the final iteration, the single melody in the beam with highest
     likelihood will be returned.
+
     Args:
       melody: The initial melody.
       num_steps: The integer length in steps of the final melody, after
@@ -139,6 +144,7 @@ class MelodyRnnModel(mm.BaseModel):
       branch_factor: The integer branch factor to use.
       steps_per_iteration: The integer number of melody steps to take per
           iteration.
+
     Returns:
       The highest-likelihood melody as computed by the beam search.
     """
@@ -180,6 +186,7 @@ class MelodyRnnModel(mm.BaseModel):
   def generate_melody(self, num_steps, primer_melody, temperature=1.0,
                       beam_size=1, branch_factor=1, steps_per_iteration=1):
     """Generate a melody from a primer melody.
+
     Args:
       num_steps: The integer length in steps of the final melody, after
           generation. Includes the primer.
@@ -192,22 +199,24 @@ class MelodyRnnModel(mm.BaseModel):
       branch_factor: An integer, beam search branch factor to use.
       steps_per_iteration: An integer, number of melody steps to take per beam
           search iteration.
+
     Returns:
       The generated Melody object (which begins with the provided primer
           melody).
+
     Raises:
-      MelodyRnnSequenceGeneratorException: If the primer melody has zero
+      MelodyRnnModelException: If the primer melody has zero
           length or is not shorter than num_steps.
     """
     if not primer_melody:
-      raise MelodyRnnSequenceGeneratorException(
+      raise MelodyRnnModelException(
           'primer melody must have non-zero length')
     if len(primer_melody) >= num_steps:
-      raise MelodyRnnSequenceGeneratorException(
+      raise MelodyRnnModelException(
           'primer melody must be shorter than `num_steps`')
 
     if beam_size != self._config.hparams.batch_size:
-      raise MelodyRnnSequenceGeneratorException(
+      raise MelodyRnnModelException(
           'currently beam search only supports using batch size as beam size')
 
     melody = copy.deepcopy(primer_melody)

--- a/magenta/models/melody_rnn/melody_rnn_model.py
+++ b/magenta/models/melody_rnn/melody_rnn_model.py
@@ -13,13 +13,25 @@
 # limitations under the License.
 """Melody RNN model."""
 
+import copy
+import heapq
+
 # internal imports
-import magenta
 
-from magenta.models.melody_rnn import melody_rnn_sequence_generator
+import numpy as np
+from six.moves import range  # pylint: disable=redefined-builtin
+
+import tensorflow as tf
+import magenta.music as mm
+
+from magenta.models.melody_rnn import melody_rnn_graph
 
 
-class MelodyRnnModel(object):
+class MelodyRnnModelException(Exception):
+  pass
+
+
+class MelodyRnnModel(mm.BaseModel):
   """Class for RNN melody generation models.
 
   Currently this class only supports generation, of both melodies and note
@@ -27,51 +39,188 @@ class MelodyRnnModel(object):
   at a later time.
   """
 
-  def __init__(self, config, checkpoint=None, bundle_filename=None,
-               steps_per_quarter=4):
+  def __init__(self, config):
     """Initialize the MelodyRnnModel.
 
     Args:
       config: A MelodyRnnConfig containing the MelodyEncoderDecoder and HParams
         use.
-      checkpoint: Where to search for the most recent model checkpoint.
-      bundle_filename: The filename of a generator_pb2.GeneratorBundle object
-          that includes both the model checkpoint and metagraph.
-      steps_per_quarter: What precision to use when quantizing the melody. How
-          many steps per quarter note.
     """
-    if bundle_filename is not None:
-      bundle = magenta.music.read_bundle_file(bundle_filename)
-    else:
-      bundle = None
-    self._generator = melody_rnn_sequence_generator.MelodyRnnSequenceGenerator(
-        config, steps_per_quarter, checkpoint, bundle)
+    super(MelodyRnnModel, self).__init__(config.details)
+    self._config = config
 
-  def generate_melody(self, num_steps, primer_melody):
-    """Uses the model to generate a melody from a primer melody.
+    # Override hparams for generation.
+    # TODO(fjord): once this class supports training, make this step conditional
+    # on the usage mode.
+    self._config.hparams.dropout_keep_prob = 1.0
+    self._config.hparams.batch_size = 1
 
+  def _build_graph_for_generation(self):
+    return melody_rnn_graph.build_graph('generate', self._config)
+
+  def _generate_step(self, melodies, inputs, initial_state, temperature):
+    """Extends a list of melodies by a single step each."""
+    graph_inputs = self._session.graph.get_collection('inputs')[0]
+    graph_initial_state = self._session.graph.get_collection('initial_state')[0]
+    graph_final_state = self._session.graph.get_collection('final_state')[0]
+    graph_softmax = self._session.graph.get_collection('softmax')[0]
+    graph_temperature = self._session.graph.get_collection('temperature')
+
+    feed_dict = {graph_inputs: inputs, graph_initial_state: initial_state}
+    # For backwards compatibility, we only try to pass temperature if the
+    # placeholder exists in the graph.
+    if graph_temperature:
+      feed_dict[graph_temperature[0]] = temperature
+    final_state, softmax = self._session.run(
+        [graph_final_state, graph_softmax], feed_dict)
+    indices = self._config.encoder_decoder.extend_event_sequences(melodies,
+                                                                  softmax)
+
+    return melodies, final_state, softmax[range(len(melodies)), -1, indices]
+
+  def _generate_branches(self, melodies, loglik, branch_factor, num_steps,
+                         inputs, initial_state, temperature):
+    """Performs a single iteration of branch generation for beam search."""
+    all_melodies = []
+    all_final_state = np.empty((0, initial_state.shape[1]))
+    all_loglik = np.empty(0)
+
+    for _ in range(branch_factor):
+      melodies_copy = copy.deepcopy(melodies)
+      loglik_copy = copy.deepcopy(loglik)
+      for _ in range(num_steps):
+        melodies_copy, final_state, softmax = self._generate_step(
+            melodies_copy, inputs, initial_state, temperature)
+        loglik_copy += np.log(softmax)
+      all_melodies += melodies_copy
+      all_final_state = np.append(all_final_state, final_state, axis=0)
+      all_loglik = np.append(all_loglik, loglik_copy, axis=0)
+
+    return all_melodies, all_final_state, all_loglik
+
+  def _prune_branches(self, melodies, final_state, loglik, k):
+    """Prune all but `k` melodies."""
+    indices = heapq.nlargest(k, range(len(melodies)), key=lambda i: loglik[i])
+
+    melodies = [melodies[i] for i in indices]
+    final_state = final_state[indices, :]
+    loglik = loglik[indices]
+
+    return melodies, final_state, loglik
+
+  def _beam_search(self, melody, num_steps, temperature, beam_size,
+                   branch_factor, steps_per_iteration):
+    """Generates a melody using beam search.
+    Initially, the beam is filled with `beam_size` copies of the initial
+    melody.
+    Each iteration, the beam is pruned to contain only the `beam_size` melodies
+    with highest likelihood. Then `branch_factor` new melodies are generated
+    for each melody in the beam. These new melodies are formed by extending
+    each melody in the beam by `steps_per_iteration` steps. So between a
+    branching and a pruning phase, there will be `beam_size` * `branch_factor`
+    active melodies.
+    Prior to the first "real" iteration, an initial branch generation will take
+    place. This is for two reasons:
+    1) The RNN model needs to be "primed" with the initial melody.
+    2) The desired total number of steps `num_steps` might not be a multiple of
+       `steps_per_iteration`, so the initial branching generates melody steps
+       such that all subsequent iterations can generate `steps_per_iteration`
+       steps.
+    After the final iteration, the single melody in the beam with highest
+    likelihood will be returned.
+    Args:
+      melody: The initial melody.
+      num_steps: The integer length in steps of the final melody, after
+          generation.
+      temperature: A float specifying how much to divide the logits by
+         before computing the softmax. Greater than 1.0 makes melodies more
+         random, less than 1.0 makes melodies less random.
+      beam_size: The integer beam size to use.
+      branch_factor: The integer branch factor to use.
+      steps_per_iteration: The integer number of melody steps to take per
+          iteration.
+    Returns:
+      The highest-likelihood melody as computed by the beam search.
+    """
+    melodies = [copy.deepcopy(melody) for _ in range(beam_size)]
+    graph_initial_state = self._session.graph.get_collection('initial_state')[0]
+    loglik = np.zeros(beam_size)
+
+    # Choose the number of steps for the first iteration such that subsequent
+    # iterations can all take the same number of steps.
+    first_iteration_num_steps = (num_steps - 1) % steps_per_iteration + 1
+
+    inputs = self._config.encoder_decoder.get_inputs_batch(
+        melodies, full_length=True)
+    initial_state = self._session.run(graph_initial_state)
+    melodies, final_state, loglik = self._generate_branches(
+        melodies, loglik, branch_factor, first_iteration_num_steps, inputs,
+        initial_state, temperature)
+
+    num_iterations = (num_steps -
+                      first_iteration_num_steps) / steps_per_iteration
+
+    for _ in range(num_iterations):
+      melodies, final_state, loglik = self._prune_branches(
+          melodies, final_state, loglik, k=beam_size)
+      inputs = self._config.encoder_decoder.get_inputs_batch(melodies)
+      melodies, final_state, loglik = self._generate_branches(
+          melodies, loglik, branch_factor, steps_per_iteration, inputs,
+          final_state, temperature)
+
+    # Prune to a single melody.
+    melodies, final_state, loglik = self._prune_branches(
+        melodies, final_state, loglik, k=1)
+
+    tf.logging.info('Beam search yields melody with log-likelihood: %f ',
+                    loglik[0])
+
+    return melodies[0]
+
+  def generate_melody(self, num_steps, primer_melody, temperature=1.0,
+                      beam_size=1, branch_factor=1, steps_per_iteration=1):
+    """Generate a melody from a primer melody.
     Args:
       num_steps: The integer length in steps of the final melody, after
           generation. Includes the primer.
       primer_melody: The primer melody, a Melody object.
-
+      temperature: A float specifying how much to divide the logits by
+         before computing the softmax. Greater than 1.0 makes melodies more
+         random, less than 1.0 makes melodies less random.
+      beam_size: An integer, beam size to use when generating melodies via beam
+          search.
+      branch_factor: An integer, beam search branch factor to use.
+      steps_per_iteration: An integer, number of melody steps to take per beam
+          search iteration.
     Returns:
       The generated Melody object (which begins with the provided primer
           melody).
+    Raises:
+      MelodyRnnSequenceGeneratorException: If the primer melody has zero
+          length or is not shorter than num_steps.
     """
-    with self._generator:
-      return self._generator.generate_melody(num_steps, primer_melody)
+    if not primer_melody:
+      raise MelodyRnnSequenceGeneratorException(
+          'primer melody must have non-zero length')
+    if len(primer_melody) >= num_steps:
+      raise MelodyRnnSequenceGeneratorException(
+          'primer melody must be shorter than `num_steps`')
 
-  def generate_sequence(self, input_sequence, generator_options):
-    """Generates a sequence from the model based on sequence and options.
+    if beam_size != self._config.hparams.batch_size:
+      raise MelodyRnnSequenceGeneratorException(
+          'currently beam search only supports using batch size as beam size')
 
-    Args:
-      input_sequence: An input NoteSequence to base the generation on.
-      generator_options: A GeneratorOptions proto with options to use for
-          generation.
+    melody = copy.deepcopy(primer_melody)
 
-    Returns:
-      The generated NoteSequence proto.
-    """
-    with self._generator:
-      return self._generator.generate(input_sequence, generator_options)
+    transpose_amount = melody.squash(
+        self._config.encoder_decoder.min_note,
+        self._config.encoder_decoder.max_note,
+        self._config.encoder_decoder.transpose_to_key)
+
+    if num_steps > len(melody):
+      melody = self._beam_search(melody, num_steps - len(melody), temperature,
+                                 beam_size, branch_factor, steps_per_iteration)
+
+    melody.transpose(-transpose_amount)
+
+    return melody

--- a/magenta/models/melody_rnn/melody_rnn_model.py
+++ b/magenta/models/melody_rnn/melody_rnn_model.py
@@ -45,7 +45,7 @@ class MelodyRnnModel(mm.BaseModel):
       config: A MelodyRnnConfig containing the MelodyEncoderDecoder and HParams
         use.
     """
-    super(MelodyRnnModel, self).__init__(config.details)
+    super(MelodyRnnModel, self).__init__()
     self._config = config
 
     # Override hparams for generation.

--- a/magenta/models/melody_rnn/melody_rnn_sequence_generator.py
+++ b/magenta/models/melody_rnn/melody_rnn_sequence_generator.py
@@ -17,22 +17,20 @@ from functools import partial
 
 # internal imports
 
-import tensorflow as tf
-import magenta.music as mm
-
 from magenta.models.melody_rnn import melody_rnn_config
 from magenta.models.melody_rnn import melody_rnn_model
+import magenta.music as mm
 
 
 class MelodyRnnSequenceGenerator(mm.BaseSequenceGenerator):
   """Shared Melody RNN generation code as a SequenceGenerator interface."""
 
-  def __init__(self, melody_rnn_model, steps_per_quarter=4, checkpoint=None,
+  def __init__(self, model, steps_per_quarter=4, checkpoint=None,
                bundle=None):
     """Creates a MelodyRnnSequenceGenerator.
 
     Args:
-      melody_rnn_model: Instance of MelodyRnnModel.
+      model: Instance of MelodyRnnModel.
       steps_per_quarter: What precision to use when quantizing the melody. How
           many steps per quarter note.
       checkpoint: Where to search for the most recent model checkpoint. Mutually
@@ -40,9 +38,8 @@ class MelodyRnnSequenceGenerator(mm.BaseSequenceGenerator):
       bundle: A GeneratorBundle object that includes both the model checkpoint
           and metagraph. Mutually exclusive with `checkpoint`.
     """
-    super(MelodyRnnSequenceGenerator, self).__init__(
-        melody_rnn_model, checkpoint, bundle)
-    self._melody_rnn_model = melody_rnn_model
+    super(MelodyRnnSequenceGenerator, self).__init__(model, checkpoint, bundle)
+    self._melody_rnn_model = model
     self._steps_per_quarter = steps_per_quarter
 
   def _initialize_with_checkpoint(self, checkpoint_file):
@@ -145,6 +142,7 @@ class MelodyRnnSequenceGenerator(mm.BaseSequenceGenerator):
     generated_sequence = generated_melody.to_sequence(qpm=qpm)
     assert (generated_sequence.total_time - generate_section.end_time) <= 1e-5
     return generated_sequence
+
 
 def get_generator_map():
   """Returns a map from the generator ID to its SequenceGenerator class.

--- a/magenta/models/melody_rnn/melody_rnn_sequence_generator.py
+++ b/magenta/models/melody_rnn/melody_rnn_sequence_generator.py
@@ -25,12 +25,13 @@ import magenta.music as mm
 class MelodyRnnSequenceGenerator(mm.BaseSequenceGenerator):
   """Shared Melody RNN generation code as a SequenceGenerator interface."""
 
-  def __init__(self, model, steps_per_quarter=4, checkpoint=None,
+  def __init__(self, model, details, steps_per_quarter=4, checkpoint=None,
                bundle=None):
     """Creates a MelodyRnnSequenceGenerator.
 
     Args:
       model: Instance of MelodyRnnModel.
+      details: A generator_pb2.GeneratorDetails for this generator.
       steps_per_quarter: What precision to use when quantizing the melody. How
           many steps per quarter note.
       checkpoint: Where to search for the most recent model checkpoint. Mutually
@@ -38,7 +39,8 @@ class MelodyRnnSequenceGenerator(mm.BaseSequenceGenerator):
       bundle: A GeneratorBundle object that includes both the model checkpoint
           and metagraph. Mutually exclusive with `checkpoint`.
     """
-    super(MelodyRnnSequenceGenerator, self).__init__(model, checkpoint, bundle)
+    super(MelodyRnnSequenceGenerator, self).__init__(
+        model, details, checkpoint, bundle)
     self._steps_per_quarter = steps_per_quarter
 
   def _seconds_to_steps(self, seconds, qpm):
@@ -140,5 +142,5 @@ def get_generator_map():
     `config` argument.
   """
   return {key: partial(MelodyRnnSequenceGenerator,
-                       melody_rnn_model.MelodyRnnModel(config))
+                       melody_rnn_model.MelodyRnnModel(config), config.details)
           for (key, config) in melody_rnn_config.default_configs.items()}

--- a/magenta/models/melody_rnn/melody_rnn_sequence_generator.py
+++ b/magenta/models/melody_rnn/melody_rnn_sequence_generator.py
@@ -39,7 +39,6 @@ class MelodyRnnSequenceGenerator(mm.BaseSequenceGenerator):
           and metagraph. Mutually exclusive with `checkpoint`.
     """
     super(MelodyRnnSequenceGenerator, self).__init__(model, checkpoint, bundle)
-    self._melody_rnn_model = model
     self._steps_per_quarter = steps_per_quarter
 
   def _seconds_to_steps(self, seconds, qpm):
@@ -123,7 +122,7 @@ class MelodyRnnSequenceGenerator(mm.BaseSequenceGenerator):
                 for name, value_fn in arg_types.items()
                 if name in generator_options.args)
 
-    generated_melody = self._melody_rnn_model.generate_melody(
+    generated_melody = self._model.generate_melody(
         end_step - melody.start_step, melody, **args)
     generated_sequence = generated_melody.to_sequence(qpm=qpm)
     assert (generated_sequence.total_time - generate_section.end_time) <= 1e-5

--- a/magenta/models/melody_rnn/melody_rnn_sequence_generator.py
+++ b/magenta/models/melody_rnn/melody_rnn_sequence_generator.py
@@ -13,37 +13,26 @@
 # limitations under the License.
 """Melody RNN generation code as a SequenceGenerator interface."""
 
-import copy
 from functools import partial
-import heapq
-import random
-
 
 # internal imports
-import numpy as np
-
-from six.moves import range  # pylint: disable=redefined-builtin
 
 import tensorflow as tf
-import magenta
+import magenta.music as mm
 
 from magenta.models.melody_rnn import melody_rnn_config
-from magenta.models.melody_rnn import melody_rnn_graph
+from magenta.models.melody_rnn import melody_rnn_model
 
 
-class MelodyRnnSequenceGeneratorException(Exception):
-  pass
-
-
-class MelodyRnnSequenceGenerator(magenta.music.BaseSequenceGenerator):
+class MelodyRnnSequenceGenerator(mm.BaseSequenceGenerator):
   """Shared Melody RNN generation code as a SequenceGenerator interface."""
 
-  def __init__(self, config, steps_per_quarter=4, checkpoint=None, bundle=None):
+  def __init__(self, melody_rnn_model, steps_per_quarter=4, checkpoint=None,
+               bundle=None):
     """Creates a MelodyRnnSequenceGenerator.
 
     Args:
-      config: A MelodyRnnConfig containing the GeneratorDetails,
-          MelodyEncoderDecoder, and HParams to use.
+      melody_rnn_model: Instance of MelodyRnnModel.
       steps_per_quarter: What precision to use when quantizing the melody. How
           many steps per quarter note.
       checkpoint: Where to search for the most recent model checkpoint. Mutually
@@ -52,39 +41,23 @@ class MelodyRnnSequenceGenerator(magenta.music.BaseSequenceGenerator):
           and metagraph. Mutually exclusive with `checkpoint`.
     """
     super(MelodyRnnSequenceGenerator, self).__init__(
-        config.details, checkpoint, bundle)
-    self._session = None
+        melody_rnn_model, checkpoint, bundle)
+    self._melody_rnn_model = melody_rnn_model
     self._steps_per_quarter = steps_per_quarter
 
-    self._config = config
-    # Override hparams for generation.
-    self._config.hparams.dropout_keep_prob = 1.0
-    self._config.hparams.batch_size = 1
-
   def _initialize_with_checkpoint(self, checkpoint_file):
-    graph = melody_rnn_graph.build_graph('generate', self._config)
-    with graph.as_default():
-      saver = tf.train.Saver()
-      self._session = tf.Session()
-      tf.logging.info('Checkpoint used: %s', checkpoint_file)
-      saver.restore(self._session, checkpoint_file)
+    self._melody_rnn_model.initialize_with_checkpoint(checkpoint_file)
 
   def _initialize_with_checkpoint_and_metagraph(self, checkpoint_filename,
                                                 metagraph_filename):
-    with tf.Graph().as_default():
-      self._session = tf.Session()
-      new_saver = tf.train.import_meta_graph(metagraph_filename)
-      new_saver.restore(self._session, checkpoint_filename)
+    self._melody_rnn_model.initialize_with_checkpoint_and_metagraph(
+        checkpoint_filename, metagraph_filename)
 
   def _write_checkpoint_with_metagraph(self, checkpoint_filename):
-    with self._session.graph.as_default():
-      saver = tf.train.Saver(sharded=False)
-      saver.save(self._session, checkpoint_filename, meta_graph_suffix='meta',
-                 write_meta_graph=True)
+    self._melody_rnn_model.write_checkpoint_with_metagraph(checkpoint_filename)
 
   def _close(self):
-    self._session.close()
-    self._session = None
+    self._melody_rnn_model.close()
 
   def _seconds_to_steps(self, seconds, qpm):
     """Converts seconds to steps.
@@ -103,44 +76,44 @@ class MelodyRnnSequenceGenerator(magenta.music.BaseSequenceGenerator):
 
   def _generate(self, input_sequence, generator_options):
     if len(generator_options.input_sections) > 1:
-      raise magenta.music.SequenceGeneratorException(
+      raise mm.SequenceGeneratorException(
           'This model supports at most one input_sections message, but got %s' %
           len(generator_options.input_sections))
     if len(generator_options.generate_sections) != 1:
-      raise magenta.music.SequenceGeneratorException(
+      raise mm.SequenceGeneratorException(
           'This model supports only 1 generate_sections message, but got %s' %
           len(generator_options.generate_sections))
 
     generate_section = generator_options.generate_sections[0]
     if generator_options.input_sections:
       input_section = generator_options.input_sections[0]
-      primer_sequence = magenta.music.extract_subsequence(
+      primer_sequence = mm.extract_subsequence(
           input_sequence, input_section.start_time, input_section.end_time)
     else:
       primer_sequence = input_sequence
 
     last_end_time = (max(n.end_time for n in primer_sequence.notes)
                      if primer_sequence.notes else 0)
-    if last_end_time > generate_section.start_time:
-      raise magenta.music.SequenceGeneratorException(
-          'Got GenerateSection request for section that is before the end of '
-          'the NoteSequence. This model can only extend sequences. '
+    if last_end_time >= generate_section.start_time:
+      raise mm.SequenceGeneratorException(
+          'Got GenerateSection request for section that is before or equal to '
+          'the end of the NoteSequence. This model can only extend sequences. '
           'Requested start time: %s, Final note end time: %s' %
           (generate_section.start_time, last_end_time))
 
     # Quantize the priming sequence.
-    quantized_sequence = magenta.music.QuantizedSequence()
+    quantized_sequence = mm.QuantizedSequence()
     quantized_sequence.from_note_sequence(
         primer_sequence, self._steps_per_quarter)
     # Setting gap_bars to infinite ensures that the entire input will be used.
-    extracted_melodies, _ = magenta.music.extract_melodies(
+    extracted_melodies, _ = mm.extract_melodies(
         quantized_sequence, min_bars=0, min_unique_pitches=1,
         gap_bars=float('inf'), ignore_polyphonic_notes=True)
     assert len(extracted_melodies) <= 1
 
     qpm = (primer_sequence.tempos[0].qpm
            if primer_sequence and primer_sequence.tempos
-           else magenta.music.DEFAULT_QUARTERS_PER_MINUTE)
+           else mm.DEFAULT_QUARTERS_PER_MINUTE)
     start_step = self._seconds_to_steps(
         generate_section.start_time, qpm)
     end_step = self._seconds_to_steps(generate_section.end_time, qpm)
@@ -148,13 +121,10 @@ class MelodyRnnSequenceGenerator(magenta.music.BaseSequenceGenerator):
     if extracted_melodies and extracted_melodies[0]:
       melody = extracted_melodies[0]
     else:
-      tf.logging.warn('No melodies were extracted from the priming sequence. '
-                      'Melodies will be generated from scratch.')
-      melody = magenta.music.Melody(
-          [random.randint(self._config.encoder_decoder.min_note,
-                          self._config.encoder_decoder.max_note)],
-          start_step=start_step)
-      start_step += 1
+      # If no melody could be extracted, create an empty melody that starts 1
+      # step before the request start_step. This will result in 1 step of
+      # silence when the melody is extended below.
+      melody = mm.Melody([], start_step=max(0, start_step - 1))
 
     # Ensure that the melody extends up to the step we want to start generating.
     melody.set_length(start_step - melody.start_step)
@@ -170,189 +140,11 @@ class MelodyRnnSequenceGenerator(magenta.music.BaseSequenceGenerator):
                 for name, value_fn in arg_types.items()
                 if name in generator_options.args)
 
-    generated_melody = self.generate_melody(
+    generated_melody = self._melody_rnn_model.generate_melody(
         end_step - melody.start_step, melody, **args)
     generated_sequence = generated_melody.to_sequence(qpm=qpm)
     assert (generated_sequence.total_time - generate_section.end_time) <= 1e-5
     return generated_sequence
-
-  def _generate_step(self, melodies, inputs, initial_state, temperature):
-    """Extends a list of melodies by a single step each."""
-    graph_inputs = self._session.graph.get_collection('inputs')[0]
-    graph_initial_state = self._session.graph.get_collection('initial_state')[0]
-    graph_final_state = self._session.graph.get_collection('final_state')[0]
-    graph_softmax = self._session.graph.get_collection('softmax')[0]
-    graph_temperature = self._session.graph.get_collection('temperature')
-
-    feed_dict = {graph_inputs: inputs, graph_initial_state: initial_state}
-    # For backwards compatibility, we only try to pass temperature if the
-    # placeholder exists in the graph.
-    if graph_temperature:
-      feed_dict[graph_temperature[0]] = temperature
-    final_state, softmax = self._session.run(
-        [graph_final_state, graph_softmax], feed_dict)
-    indices = self._config.encoder_decoder.extend_event_sequences(melodies,
-                                                                  softmax)
-
-    return melodies, final_state, softmax[range(len(melodies)), -1, indices]
-
-  def _generate_branches(self, melodies, loglik, branch_factor, num_steps,
-                         inputs, initial_state, temperature):
-    """Performs a single iteration of branch generation for beam search."""
-    all_melodies = []
-    all_final_state = np.empty((0, initial_state.shape[1]))
-    all_loglik = np.empty(0)
-
-    for _ in range(branch_factor):
-      melodies_copy = copy.deepcopy(melodies)
-      loglik_copy = copy.deepcopy(loglik)
-      for _ in range(num_steps):
-        melodies_copy, final_state, softmax = self._generate_step(
-            melodies_copy, inputs, initial_state, temperature)
-        loglik_copy += np.log(softmax)
-      all_melodies += melodies_copy
-      all_final_state = np.append(all_final_state, final_state, axis=0)
-      all_loglik = np.append(all_loglik, loglik_copy, axis=0)
-
-    return all_melodies, all_final_state, all_loglik
-
-  def _prune_branches(self, melodies, final_state, loglik, k):
-    """Prune all but `k` melodies."""
-    indices = heapq.nlargest(k, range(len(melodies)), key=lambda i: loglik[i])
-
-    melodies = [melodies[i] for i in indices]
-    final_state = final_state[indices, :]
-    loglik = loglik[indices]
-
-    return melodies, final_state, loglik
-
-  def _beam_search(self, melody, num_steps, temperature, beam_size,
-                   branch_factor, steps_per_iteration):
-    """Generates a melody using beam search.
-
-    Initially, the beam is filled with `beam_size` copies of the initial
-    melody.
-
-    Each iteration, the beam is pruned to contain only the `beam_size` melodies
-    with highest likelihood. Then `branch_factor` new melodies are generated
-    for each melody in the beam. These new melodies are formed by extending
-    each melody in the beam by `steps_per_iteration` steps. So between a
-    branching and a pruning phase, there will be `beam_size` * `branch_factor`
-    active melodies.
-
-    Prior to the first "real" iteration, an initial branch generation will take
-    place. This is for two reasons:
-
-    1) The RNN model needs to be "primed" with the initial melody.
-    2) The desired total number of steps `num_steps` might not be a multiple of
-       `steps_per_iteration`, so the initial branching generates melody steps
-       such that all subsequent iterations can generate `steps_per_iteration`
-       steps.
-
-    After the final iteration, the single melody in the beam with highest
-    likelihood will be returned.
-
-    Args:
-      melody: The initial melody.
-      num_steps: The integer length in steps of the final melody, after
-          generation.
-      temperature: A float specifying how much to divide the logits by
-         before computing the softmax. Greater than 1.0 makes melodies more
-         random, less than 1.0 makes melodies less random.
-      beam_size: The integer beam size to use.
-      branch_factor: The integer branch factor to use.
-      steps_per_iteration: The integer number of melody steps to take per
-          iteration.
-
-    Returns:
-      The highest-likelihood melody as computed by the beam search.
-    """
-    melodies = [copy.deepcopy(melody) for _ in range(beam_size)]
-    graph_initial_state = self._session.graph.get_collection('initial_state')[0]
-    loglik = np.zeros(beam_size)
-
-    # Choose the number of steps for the first iteration such that subsequent
-    # iterations can all take the same number of steps.
-    first_iteration_num_steps = (num_steps - 1) % steps_per_iteration + 1
-
-    inputs = self._config.encoder_decoder.get_inputs_batch(
-        melodies, full_length=True)
-    initial_state = self._session.run(graph_initial_state)
-    melodies, final_state, loglik = self._generate_branches(
-        melodies, loglik, branch_factor, first_iteration_num_steps, inputs,
-        initial_state, temperature)
-
-    num_iterations = (num_steps -
-                      first_iteration_num_steps) / steps_per_iteration
-
-    for _ in range(num_iterations):
-      melodies, final_state, loglik = self._prune_branches(
-          melodies, final_state, loglik, k=beam_size)
-      inputs = self._config.encoder_decoder.get_inputs_batch(melodies)
-      melodies, final_state, loglik = self._generate_branches(
-          melodies, loglik, branch_factor, steps_per_iteration, inputs,
-          final_state, temperature)
-
-    # Prune to a single melody.
-    melodies, final_state, loglik = self._prune_branches(
-        melodies, final_state, loglik, k=1)
-
-    tf.logging.info('Beam search yields melody with log-likelihood: %f ',
-                    loglik[0])
-
-    return melodies[0]
-
-  def generate_melody(self, num_steps, primer_melody, temperature=1.0,
-                      beam_size=1, branch_factor=1, steps_per_iteration=1):
-    """Generate a melody from a primer melody.
-
-    Args:
-      num_steps: The integer length in steps of the final melody, after
-          generation. Includes the primer.
-      primer_melody: The primer melody, a Melody object.
-      temperature: A float specifying how much to divide the logits by
-         before computing the softmax. Greater than 1.0 makes melodies more
-         random, less than 1.0 makes melodies less random.
-      beam_size: An integer, beam size to use when generating melodies via beam
-          search.
-      branch_factor: An integer, beam search branch factor to use.
-      steps_per_iteration: An integer, number of melody steps to take per beam
-          search iteration.
-
-    Returns:
-      The generated Melody object (which begins with the provided primer
-          melody).
-
-    Raises:
-      MelodyRnnSequenceGeneratorException: If the primer melody has zero
-          length or is not shorter than num_steps.
-    """
-    if not primer_melody:
-      raise MelodyRnnSequenceGeneratorException(
-          'primer melody must have non-zero length')
-    if len(primer_melody) >= num_steps:
-      raise MelodyRnnSequenceGeneratorException(
-          'primer melody must be shorter than `num_steps`')
-
-    if beam_size != self._config.hparams.batch_size:
-      raise MelodyRnnSequenceGeneratorException(
-          'currently beam search only supports using batch size as beam size')
-
-    melody = copy.deepcopy(primer_melody)
-
-    transpose_amount = melody.squash(
-        self._config.encoder_decoder.min_note,
-        self._config.encoder_decoder.max_note,
-        self._config.encoder_decoder.transpose_to_key)
-
-    if num_steps > len(melody):
-      melody = self._beam_search(melody, num_steps - len(melody), temperature,
-                                 beam_size, branch_factor, steps_per_iteration)
-
-    melody.transpose(-transpose_amount)
-
-    return melody
-
 
 def get_generator_map():
   """Returns a map from the generator ID to its SequenceGenerator class.
@@ -364,5 +156,6 @@ def get_generator_map():
     Map from the generator ID to its SequenceGenerator class with a bound
     `config` argument.
   """
-  return {key: partial(MelodyRnnSequenceGenerator, config)
+  return {key: partial(MelodyRnnSequenceGenerator,
+                       melody_rnn_model.MelodyRnnModel(config))
           for (key, config) in melody_rnn_config.default_configs.items()}

--- a/magenta/models/melody_rnn/melody_rnn_sequence_generator.py
+++ b/magenta/models/melody_rnn/melody_rnn_sequence_generator.py
@@ -42,20 +42,6 @@ class MelodyRnnSequenceGenerator(mm.BaseSequenceGenerator):
     self._melody_rnn_model = model
     self._steps_per_quarter = steps_per_quarter
 
-  def _initialize_with_checkpoint(self, checkpoint_file):
-    self._melody_rnn_model.initialize_with_checkpoint(checkpoint_file)
-
-  def _initialize_with_checkpoint_and_metagraph(self, checkpoint_filename,
-                                                metagraph_filename):
-    self._melody_rnn_model.initialize_with_checkpoint_and_metagraph(
-        checkpoint_filename, metagraph_filename)
-
-  def _write_checkpoint_with_metagraph(self, checkpoint_filename):
-    self._melody_rnn_model.write_checkpoint_with_metagraph(checkpoint_filename)
-
-  def _close(self):
-    self._melody_rnn_model.close()
-
   def _seconds_to_steps(self, seconds, qpm):
     """Converts seconds to steps.
 

--- a/magenta/music/BUILD
+++ b/magenta/music/BUILD
@@ -31,6 +31,7 @@ py_library(
         ":melody_encoder_decoder",
         ":midi_io",
         ":midi_synth",
+        ":model",
         ":note_sequence_io",
         ":notebook_utils",
         ":sequence_generator",
@@ -309,8 +310,9 @@ py_test(
     name = "sequence_generator_test",
     srcs = ["sequence_generator_test.py"],
     deps = [
-        ":sequence_generator",
         "//magenta/protobuf:generator_py_pb2",
+        ":model",
+        ":sequence_generator",
         # tensorflow dep
     ],
 )
@@ -382,6 +384,14 @@ py_test(
     ],
     deps = [
         ":music_xml_io",
+        # tensorflow dep
+    ],
+)
+
+py_library(
+    name = "model",
+    srcs = ["model.py"],
+    deps = [
         # tensorflow dep
     ],
 )

--- a/magenta/music/__init__.py
+++ b/magenta/music/__init__.py
@@ -38,6 +38,8 @@ from midi_io import sequence_proto_to_pretty_midi
 from midi_synth import fluidsynth
 from midi_synth import synthesize
 
+from model import BaseModel
+
 from notebook_utils import play_sequence
 
 from sequence_generator import BaseSequenceGenerator

--- a/magenta/music/model.py
+++ b/magenta/music/model.py
@@ -64,7 +64,6 @@ class BaseModel(object):
 
   def initialize_with_checkpoint_and_metagraph(self, checkpoint_filename,
                                                metagraph_filename):
-                                                metagraph_file):
     """Builds the TF graph with a checkpoint and metagraph.
 
     Args:

--- a/magenta/music/model.py
+++ b/magenta/music/model.py
@@ -31,19 +31,9 @@ class BaseModel(object):
 
   __metaclass__ = abc.ABCMeta
 
-  def __init__(self, details):
-    """Constructs a BaseModel.
-
-    Args:
-      details: A generator_pb2.GeneratorDetails for this generator.
-    """
-    self._details = details
+  def __init__(self):
+    """Constructs a BaseModel."""
     self._session = None
-
-  @property
-  def details(self):
-    """Returns a GeneratorDetails object describing the model."""
-    return self._details
 
   @abc.abstractmethod
   def _build_graph_for_generation(self):

--- a/magenta/music/model.py
+++ b/magenta/music/model.py
@@ -67,8 +67,8 @@ class BaseModel(object):
     """Builds the TF graph with a checkpoint and metagraph.
 
     Args:
-      checkpoint_file: The path to the checkpoint file that should be used.
-      metagraph_file: The path to the metagraph file that should be used.
+      checkpoint_filename: The path to the checkpoint file that should be used.
+      metagraph_filename: The path to the metagraph file that should be used.
     """
     with tf.Graph().as_default():
       self._session = tf.Session()

--- a/magenta/music/model.py
+++ b/magenta/music/model.py
@@ -65,7 +65,7 @@ class BaseModel(object):
       saver.restore(self._session, checkpoint_file)
 
   def initialize_with_checkpoint_and_metagraph(self, checkpoint_filename,
-                                                metagraph_filename):
+                                               metagraph_filename):
     with tf.Graph().as_default():
       self._session = tf.Session()
       new_saver = tf.train.import_meta_graph(metagraph_filename)

--- a/magenta/music/model.py
+++ b/magenta/music/model.py
@@ -1,0 +1,83 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Abstract class for models.
+
+Provides a uniform interface for interacting with any model.
+"""
+
+import abc
+
+# internal imports
+
+import tensorflow as tf
+
+
+class BaseModel(object):
+  """Abstract class for models.
+
+  Implements default session checkpoint restore methods.
+  """
+
+  __metaclass__ = abc.ABCMeta
+
+  def __init__(self, details):
+    """Constructs a BaseModel.
+
+    Args:
+      details: A generator_pb2.GeneratorDetails for this generator.
+    """
+    self._details = details
+    self._session = None
+
+  @property
+  def details(self):
+    """Returns a GeneratorDetails object describing the model."""
+    return self._details
+
+  @abc.abstractmethod
+  def _build_graph_for_generation(self):
+    """Builds and returns the model graph for generation.
+
+    Will be called before restoring a checkpoint file.
+
+    Returns:
+      The tf.Graph object.
+    """
+    pass
+
+  def initialize_with_checkpoint(self, checkpoint_file):
+    graph = self._build_graph()
+    with graph.as_default():
+      saver = tf.train.Saver()
+      self._session = tf.Session()
+      tf.logging.info('Checkpoint used: %s', checkpoint_file)
+      saver.restore(self._session, checkpoint_file)
+
+  def initialize_with_checkpoint_and_metagraph(self, checkpoint_filename,
+                                                metagraph_filename):
+    with tf.Graph().as_default():
+      self._session = tf.Session()
+      new_saver = tf.train.import_meta_graph(metagraph_filename)
+      new_saver.restore(self._session, checkpoint_filename)
+
+  def write_checkpoint_with_metagraph(self, checkpoint_filename):
+    with self._session.graph.as_default():
+      saver = tf.train.Saver(sharded=False)
+      saver.save(self._session, checkpoint_filename, meta_graph_suffix='meta',
+                 write_meta_graph=True)
+
+  def close(self):
+    self._session.close()
+    self._session = None
+

--- a/magenta/music/model.py
+++ b/magenta/music/model.py
@@ -47,6 +47,14 @@ class BaseModel(object):
     pass
 
   def initialize_with_checkpoint(self, checkpoint_file):
+    """Builds the TF graph given a checkpoint file.
+
+    Calls into _build_graph, which must be implemented by the subclass, before
+    restoring the checkpoint.
+
+    Args:
+      checkpoint_file: The path to the checkpoint file that should be used.
+    """
     graph = self._build_graph()
     with graph.as_default():
       saver = tf.train.Saver()
@@ -56,18 +64,31 @@ class BaseModel(object):
 
   def initialize_with_checkpoint_and_metagraph(self, checkpoint_filename,
                                                metagraph_filename):
+                                                metagraph_file):
+    """Builds the TF graph with a checkpoint and metagraph.
+
+    Args:
+      checkpoint_file: The path to the checkpoint file that should be used.
+      metagraph_file: The path to the metagraph file that should be used.
+    """
     with tf.Graph().as_default():
       self._session = tf.Session()
       new_saver = tf.train.import_meta_graph(metagraph_filename)
       new_saver.restore(self._session, checkpoint_filename)
 
   def write_checkpoint_with_metagraph(self, checkpoint_filename):
+    """Writes the checkpoint and metagraph.
+
+    Args:
+      checkpoint_filename: Path to the checkpoint file.
+    """
     with self._session.graph.as_default():
       saver = tf.train.Saver(sharded=False)
       saver.save(self._session, checkpoint_filename, meta_graph_suffix='meta',
                  write_meta_graph=True)
 
   def close(self):
+    """Closes the TF session."""
     self._session.close()
     self._session = None
 

--- a/magenta/music/sequence_generator.py
+++ b/magenta/music/sequence_generator.py
@@ -37,11 +37,12 @@ class BaseSequenceGenerator(object):
 
   __metaclass__ = abc.ABCMeta
 
-  def __init__(self, model, checkpoint, bundle):
+  def __init__(self, model, details, checkpoint, bundle):
     """Constructs a BaseSequenceGenerator.
 
     Args:
       model: An instance of BaseModel.
+      details: A generator_pb2.GeneratorDetails for this generator.
       checkpoint: Where to look for the most recent model checkpoint. Either a
           directory to be used with tf.train.latest_checkpoint or the path to a
           single checkpoint file. Or None if a bundle should be used.
@@ -52,6 +53,7 @@ class BaseSequenceGenerator(object):
       SequenceGeneratorException: if neither checkpoint nor bundle is set.
     """
     self._model = model
+    self._details = details
     self._checkpoint = checkpoint
     self._bundle = bundle
 
@@ -63,18 +65,18 @@ class BaseSequenceGenerator(object):
           'Checkpoint and bundle cannot both be set')
 
     if self._bundle:
-      if self._bundle.generator_details.id != self._model.details.id:
+      if self._bundle.generator_details.id != self._details.id:
         raise SequenceGeneratorException(
             'Generator id in bundle (%s) does not match this generator\'s id '
             '(%s)' % (self._bundle.generator_details.id,
-                      self._model.details.id))
+                      self._details.id))
 
     self._initialized = False
 
   @property
   def details(self):
     """Returns a GeneratorDetails description of this generator."""
-    return self._model.details
+    return self._details
 
   @property
   def bundle_details(self):

--- a/magenta/music/sequence_generator.py
+++ b/magenta/music/sequence_generator.py
@@ -52,7 +52,6 @@ class BaseSequenceGenerator(object):
       SequenceGeneratorException: if neither checkpoint nor bundle is set.
     """
     self._model = model
-    self._details = model.details
     self._checkpoint = checkpoint
     self._bundle = bundle
 
@@ -64,17 +63,18 @@ class BaseSequenceGenerator(object):
           'Checkpoint and bundle cannot both be set')
 
     if self._bundle:
-      if self._bundle.generator_details.id != self._details.id:
+      if self._bundle.generator_details.id != self._model.details.id:
         raise SequenceGeneratorException(
             'Generator id in bundle (%s) does not match this generator\'s id '
-            '(%s)' % (self._bundle.generator_details.id, self._details.id))
+            '(%s)' % (self._bundle.generator_details.id,
+                      self._model.details.id))
 
     self._initialized = False
 
   @property
   def details(self):
     """Returns a GeneratorDetails description of this generator."""
-    return self._details
+    return self._model.details
 
   @property
   def bundle_details(self):

--- a/magenta/music/sequence_generator_test.py
+++ b/magenta/music/sequence_generator_test.py
@@ -17,12 +17,13 @@
 
 import tensorflow as tf
 
-from magenta.music import sequence_generator
 from magenta.music import model
+from magenta.music import sequence_generator
 from magenta.protobuf import generator_pb2
 
 
 class TestModel(model.BaseModel):
+
   def __init__(self):
     details = generator_pb2.GeneratorDetails(
         id='test_generator',

--- a/magenta/music/sequence_generator_test.py
+++ b/magenta/music/sequence_generator_test.py
@@ -25,11 +25,7 @@ from magenta.protobuf import generator_pb2
 class TestModel(model.BaseModel):
 
   def __init__(self):
-    details = generator_pb2.GeneratorDetails(
-        id='test_generator',
-        description='Test Generator')
-
-    super(TestModel, self).__init__(details)
+    super(TestModel, self).__init__()
 
   def _build_graph_for_generation(self):
     pass
@@ -38,7 +34,12 @@ class TestModel(model.BaseModel):
 class TestSequenceGenerator(sequence_generator.BaseSequenceGenerator):
 
   def __init__(self, checkpoint=None, bundle=None):
-    super(TestSequenceGenerator, self).__init__(TestModel(), checkpoint, bundle)
+    details = generator_pb2.GeneratorDetails(
+        id='test_generator',
+        description='Test Generator')
+
+    super(TestSequenceGenerator, self).__init__(
+        TestModel(), details, checkpoint, bundle)
 
   def _generate(self):
     pass

--- a/magenta/music/sequence_generator_test.py
+++ b/magenta/music/sequence_generator_test.py
@@ -18,32 +18,28 @@
 import tensorflow as tf
 
 from magenta.music import sequence_generator
+from magenta.music import model
 from magenta.protobuf import generator_pb2
+
+
+class TestModel(model.BaseModel):
+  def __init__(self):
+    details = generator_pb2.GeneratorDetails(
+        id='test_generator',
+        description='Test Generator')
+
+    super(TestModel, self).__init__(details)
+
+  def _build_graph_for_generation(self):
+    pass
 
 
 class TestSequenceGenerator(sequence_generator.BaseSequenceGenerator):
 
   def __init__(self, checkpoint=None, bundle=None):
-    details = generator_pb2.GeneratorDetails(
-        id='test_generator',
-        description='Test Generator')
-
-    super(TestSequenceGenerator, self).__init__(details, checkpoint, bundle)
-
-  def _initialize_with_checkpoint(self, checkpoint_file):
-    pass
-
-  def _initialize_with_checkpoint_and_metagraph(self, checkpoint_file,
-                                                metagraph_file):
-    pass
-
-  def _close(self):
-    pass
+    super(TestSequenceGenerator, self).__init__(TestModel(), checkpoint, bundle)
 
   def _generate(self):
-    pass
-
-  def _write_checkpoint_with_metagraph(self, checkpoint_file):
     pass
 
 


### PR DESCRIPTION
Moves generate_melody into MelodyRnnModel so that MelodyRnnSequenceGenerator is concerned only with acting as a bridge between the sequence generator API and the model. If you only want to generate a melody and don't care about NoteSequence interaction, you can just instantiate the model directly.

Also creates a BaseModel class that defines some standard checkpoint-handling methods and moves that logic out of BaseSequenceGenerator. The goal here is to have the model class be the place where the graph is managed. The sequence generator doesn't need to know anything about the graph.

Finally, updates the error checking logic around empty sequences. It is now the caller's responsibility to supply some kind of priming sequence. If the sequence is silence, the model will just be primed with silence instead of a randomly-generated note (this is the case if you don't play any notes during a midi call/response cycle). If the sequence is completely empty, an exception will be thrown. To prevent this exception when running the command line generation script, added a hard-coded default sequence if no primer is given.