### PR TITLE
Fix some linter errors with the new MusicXML importer

### DIFF
--- a/magenta/music/BUILD
+++ b/magenta/music/BUILD
@@ -290,7 +290,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         "//magenta/music:constants",
-        "//magenta/protobuf:music_py_pb2"
+        "//magenta/protobuf:music_py_pb2",
     ],
 )
 
@@ -300,7 +300,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         "//magenta/music:musicxml_parser",
-        "//magenta/protobuf:music_py_pb2"
+        "//magenta/protobuf:music_py_pb2",
     ],
 )
 
@@ -310,8 +310,8 @@ py_test(
     data = [
         "testdata/clarinet_scale.xml",
         "testdata/el_capitan.xml",
-        "testdata/flute_scale.xml",
         "testdata/flute_scale.mxl",
+        "testdata/flute_scale.xml",
         "testdata/flute_scale_with_png.mxl",
         "testdata/rhythm_durations.xml",
     ],
@@ -319,11 +319,8 @@ py_test(
     deps = [
         ":musicxml_parser",
         ":musicxml_reader",
-        "@mido//:mido",
-        "@pretty_midi//:pretty_midi",
         ":sequences_lib",
         ":testing_lib",
-        "//magenta/common:testing_lib",
         # tensorflow dep
     ],
 )

--- a/magenta/music/BUILD
+++ b/magenta/music/BUILD
@@ -290,7 +290,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         "//magenta/music:constants",
-        "//magenta/protobuf:music_py_pb2"
+        "//magenta/protobuf:music_py_pb2",
     ],
 )
 
@@ -300,7 +300,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         "//magenta/music:musicxml_parser",
-        "//magenta/protobuf:music_py_pb2"
+        "//magenta/protobuf:music_py_pb2",
     ],
 )
 
@@ -310,9 +310,8 @@ py_test(
     data = [
         "testdata/clarinet_scale.xml",
         "testdata/el_capitan.xml",
-        "testdata/flute_scale.xml",
         "testdata/flute_scale.mxl",
-        "testdata/flute_scale_with_png.mxl",
+        "testdata/flute_scale.xml",
         "testdata/rhythm_durations.xml",
     ],
     srcs_version = "PY2AND3",

--- a/magenta/music/BUILD
+++ b/magenta/music/BUILD
@@ -290,7 +290,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         "//magenta/music:constants",
-        "//magenta/protobuf:music_py_pb2",
+        "//magenta/protobuf:music_py_pb2"
     ],
 )
 
@@ -300,7 +300,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         "//magenta/music:musicxml_parser",
-        "//magenta/protobuf:music_py_pb2",
+        "//magenta/protobuf:music_py_pb2"
     ],
 )
 
@@ -310,8 +310,9 @@ py_test(
     data = [
         "testdata/clarinet_scale.xml",
         "testdata/el_capitan.xml",
-        "testdata/flute_scale.mxl",
         "testdata/flute_scale.xml",
+        "testdata/flute_scale.mxl",
+        "testdata/flute_scale_with_png.mxl",
         "testdata/rhythm_durations.xml",
     ],
     srcs_version = "PY2AND3",

--- a/magenta/music/musicxml_parser.py
+++ b/magenta/music/musicxml_parser.py
@@ -780,7 +780,7 @@ class Tempo(object):
     self.qpm = -1
     self.time_position = -1
     self.state = state
-    if xml_sound != None:
+    if xml_sound is not None:
       self._parse()
 
   def _parse(self):

--- a/magenta/music/musicxml_parser.py
+++ b/magenta/music/musicxml_parser.py
@@ -427,7 +427,7 @@ class Measure(object):
           self.tempos.append(tempo)
           self.state.qpm = tempo.qpm
           self.state.seconds_per_quarter = 60 / self.state.qpm
-          if child.get('dynamics') != None:
+          if child.get('dynamics') is not None:
             self.state.velocity = int(child.get('dynamics'))
 
   def _parse_forward(self, xml_forward):
@@ -463,7 +463,7 @@ class Note(object):
     self._parse()
 
   def _parse(self):
-    """Parse the MusicXML <note> element"""
+    """Parse the MusicXML <note> element."""
 
     self.midi_channel = self.state.midi_channel
     self.midi_program = self.state.midi_program
@@ -538,7 +538,7 @@ class Note(object):
     Represented in MusicXML by the <time-modification> element.
 
     Args:
-      An xml time-modification element.
+      xml_time_modification: An xml time-modification element.
     """
     numerator = int(xml_time_modification.find('actual-notes').text)
     denominator = int(xml_time_modification.find('normal-notes').text)
@@ -693,6 +693,7 @@ class NoteDuration(object):
     ratio = self.duration_ratio()
     return ratio.numerator / ratio.denominator
 
+
 class TimeSignature(object):
   """Internal representation of a MusicXML time signature.
 
@@ -740,7 +741,7 @@ class KeySignature(object):
     self.mode = 'major'
     self.time_position = -1
     self.state = state
-    if xml_key != None:
+    if xml_key is not None:
       self._parse()
 
   def _parse(self):
@@ -773,6 +774,7 @@ class KeySignature(object):
 
 class Tempo(object):
   """Internal representation of a MusicXML tempo."""
+
   def __init__(self, state, xml_sound=None):
     self.xml_sound = xml_sound
     self.qpm = -1
@@ -804,6 +806,7 @@ class PitchStepParseException(Exception):
   Will happen if pitch step is not one of A, B, C, D, E, F, or G
   """
   pass
+
 
 class MusicXMLParseException(Exception):
   """Exception thrown when the MusicXML contents cannot be parsed."""

--- a/magenta/music/musicxml_parser.py
+++ b/magenta/music/musicxml_parser.py
@@ -502,7 +502,7 @@ class Note(object):
     octave = xml_pitch.find('octave').text
 
     # Parse alter string to a float (floats represent microtonal alterations)
-    if not alter_text:
+    if alter_text:
       alter = float(alter_text)
 
     # Check if this is a semitone alter (i.e. an integer) or microtonal (float)

--- a/magenta/music/musicxml_parser_test.py
+++ b/magenta/music/musicxml_parser_test.py
@@ -17,15 +17,17 @@ from collections import defaultdict
 import os.path
 
 # internal imports
+
 import tensorflow as tf
-from magenta.common import testing_lib as common_testing_lib
 from magenta.music import sequences_lib
 from magenta.music import testing_lib
 from magenta.music.musicxml_parser import MusicXMLDocument
 from magenta.music.musicxml_reader import musicxml_to_sequence_proto
 
+
 class MusicXMLParserTest(tf.test.TestCase):
-  """Class to test the MusicXML parser use cases
+  """Class to test the MusicXML parser use cases.
+
   self.flute_scale_filename contains an F-major scale of 8 quarter notes each
 
   self.clarinet_scale_filename contains a F-major scale of 8 quarter notes
@@ -43,6 +45,7 @@ class MusicXMLParserTest(tf.test.TestCase):
   self.compressed_filename contains the same content as
   self.flute_scale_filename, but compressed in MXL format
   """
+
   def setUp(self):
 
     self.steps_per_quarter = 4
@@ -93,9 +96,9 @@ class MusicXMLParserTest(tf.test.TestCase):
     for musicxml_key, sequence_key in zip(musicxml.get_key_signatures(),
                                           sequence_proto.key_signatures):
 
-      if musicxml_key.mode == "major":
+      if musicxml_key.mode == 'major':
         mode = 0
-      elif musicxml_key.mode == "minor":
+      elif musicxml_key.mode == 'minor':
         mode = 1
 
       # The Key enum in music.proto does NOT follow MIDI / MusicXML specs
@@ -144,7 +147,7 @@ class MusicXMLParserTest(tf.test.TestCase):
         self.assertEqual(musicxml_note.velocity, sequence_note.velocity)
         self.assertAlmostEqual(musicxml_note.note_duration.time_position,
                                sequence_note.start_time)
-        self.assertAlmostEqual(musicxml_note.note_duration.time_position \
+        self.assertAlmostEqual(musicxml_note.note_duration.time_position
                                + musicxml_note.note_duration.seconds,
                                sequence_note.end_time)
         # Check that the duration specified in the MusicXML and the
@@ -155,10 +158,11 @@ class MusicXMLParserTest(tf.test.TestCase):
         # 341.0, 341.0, 342.0.
         # Check that (3 * 341.333) = (341 + 341 + 342) is true by checking
         # that 341.0 and 342.0 are +/- 1 of 341.333
-        self.assertAlmostEqual(musicxml_note.note_duration.duration, \
-                               musicxml_note.state.divisions * 4 \
-                               * musicxml_note.note_duration.duration_float(),\
-                               delta=1)
+        self.assertAlmostEqual(
+            musicxml_note.note_duration.duration,
+            musicxml_note.state.divisions * 4
+            * musicxml_note.note_duration.duration_float(),
+            delta=1)
 
   def checkmusicxmltosequence(self, filename):
     """Test the translation from MusicXML to Sequence proto."""
@@ -167,21 +171,26 @@ class MusicXMLParserTest(tf.test.TestCase):
     self.checkmusicxmlandsequence(source_musicxml, sequence_proto)
 
   def checkFMajorScale(self, filename):
-    """Verify that the MusicXML scale file contains the correct
-    pitches (sounding pitch) and durations"""
+    """Verify MusicXML scale file.
+
+    Verify that it contains the correct pitches (sounding pitch) and durations.
+    """
 
     # Expected QuantizedSequence
     # Sequence tuple = (midi_pitch, velocity, start_seconds, end_seconds)
     expected_quantized_sequence = sequences_lib.QuantizedSequence()
     expected_quantized_sequence.steps_per_quarter = self.steps_per_quarter
     expected_quantized_sequence.qpm = 120.0
-    expected_quantized_sequence.time_signature = sequences_lib.QuantizedSequence.TimeSignature(
-      numerator = 4, denominator = 4)
+    expected_quantized_sequence.time_signature = (
+        sequences_lib.QuantizedSequence.TimeSignature(numerator=4,
+                                                      denominator=4))
     testing_lib.add_quantized_track_to_sequence(
       expected_quantized_sequence, 0,
-      [(65, 64, 0, 4), (67, 64, 4, 8), (69, 64, 8, 12),
-      (70, 64, 12, 16), (72, 64, 16, 20), (74, 64, 20, 24),
-      (76, 64, 24, 28), (77, 64, 28, 32)]
+      [
+          (65, 64, 0, 4), (67, 64, 4, 8), (69, 64, 8, 12),
+          (70, 64, 12, 16), (72, 64, 16, 20), (74, 64, 20, 24),
+          (76, 64, 24, 28), (77, 64, 28, 32)
+      ]
     )
 
     # Convert MusicXML to QuantizedSequence
@@ -194,18 +203,19 @@ class MusicXMLParserTest(tf.test.TestCase):
     self.assertEqual(expected_quantized_sequence, quantized)
 
   def testsimplemusicxmltosequence(self):
-    """Test the simple flute scale MusicXML file"""
+    """Test the simple flute scale MusicXML file."""
     self.checkmusicxmltosequence(self.flute_scale_filename)
     self.checkFMajorScale(self.flute_scale_filename)
 
   def testcomplexmusicxmltosequence(self):
-    """Test the complex band score MusicXML file"""
+    """Test the complex band score MusicXML file."""
     self.checkmusicxmltosequence(self.band_score_filename)
 
   def testtransposedxmltosequence(self):
-    """Test the translation from MusicXML to Sequence proto when the music
-    is transposed. Compare a transpoed MusicXML file (clarinet) to an
-    identical untransposed sequence (flute)
+    """Test the translation from transposed MusicXML to Sequence proto.
+
+    Compare a transposed MusicXML file (clarinet) to an identical untransposed
+    sequence (flute).
     """
     untransposed_musicxml = MusicXMLDocument(self.flute_scale_filename)
     transposed_musicxml = MusicXMLDocument(self.clarinet_scale_filename)
@@ -214,9 +224,9 @@ class MusicXMLParserTest(tf.test.TestCase):
     self.checkFMajorScale(self.clarinet_scale_filename)
 
   def testcompressedxmltosequence(self):
-    """Test the translation from MusicXML to Sequence proto when the music
-    is compressed in MXL format. Compare a compressed MusicXML file to an
-    identical uncompressed sequence
+    """Test the translation from compressed MusicXML to Sequence proto.
+
+    Compare a compressed MusicXML file to an identical uncompressed sequence.
     """
     uncompressed_musicxml = MusicXMLDocument(self.flute_scale_filename)
     compressed_musicxml = MusicXMLDocument(self.compressed_filename)
@@ -225,11 +235,11 @@ class MusicXMLParserTest(tf.test.TestCase):
     self.checkFMajorScale(self.flute_scale_filename)
 
   def testmultiplecompressedxmltosequence(self):
-    """Test the translation from MusicXML to Sequence proto when the music
-    is compressed in MXL format with multiple rootfiles. The example
-    MXL file contains a MusicXML file of the Flute F Major scale, as well
-    as the PNG rendering of the score contained within the single MXL file.
-    Compare a compressed MusicXML file to an identical uncompressed sequence
+    """Test the translation from compressed MusicXML with multiple rootfiles.
+
+    The example MXL file contains a MusicXML file of the Flute F Major scale,
+    as well as the PNG rendering of the score contained within the single MXL
+    file.
     """
     uncompressed_musicxml = MusicXMLDocument(self.flute_scale_filename)
     compressed_musicxml = MusicXMLDocument(
@@ -239,7 +249,7 @@ class MusicXMLParserTest(tf.test.TestCase):
     self.checkFMajorScale(self.flute_scale_filename)
 
   def testrhythmdurationsxmltosequence(self):
-    """Test the rhythm durations MusicXML file"""
+    """Test the rhythm durations MusicXML file."""
     self.checkmusicxmltosequence(self.rhythm_durations_filename)
 
 if __name__ == '__main__':

--- a/magenta/music/musicxml_parser_test.py
+++ b/magenta/music/musicxml_parser_test.py
@@ -174,6 +174,9 @@ class MusicXMLParserTest(tf.test.TestCase):
     """Verify MusicXML scale file.
 
     Verify that it contains the correct pitches (sounding pitch) and durations.
+
+    Args:
+      filename: file to test.
     """
 
     # Expected QuantizedSequence
@@ -185,12 +188,12 @@ class MusicXMLParserTest(tf.test.TestCase):
         sequences_lib.QuantizedSequence.TimeSignature(numerator=4,
                                                       denominator=4))
     testing_lib.add_quantized_track_to_sequence(
-      expected_quantized_sequence, 0,
-      [
-          (65, 64, 0, 4), (67, 64, 4, 8), (69, 64, 8, 12),
-          (70, 64, 12, 16), (72, 64, 16, 20), (74, 64, 20, 24),
-          (76, 64, 24, 28), (77, 64, 28, 32)
-      ]
+        expected_quantized_sequence, 0,
+        [
+            (65, 64, 0, 4), (67, 64, 4, 8), (69, 64, 8, 12),
+            (70, 64, 12, 16), (72, 64, 16, 20), (74, 64, 20, 24),
+            (76, 64, 24, 28), (77, 64, 28, 32)
+        ]
     )
 
     # Convert MusicXML to QuantizedSequence
@@ -243,7 +246,7 @@ class MusicXMLParserTest(tf.test.TestCase):
     """
     uncompressed_musicxml = MusicXMLDocument(self.flute_scale_filename)
     compressed_musicxml = MusicXMLDocument(
-                            self.multiple_rootfile_compressed_filename)
+        self.multiple_rootfile_compressed_filename)
     uncompressed_proto = musicxml_to_sequence_proto(uncompressed_musicxml)
     self.checkmusicxmlandsequence(compressed_musicxml, uncompressed_proto)
     self.checkFMajorScale(self.flute_scale_filename)

--- a/magenta/music/musicxml_reader.py
+++ b/magenta/music/musicxml_reader.py
@@ -17,12 +17,15 @@ Input wrappers for converting MusicXML into tensorflow.magenta.NoteSequence.
 """
 
 # internal imports
+
 from magenta.music.musicxml_parser import MusicXMLDocument
 from magenta.protobuf import music_pb2
 
+
 class MusicXMLConversionError(Exception):
-  """MusicXML conversion error handler"""
+  """MusicXML conversion error handler."""
   pass
+
 
 def musicxml_to_sequence_proto(musicxml_document):
   """Convert MusicXML file contents to a tensorflow.magenta.NoteSequence proto.
@@ -32,7 +35,7 @@ def musicxml_to_sequence_proto(musicxml_document):
 
   Args:
     musicxml_document: A parsed MusicXML file.
-    This file has been parsed by class MusicXMLDocument
+        This file has been parsed by class MusicXMLDocument
 
   Returns:
     A tensorflow.magenta.NoteSequence proto.
@@ -92,7 +95,7 @@ def musicxml_to_sequence_proto(musicxml_document):
             note.start_time = 0
 
           note.end_time = note.start_time + musicxml_note.note_duration.seconds
-          note.pitch = musicxml_note.pitch[1] # Index 1 = MIDI pitch number
+          note.pitch = musicxml_note.pitch[1]  # Index 1 = MIDI pitch number
           note.velocity = musicxml_note.velocity
 
           durationratio = musicxml_note.note_duration.duration_ratio()
@@ -100,6 +103,7 @@ def musicxml_to_sequence_proto(musicxml_document):
           note.denominator = durationratio.denominator
 
   return sequence
+
 
 def musicxml_file_to_sequence_proto(musicxml_file):
   """Converts a MusicXML file to a tensorflow.magenta.NoteSequence proto.


### PR DESCRIPTION
These errors were caught by our internal linter. Unfortunately not all of these show up in the external linter, so this extra internal pass was needed. In the future, we should figure out a way to expose more of these errors to external contributors.

There should be no functional changes in this PR.

FYI @jsawruk