### PR TITLE
Encapsulate MusicXML exceptions

### DIFF
--- a/magenta/music/musicxml_reader.py
+++ b/magenta/music/musicxml_reader.py
@@ -18,7 +18,7 @@ Input wrappers for converting MusicXML into tensorflow.magenta.NoteSequence.
 
 # internal imports
 
-from magenta.music.musicxml_parser import MusicXMLDocument
+from magenta.music import musicxml_parser
 from magenta.protobuf import music_pb2
 
 
@@ -117,5 +117,8 @@ def musicxml_file_to_sequence_proto(musicxml_file):
   Raises:
     MusicXMLConversionError: Invalid musicxml_file.
   """
-  musicxml_document = MusicXMLDocument(musicxml_file)
+  try:
+    musicxml_document = musicxml_parser.MusicXMLDocument(musicxml_file)
+  except musicxml_parser.MusicXMLParseException as e:
+    raise MusicXMLConversionError(e)
   return musicxml_to_sequence_proto(musicxml_document)


### PR DESCRIPTION
Callers of musicxml_reader only need to worry about
MusicXMLConversionError, and callers of musicxml_parser only need to
worry about MusicXMLParseException.

Has the net effect of allowing convert_musicxml_dir_to_note_sequences to
continue on to the next file if the current file has a parse error.