### PR TITLE
MusicXML: Fix transposition bug when no key signature found

### DIFF
--- a/magenta/music/BUILD
+++ b/magenta/music/BUILD
@@ -314,6 +314,7 @@ py_test(
         "testdata/flute_scale.xml",
         "testdata/flute_scale_with_png.mxl",
         "testdata/rhythm_durations.xml",
+        "testdata/atonal_transposition_change.xml",
     ],
     srcs_version = "PY2AND3",
     deps = [

--- a/magenta/music/musicxml_parser.py
+++ b/magenta/music/musicxml_parser.py
@@ -410,7 +410,8 @@ class Measure(object):
       elif child.tag == 'transpose':
         transpose = int(child.find('chromatic').text)
         self.state.transpose = transpose
-        self.key_signature.key += transpose
+        if self.key_signature != None:
+          self.key_signature.key += transpose
       else:
         # Ignore other tag types because they are not relevant to Magenta.
         pass

--- a/magenta/music/musicxml_parser.py
+++ b/magenta/music/musicxml_parser.py
@@ -410,7 +410,7 @@ class Measure(object):
       elif child.tag == 'transpose':
         transpose = int(child.find('chromatic').text)
         self.state.transpose = transpose
-        if self.key_signature != None:
+        if self.key_signature is not None:
           self.key_signature.key += transpose
       else:
         # Ignore other tag types because they are not relevant to Magenta.

--- a/magenta/music/musicxml_parser_test.py
+++ b/magenta/music/musicxml_parser_test.py
@@ -342,6 +342,11 @@ class MusicXMLParserTest(tf.test.TestCase):
         }
         key_signatures: {
         }
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: MUSIC_XML
+          parser: MAGENTA_MUSIC_XML
+        }
         total_time: 4.0
         """)
     expected_pitches = [72, 74, 76, 77, 79, 77, 76, 74]

--- a/magenta/music/musicxml_parser_test.py
+++ b/magenta/music/musicxml_parser_test.py
@@ -318,9 +318,14 @@ class MusicXMLParserTest(tf.test.TestCase):
       note.denominator = 4
     self.assertProtoEquals(expected_ns, ns)
 
-  def testatonaltransposition(self):
-    """Test that transposition works when changing instrument transposition
-    within a single part in a score that has no key signature / is atonal.
+  def test_atonal_transposition(self):
+    """Test that transposition works when changing instrument transposition.
+
+    This can occur within a single part in a score where the score
+    has no key signature / is atonal. Examples include changing from a
+    non-transposing instrument to a transposing one (ex. Flute to Bb Clarinet)
+    or vice versa, or changing among transposing instruments (ex. Bb Clarinet
+    to Eb Alto Saxophone).
     """
     ns = musicxml_reader.musicxml_file_to_sequence_proto(
         self.atonal_transposition_filename)

--- a/magenta/music/musicxml_parser_test.py
+++ b/magenta/music/musicxml_parser_test.py
@@ -47,6 +47,15 @@ class MusicXMLParserTest(tf.test.TestCase):
 
   self.compressed_filename contains the same content as
   self.flute_scale_filename, but compressed in MXL format
+
+  self.rhythm_durations_filename contains a variety of rhythms (long, short,
+  dotted, tuplet, and dotted tuplet) to test the computation of rhythmic
+  ratios.
+
+  self.atonal_transposition_filename contains a change of instrument
+  from a non-transposing (Flute) to transposing (Bb Clarinet) in a score
+  with no key / atonal. This ensures that transposition works properly when
+  no key signature is found (Issue #355)
   """
 
   def setUp(self):
@@ -77,6 +86,10 @@ class MusicXMLParserTest(tf.test.TestCase):
     self.rhythm_durations_filename = os.path.join(
         tf.resource_loader.get_data_files_path(),
         'testdata/rhythm_durations.xml')
+
+    self.atonal_transposition_filename = os.path.join(
+        tf.resource_loader.get_data_files_path(),
+        'testdata/atonal_transposition_change.xml')
 
   def checkmusicxmlandsequence(self, musicxml, sequence_proto):
     """Compares MusicXMLDocument object against a sequence proto.
@@ -303,6 +316,41 @@ class MusicXMLParserTest(tf.test.TestCase):
       note.velocity = 64
       note.numerator = 1
       note.denominator = 4
+    self.assertProtoEquals(expected_ns, ns)
+
+  def testatonaltransposition(self):
+    """Test that transposition works when changing instrument transposition
+    within a single part in a score that has no key signature / is atonal.
+    """
+    ns = musicxml_reader.musicxml_file_to_sequence_proto(
+        self.atonal_transposition_filename)
+    expected_ns = common_testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        """
+        ticks_per_quarter: 220
+        time_signatures: {
+          numerator: 4
+          denominator: 4
+        }
+        tempos: {
+          qpm: 120
+        }
+        key_signatures: {
+        }
+        total_time: 4.0
+        """)
+    expected_pitches = [72, 74, 76, 77, 79, 77, 76, 74]
+    time = 0
+    for pitch in expected_pitches:
+      note = expected_ns.notes.add()
+      note.pitch = pitch
+      note.start_time = time
+      time += .5
+      note.end_time = time
+      note.velocity = 64
+      note.numerator = 1
+      note.denominator = 4
+    self.maxDiff = None
     self.assertProtoEquals(expected_ns, ns)
 
 if __name__ == '__main__':

--- a/magenta/music/testdata/atonal_transposition_change.xml
+++ b/magenta/music/testdata/atonal_transposition_change.xml
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding='UTF-8' standalone='no' ?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+ <work>
+  <work-title />
+ </work>
+ <identification>
+  <rights>PUBLIC DOMAIN</rights>
+  <encoding>
+   <encoding-date>2016-11-07</encoding-date>
+   <encoder>Jeremy Sawruk</encoder>
+   <software>Sibelius 8.4.2</software>
+   <software>Direct export, not from Dolet</software>
+   <encoding-description>Sibelius / MusicXML 3.0</encoding-description>
+   <supports element="print" type="yes" value="yes" attribute="new-system" />
+   <supports element="print" type="yes" value="yes" attribute="new-page" />
+   <supports element="accidental" type="yes" />
+   <supports element="beam" type="yes" />
+   <supports element="stem" type="yes" />
+  </encoding>
+ </identification>
+ <defaults>
+  <scaling>
+   <millimeters>215.9</millimeters>
+   <tenths>1233</tenths>
+  </scaling>
+  <page-layout>
+   <page-height>1596</page-height>
+   <page-width>1233</page-width>
+   <page-margins type="both">
+    <left-margin>85</left-margin>
+    <right-margin>85</right-margin>
+    <top-margin>85</top-margin>
+    <bottom-margin>85</bottom-margin>
+   </page-margins>
+  </page-layout>
+  <system-layout>
+   <system-margins>
+    <left-margin>50</left-margin>
+    <right-margin>0</right-margin>
+   </system-margins>
+   <system-distance>92</system-distance>
+  </system-layout>
+  <appearance>
+   <line-width type="stem">0.9375</line-width>
+   <line-width type="beam">5</line-width>
+   <line-width type="staff">0.9375</line-width>
+   <line-width type="light barline">1.5625</line-width>
+   <line-width type="heavy barline">5</line-width>
+   <line-width type="leger">1.5625</line-width>
+   <line-width type="ending">1.5625</line-width>
+   <line-width type="wedge">1.25</line-width>
+   <line-width type="enclosure">0.9375</line-width>
+   <line-width type="tuplet bracket">1.25</line-width>
+   <line-width type="bracket">5</line-width>
+   <line-width type="dashes">1.5625</line-width>
+   <line-width type="extend">0.9375</line-width>
+   <line-width type="octave shift">1.5625</line-width>
+   <line-width type="pedal">1.5625</line-width>
+   <line-width type="slur middle">1.5625</line-width>
+   <line-width type="slur tip">0.625</line-width>
+   <line-width type="tie middle">1.5625</line-width>
+   <line-width type="tie tip">0.625</line-width>
+   <note-size type="cue">75</note-size>
+   <note-size type="grace">60</note-size>
+  </appearance>
+  <music-font font-family="Opus Std" font-size="19.8425" />
+  <lyric-font font-family="Plantin MT Std" font-size="11.4715" />
+  <lyric-language xml:lang="en" />
+ </defaults>
+ <part-list>
+  <score-part id="P1">
+   <part-name>Flute</part-name>
+   <part-name-display>
+    <display-text>Flute</display-text>
+   </part-name-display>
+   <part-abbreviation>Fl.</part-abbreviation>
+   <part-abbreviation-display>
+    <display-text>Fl.</display-text>
+   </part-abbreviation-display>
+   <score-instrument id="P1-I1">
+    <instrument-name>Flute (2)</instrument-name>
+    <instrument-sound>wind.flutes.flute</instrument-sound>
+    <solo />
+    <virtual-instrument>
+     <virtual-library>General MIDI</virtual-library>
+     <virtual-name>Flute</virtual-name>
+    </virtual-instrument>
+   </score-instrument>
+   <score-instrument id="P1-I2">
+    <instrument-name>Clarinet in B^b</instrument-name>
+    <instrument-sound>wind.reed.clarinet</instrument-sound>
+    <solo />
+    <virtual-instrument>
+     <virtual-library>General MIDI</virtual-library>
+     <virtual-name>Clarinet</virtual-name>
+    </virtual-instrument>
+   </score-instrument>
+  </score-part>
+ </part-list>
+ <part id="P1">
+  <!--============== Part: P1, Measure: 1 ==============-->
+  <measure number="1" width="474">
+   <print new-page="yes">
+    <system-layout>
+     <system-margins>
+      <left-margin>165</left-margin>
+      <right-margin>0</right-margin>
+     </system-margins>
+     <top-system-distance>218</top-system-distance>
+    </system-layout>
+   </print>
+   <attributes>
+    <divisions>256</divisions>
+    <key color="#000000">
+     <fifths>0</fifths>
+     <mode>none</mode>
+    </key>
+    <time color="#000000">
+     <beats>4</beats>
+     <beat-type>4</beat-type>
+    </time>
+    <staves>1</staves>
+    <clef number="1" color="#000000">
+     <sign>G</sign>
+     <line>2</line>
+    </clef>
+    <staff-details number="1" print-object="yes" />
+   </attributes>
+   <direction>
+    <direction-type>
+     <metronome default-y="30" color="#000000" font-family="Opus Text Std" font-style="normal" font-size="13.0217" font-weight="normal">
+      <beat-unit>quarter</beat-unit>
+      <per-minute>120</per-minute>
+     </metronome>
+    </direction-type>
+    <voice>1</voice>
+    <staff>1</staff>
+   </direction>
+   <note color="#000000" default-x="81" default-y="-50">
+    <pitch>
+     <step>C</step>
+     <octave>5</octave>
+    </pitch>
+    <duration>256</duration>
+    <instrument id="P1-I1" />
+    <voice>1</voice>
+    <type>quarter</type>
+    <stem>down</stem>
+    <staff>1</staff>
+   </note>
+   <note color="#000000" default-x="179" default-y="-45">
+    <pitch>
+     <step>D</step>
+     <octave>5</octave>
+    </pitch>
+    <duration>256</duration>
+    <instrument id="P1-I1" />
+    <voice>1</voice>
+    <type>quarter</type>
+    <stem>down</stem>
+    <staff>1</staff>
+   </note>
+   <note color="#000000" default-x="277" default-y="-40">
+    <pitch>
+     <step>E</step>
+     <octave>5</octave>
+    </pitch>
+    <duration>256</duration>
+    <instrument id="P1-I1" />
+    <voice>1</voice>
+    <type>quarter</type>
+    <stem>down</stem>
+    <staff>1</staff>
+   </note>
+   <direction>
+    <direction-type>
+     <words default-x="370" default-y="20" justify="left" valign="middle" font-family="Plantin MT Std" font-style="normal" font-size="11.9365" font-weight="normal">To Cl.</words>
+    </direction-type>
+    <voice>1</voice>
+    <staff>1</staff>
+   </direction>
+   <note color="#000000" default-x="376" default-y="-35">
+    <pitch>
+     <step>F</step>
+     <octave>5</octave>
+    </pitch>
+    <duration>256</duration>
+    <instrument id="P1-I1" />
+    <voice>1</voice>
+    <type>quarter</type>
+    <stem>down</stem>
+    <staff>1</staff>
+   </note>
+  </measure>
+  <!--============== Part: P1, Measure: 2 ==============-->
+  <measure number="2" width="423">
+   <print>
+    <part-name-display>
+     <display-text>Clarinet in B</display-text>
+     <accidental-text>flat</accidental-text>
+    </part-name-display>
+    <part-abbreviation-display>
+     <display-text>Cl.</display-text>
+    </part-abbreviation-display>
+   </print>
+   <attributes>
+    <transpose>
+     <diatonic>-1</diatonic>
+     <chromatic>-2</chromatic>
+    </transpose>
+   </attributes>
+   <note color="#000000" default-x="15" default-y="-25">
+    <pitch>
+     <step>A</step>
+     <octave>5</octave>
+    </pitch>
+    <duration>256</duration>
+    <instrument id="P1-I2" />
+    <voice>1</voice>
+    <type>quarter</type>
+    <stem>down</stem>
+    <staff>1</staff>
+   </note>
+   <note color="#000000" default-x="113" default-y="-30">
+    <pitch>
+     <step>G</step>
+     <octave>5</octave>
+    </pitch>
+    <duration>256</duration>
+    <instrument id="P1-I2" />
+    <voice>1</voice>
+    <type>quarter</type>
+    <stem>down</stem>
+    <staff>1</staff>
+   </note>
+   <note color="#000000" default-x="211" default-y="-35">
+    <pitch>
+     <step>F</step>
+     <alter>1</alter>
+     <octave>5</octave>
+    </pitch>
+    <duration>256</duration>
+    <instrument id="P1-I2" />
+    <voice>1</voice>
+    <type>quarter</type>
+    <accidental>sharp</accidental>
+    <stem>down</stem>
+    <staff>1</staff>
+   </note>
+   <note color="#000000" default-x="309" default-y="-40">
+    <pitch>
+     <step>E</step>
+     <octave>5</octave>
+    </pitch>
+    <duration>256</duration>
+    <instrument id="P1-I2" />
+    <voice>1</voice>
+    <type>quarter</type>
+    <stem>down</stem>
+    <staff>1</staff>
+   </note>
+   <barline>
+    <bar-style>light-heavy</bar-style>
+   </barline>
+  </measure>
+ </part>
+</score-partwise>


### PR DESCRIPTION
Fix issue #354.

Only changed the transposition of the key signature if a key signature was present. If the music has no key, but the part changes transposition (i.e. a change of instruments within a part), the key signature remains none.