### PR TITLE
add flag exluding primer sequence

### DIFF
--- a/magenta/models/melody_rnn/melody_rnn_generate.py
+++ b/magenta/models/melody_rnn/melody_rnn_generate.py
@@ -97,6 +97,10 @@ tf.app.flags.DEFINE_string(
     'log', 'INFO',
     'The threshold for what messages will be logged DEBUG, INFO, WARN, ERROR, '
     'or FATAL.')
+tf.app.flags.DEFINE_boolean(
+    'exclude_primer_midi', True,
+    'If true, instead of including the primer MIDI in the generated sequence, '
+    'will only output the newly generated MIDI.')
 
 
 def get_checkpoint():
@@ -194,9 +198,11 @@ def run_with_flags(generator):
     # Set the start time to begin on the next step after the last note ends.
     last_end_time = (max(n.end_time for n in primer_sequence.notes)
                      if primer_sequence.notes else 0)
+    start_time = last_end_time + _steps_to_seconds(1, qpm)
+
     generate_section = generator_options.generate_sections.add(
-        start_time=last_end_time + _steps_to_seconds(1, qpm),
-        end_time=total_seconds)
+      start_time=start_time,
+      end_time=total_seconds)
 
     if generate_section.start_time >= generate_section.end_time:
       tf.logging.fatal(
@@ -223,8 +229,23 @@ def run_with_flags(generator):
   # files.
   date_and_time = time.strftime('%Y-%m-%d_%H%M%S')
   digits = len(str(FLAGS.num_outputs))
+
   for i in range(FLAGS.num_outputs):
     generated_sequence = generator.generate(input_sequence, generator_options)
+
+    if FLAGS.exclude_primer_midi is True:
+      # Remove the first half ot the sequence. Iterating through all notes
+      # and popping the first one each time stops halfway through the list
+      # because we are continually shortening the list by 1 and moving onto
+      # the next index.
+      for note in generated_sequence.notes:
+        generated_sequence.notes.pop(0)
+
+      # Subtract the length of the removed input_sequence from start_time and
+      # end_time of remaining notes.
+      for note in generated_sequence.notes:
+        note.start_time -= start_time
+        note.end_time   -= start_time
 
     midi_filename = '%s_%s.mid' % (date_and_time, str(i + 1).zfill(digits))
     midi_path = os.path.join(FLAGS.output_dir, midi_filename)


### PR DESCRIPTION
Adds a flag, `exclude_primer_midi`, to `melody_rnn_generate.py` that, if set to `True`, results in removing notes in generated_sequence that start before the calculated start_time in the generate_section request.