### PR TITLE
Skip inputs with too many simultaneous notes

### DIFF
--- a/magenta/models/polyphonic_rnn/polyphonic_rnn_graph.py
+++ b/magenta/models/polyphonic_rnn/polyphonic_rnn_graph.py
@@ -43,9 +43,9 @@ class Graph(object):
 
     num_note_features = note_mb.shape[-1]
     num_duration_features = duration_mb.shape[-1]
-    n_note_symbols = len(self.train_itr.note_classes)
+    n_note_symbols = len(polyphonic_rnn_lib.NOTE_CLASSES)
     n_duration_symbols = len(polyphonic_rnn_lib.TIME_CLASSES)
-    self.n_notes = self.train_itr.simultaneous_notes
+    self.n_notes = polyphonic_rnn_lib.SIMULTANEOUS_NOTES
     note_embed_dim = 20
     duration_embed_dim = 4
     n_dim = 64


### PR DESCRIPTION
This should make training more accurate for datasets containing sequences with more than 4 simultaneous notes.