### PR TITLE
Make quantization more strict

### DIFF
--- a/magenta/music/BUILD
+++ b/magenta/music/BUILD
@@ -412,6 +412,9 @@ py_library(
 py_library(
     name = "sequences_lib",
     srcs = ["sequences_lib.py"],
+    deps = [
+        ":constants",
+    ],
 )
 
 py_test(

--- a/magenta/music/__init__.py
+++ b/magenta/music/__init__.py
@@ -65,7 +65,8 @@ from magenta.music.sequence_generator_bundle import GeneratorBundleParseExceptio
 from magenta.music.sequence_generator_bundle import read_bundle_file
 
 from magenta.music.sequences_lib import BadTimeSignatureException
-from magenta.music.sequences_lib import extract_subsequence
+from magenta.music.sequences_lib import MultipleTempoException
 from magenta.music.sequences_lib import MultipleTimeSignatureException
 from magenta.music.sequences_lib import NegativeTimeException
+from magenta.music.sequences_lib import extract_subsequence
 from magenta.music.sequences_lib import QuantizedSequence

--- a/magenta/music/__init__.py
+++ b/magenta/music/__init__.py
@@ -65,8 +65,8 @@ from magenta.music.sequence_generator_bundle import GeneratorBundleParseExceptio
 from magenta.music.sequence_generator_bundle import read_bundle_file
 
 from magenta.music.sequences_lib import BadTimeSignatureException
+from magenta.music.sequences_lib import extract_subsequence
 from magenta.music.sequences_lib import MultipleTempoException
 from magenta.music.sequences_lib import MultipleTimeSignatureException
 from magenta.music.sequences_lib import NegativeTimeException
-from magenta.music.sequences_lib import extract_subsequence
 from magenta.music.sequences_lib import QuantizedSequence

--- a/magenta/music/sequences_lib.py
+++ b/magenta/music/sequences_lib.py
@@ -16,6 +16,7 @@
 import collections
 import copy
 from magenta.protobuf import music_pb2
+from magenta.music import constants
 
 # Set the quantization cutoff.
 # Note events before this cutoff are rounded down to nearest step. Notes
@@ -37,6 +38,10 @@ class BadTimeSignatureException(Exception):
 
 
 class MultipleTimeSignatureException(Exception):
+  pass
+
+
+class MultipleTempoException(Exception):
   pass
 
 
@@ -156,6 +161,7 @@ class QuantizedSequence(object):
     Raises:
       MultipleTimeSignatureException: If there is a change in time signature
           in `note_sequence`.
+      MultipleTempoException: If there is a change in tempo in `note_sequence`.
       BadTimeSignatureException: If the time signature found in `note_sequence`
           has a denominator which is not a power of 2.
       NegativeTimeException: If a note or chord occurs at a negative time.
@@ -165,21 +171,49 @@ class QuantizedSequence(object):
     self.steps_per_quarter = steps_per_quarter
 
     if note_sequence.time_signatures:
-      self.time_signature = QuantizedSequence.TimeSignature(
-          note_sequence.time_signatures[0].numerator,
-          note_sequence.time_signatures[0].denominator)
-    for time_signature in note_sequence.time_signatures[1:]:
-      if (time_signature.numerator != self.time_signature.numerator or
-          time_signature.denominator != self.time_signature.denominator):
+      time_signatures = sorted(note_sequence.time_signatures,
+                               key=lambda ts: ts.time)
+      # There is an implicit 4/4 time signature at 0 time. So if the first time
+      # signature is something other than 4/4 and it's at a time other than 0,
+      # that's an implicit time signature change.
+      if time_signatures[0].time != 0 and not (
+          time_signatures[0].numerator == 4 and
+          time_signatures[0].denominator == 4):
         raise MultipleTimeSignatureException(
-            'NoteSequence has at least one time signature change.')
+            'NoteSequence has an implicit change from initial 4/4 time '
+            'signature.')
+
+      self.time_signature = QuantizedSequence.TimeSignature(
+          time_signatures[0].numerator, time_signatures[0].denominator)
+
+      for time_signature in time_signatures[1:]:
+        if (time_signature.numerator != self.time_signature.numerator or
+            time_signature.denominator != self.time_signature.denominator):
+          raise MultipleTimeSignatureException(
+              'NoteSequence has at least one time signature change.')
 
     if not is_power_of_2(self.time_signature.denominator):
       raise BadTimeSignatureException(
           'Denominator is not a power of 2. Time signature: %d/%d' %
           (self.time_signature.numerator, self.time_signature.denominator))
 
-    self.qpm = note_sequence.tempos[0].qpm if note_sequence.tempos else 120.0
+    if note_sequence.tempos:
+      tempos = sorted(note_sequence.tempos, key=lambda t: t.time)
+      # There is an implicit 120.0 qpm tempo at 0 time. So if the first tempo is
+      # something other that 120.0 and it's at a time other than 0, that's an
+      # implicit tempo change.
+      if tempos[0].time != 0 and tempos[0].qpm != 120.0:
+        raise MultipleTempoException(
+            'NoteSequence has an implicit tempo change from initial 120.0 qpm')
+
+      self.qpm = tempos[0].qpm
+
+      for tempo in tempos[1:]:
+        if tempo.qpm != self.qpm:
+          raise MultipleTempoException(
+              'NoteSequence has at least one tempo change.')
+    else:
+      self.qpm = constants.DEFAULT_QUARTERS_PER_MINUTE
 
     # Compute quantization steps per second.
     steps_per_second = steps_per_quarter * self.qpm / 60.0

--- a/magenta/music/sequences_lib.py
+++ b/magenta/music/sequences_lib.py
@@ -15,8 +15,11 @@
 
 import collections
 import copy
-from magenta.protobuf import music_pb2
+
+# internal imports
+
 from magenta.music import constants
+from magenta.protobuf import music_pb2
 
 # Set the quantization cutoff.
 # Note events before this cutoff are rounded down to nearest step. Notes

--- a/magenta/pipelines/pipelines_common.py
+++ b/magenta/pipelines/pipelines_common.py
@@ -40,10 +40,16 @@ class Quantizer(pipeline.Pipeline):
       quantized_sequence.from_note_sequence(note_sequence,
                                             self._steps_per_quarter)
       return [quantized_sequence]
-    except sequences_lib.MultipleTimeSignatureException:
-      tf.logging.debug('Multiple time signatures found in NoteSequence')
+    except sequences_lib.MultipleTimeSignatureException as e:
+      tf.logging.debug('Multiple time signatures found in NoteSequence %s: %s',
+                       note_sequence.)
       self._set_stats([statistics.Counter(
           'sequences_discarded_because_multiple_time_signatures', 1)])
+      return []
+    except sequences_lib.MultipleTempoException:
+      tf.logging.debug('Multiple tempos found in NoteSequence')
+      self._set_stats([statistics.Counter(
+          'sequences_discarded_because_multiple_tempos', 1)])
       return []
 
 

--- a/magenta/pipelines/pipelines_common.py
+++ b/magenta/pipelines/pipelines_common.py
@@ -42,12 +42,13 @@ class Quantizer(pipeline.Pipeline):
       return [quantized_sequence]
     except sequences_lib.MultipleTimeSignatureException as e:
       tf.logging.debug('Multiple time signatures found in NoteSequence %s: %s',
-                       note_sequence.)
+                       note_sequence.filename, e)
       self._set_stats([statistics.Counter(
           'sequences_discarded_because_multiple_time_signatures', 1)])
       return []
-    except sequences_lib.MultipleTempoException:
-      tf.logging.debug('Multiple tempos found in NoteSequence')
+    except sequences_lib.MultipleTempoException as e:
+      tf.logging.debug('Multiple tempos found in NoteSequence %s: %s',
+                       note_sequence.filename, e)
       self._set_stats([statistics.Counter(
           'sequences_discarded_because_multiple_tempos', 1)])
       return []


### PR DESCRIPTION
Don't allow implicit or explicit time signature or tempo changes.

This is in preparation for #307, so that when we switch to using
NoteSequences, it's clear that time signature and tempo changes don't
change and therefore don't need to be aligned.
