### PR TITLE
Fix PolyphonicSequence.set_length on partial sequences (without END)

### DIFF
--- a/magenta/models/polyphonic_rnn/polyphony_lib.py
+++ b/magenta/models/polyphonic_rnn/polyphony_lib.py
@@ -136,7 +136,7 @@ class PolyphonicSequence(events_lib.EventSequence):
   def _trim_steps(self, num_steps):
     """Trims a given number of steps from the end of the sequence."""
     steps_trimmed = 0
-    for i in reversed(range(len(self._events) - 1)):
+    for i in reversed(range(len(self._events))):
       if self._events[i].event_type == PolyphonicEvent.STEP_END:
         if steps_trimmed == num_steps:
           del self._events[i + 1:]

--- a/magenta/models/polyphonic_rnn/polyphony_lib_test.py
+++ b/magenta/models/polyphonic_rnn/polyphony_lib_test.py
@@ -194,6 +194,24 @@ class PolyphonyLibTest(tf.test.TestCase):
     ]
     self.assertEqual(poly_events, list(poly_seq))
 
+  def testSetLengthAddStepsToUnfinished(self):
+    poly_seq = polyphony_lib.PolyphonicSequence(steps_per_quarter=1)
+
+    # Construct a list with one silence step and no END.
+    pe = polyphony_lib.PolyphonicEvent
+    poly_seq.append(pe(pe.STEP_END, None))
+
+    poly_seq.set_length(2)
+    poly_events = [
+        pe(pe.START, None),
+
+        pe(pe.STEP_END, None),
+        pe(pe.STEP_END, None),
+
+        pe(pe.END, None),
+    ]
+    self.assertEqual(poly_events, list(poly_seq))
+
   def testSetLengthRemoveSteps(self):
     poly_seq = polyphony_lib.PolyphonicSequence(steps_per_quarter=1)
 
@@ -242,6 +260,24 @@ class PolyphonyLibTest(tf.test.TestCase):
     poly_seq.set_length(0)
     poly_events = [
         pe(pe.START, None),
+
+        pe(pe.END, None),
+    ]
+    self.assertEqual(poly_events, list(poly_seq))
+
+  def testSetLengthRemoveStepsFromUnfinished(self):
+    poly_seq = polyphony_lib.PolyphonicSequence(steps_per_quarter=1)
+
+    # Construct a list with two silence steps and no END.
+    pe = polyphony_lib.PolyphonicEvent
+    poly_seq.append(pe(pe.STEP_END, None))
+    poly_seq.append(pe(pe.STEP_END, None))
+
+    poly_seq.set_length(1)
+    poly_events = [
+        pe(pe.START, None),
+
+        pe(pe.STEP_END, None),
 
         pe(pe.END, None),
     ]


### PR DESCRIPTION
`_trim_steps()` mistakenly assumes sequences always end with an `END` event and skips the last event. However, while generating sequences, it is possible to call `set_length()` on unfinished sequences and `_trim_steps()` would fail as the last event would be `STEP_END` instead.

Also add test cases to cover this.

---------------------

An example failure happened [here](https://github.com/tensorflow/magenta/blob/master/magenta/models/polyphonic_rnn/polyphony_sequence_generator.py#L134). The full traceback:

```
WARNING:tensorflow:No priming sequence specified. Defaulting to silence.
INFO:tensorflow:hparams = {'rnn_layer_sizes': [256, 256, 256], 'decay_rate': 0.95, 'dropout_keep_prob': 1.0, 'batch_size': 1, 'decay_steps': 1000, 'clip_norm': 5, 'initial_learning_rate': 0.001, 'skip_first_n_losses': 10}
WARNING:tensorflow:<tensorflow.python.ops.rnn_cell.BasicLSTMCell object at 0x7f27065cad50>: Using a concatenated state is slower and will soon be deprecated.  Use state_is_tuple=True.
WARNING:tensorflow:<tensorflow.python.ops.rnn_cell.BasicLSTMCell object at 0x7f2703a73690>: Using a concatenated state is slower and will soon be deprecated.  Use state_is_tuple=True.
WARNING:tensorflow:<tensorflow.python.ops.rnn_cell.BasicLSTMCell object at 0x7f2703a73510>: Using a concatenated state is slower and will soon be deprecated.  Use state_is_tuple=True.
INFO:tensorflow:Checkpoint used: /magenta-data/leo3/train/model.ckpt-10
INFO:tensorflow:Need to generate 120 more steps for this sequence, will try asking for 600 RNN steps
INFO:tensorflow:Beam search yields sequence with log-likelihood: -2083.229592 
Traceback (most recent call last):
  File "/magenta/bazel-bin/magenta/models/polyphonic_rnn/polyphonic_rnn_generate.runfiles/__main__/magenta/models/polyphonic_rnn/polyphonic_rnn_generate.py", line 262, in <module>
    console_entry_point()
  File "/magenta/bazel-bin/magenta/models/polyphonic_rnn/polyphonic_rnn_generate.runfiles/__main__/magenta/models/polyphonic_rnn/polyphonic_rnn_generate.py", line 258, in console_entry_point
    tf.app.run(main)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/platform/app.py", line 43, in run
    sys.exit(main(sys.argv[:1] + flags_passthrough))
  File "/magenta/bazel-bin/magenta/models/polyphonic_rnn/polyphonic_rnn_generate.runfiles/__main__/magenta/models/polyphonic_rnn/polyphonic_rnn_generate.py", line 254, in main
    run_with_flags(generator)
  File "/magenta/bazel-bin/magenta/models/polyphonic_rnn/polyphonic_rnn_generate.runfiles/__main__/magenta/models/polyphonic_rnn/polyphonic_rnn_generate.py", line 224, in run_with_flags
    generated_sequence = generator.generate(primer_sequence, generator_options)
  File "/magenta/bazel-bin/magenta/models/polyphonic_rnn/polyphonic_rnn_generate.runfiles/__main__/magenta/music/sequence_generator.py", line 204, in generate
    return self._generate(input_sequence, generator_options)
  File "/magenta/bazel-bin/magenta/models/polyphonic_rnn/polyphonic_rnn_generate.runfiles/__main__/magenta/models/polyphonic_rnn/polyphony_sequence_generator.py", line 134, in _generate
    poly_seq.set_length(total_steps)
  File "/magenta/bazel-bin/magenta/models/polyphonic_rnn/polyphonic_rnn_generate.runfiles/__main__/magenta/models/polyphonic_rnn/polyphony_lib.py", line 172, in set_length
    assert self.num_steps == steps
AssertionError
```

With this fix, the assertion holds and the generation works as expected.