### PR TITLE
Fix up to work with TF v1.0 API.

### DIFF
--- a/magenta/models/rl_tuner/rl_tuner_ops.py
+++ b/magenta/models/rl_tuner/rl_tuner_ops.py
@@ -297,17 +297,14 @@ def make_rnn_cell(rnn_layer_sizes, state_is_tuple=False):
         and cell matrix as a state instead of a concatenated matrix.
 
   Returns:
-      A tf.contrib.rnn.rnn_cell.MultiRNNCell based on the given
-      hyperparameters.
+      A tf.contrib.rnn.MultiRNNCell based on the given hyperparameters.
   """
   cells = []
   for num_units in rnn_layer_sizes:
-    cell = tf.contrib.rnn.rnn_cell.LSTMCell(
-        num_units, state_is_tuple=state_is_tuple)
+    cell = tf.contrib.rnn.LSTMCell(num_units, state_is_tuple=state_is_tuple)
     cells.append(cell)
 
-  cell = tf.contrib.rnn.rnn_cell.MultiRNNCell(
-      cells, state_is_tuple=state_is_tuple)
+  cell = tf.contrib.rnn.MultiRNNCell(cells, state_is_tuple=state_is_tuple)
 
   return cell
 

--- a/magenta/models/rl_tuner/rl_tuner_ops.py
+++ b/magenta/models/rl_tuner/rl_tuner_ops.py
@@ -21,7 +21,6 @@ import random
 
 import numpy as np
 import tensorflow as tf
-from tensorflow.contrib.rnn import rnn_cell
 
 from magenta.common import tf_lib
 
@@ -298,15 +297,17 @@ def make_rnn_cell(rnn_layer_sizes, state_is_tuple=False):
         and cell matrix as a state instead of a concatenated matrix.
 
   Returns:
-      A rnn_cell.MultiRNNCell based on the given hyperparameters.
+      A tf.contrib.rnn.rnn_cell.MultiRNNCell based on the given
+      hyperparameters.
   """
   cells = []
   for num_units in rnn_layer_sizes:
-    cell = rnn_cell.LSTMCell(
+    cell = tf.contrib.rnn.rnn_cell.LSTMCell(
         num_units, state_is_tuple=state_is_tuple)
     cells.append(cell)
 
-  cell = rnn_cell.MultiRNNCell(cells, state_is_tuple=state_is_tuple)
+  cell = tf.contrib.rnn.rnn_cell.MultiRNNCell(
+      cells, state_is_tuple=state_is_tuple)
 
   return cell
 

--- a/magenta/models/rl_tuner/rl_tuner_ops.py
+++ b/magenta/models/rl_tuner/rl_tuner_ops.py
@@ -21,6 +21,7 @@ import random
 
 import numpy as np
 import tensorflow as tf
+from tensorflow.contrib.rnn import rnn_cell
 
 from magenta.common import tf_lib
 
@@ -297,15 +298,15 @@ def make_rnn_cell(rnn_layer_sizes, state_is_tuple=False):
         and cell matrix as a state instead of a concatenated matrix.
 
   Returns:
-      A tf.nn.rnn_cell.MultiRNNCell based on the given hyperparameters.
+      A rnn_cell.MultiRNNCell based on the given hyperparameters.
   """
   cells = []
   for num_units in rnn_layer_sizes:
-    cell = tf.nn.rnn_cell.LSTMCell(
+    cell = rnn_cell.LSTMCell(
         num_units, state_is_tuple=state_is_tuple)
     cells.append(cell)
 
-  cell = tf.nn.rnn_cell.MultiRNNCell(cells, state_is_tuple=state_is_tuple)
+  cell = rnn_cell.MultiRNNCell(cells, state_is_tuple=state_is_tuple)
 
   return cell
 

--- a/magenta/models/shared/events_rnn_graph.py
+++ b/magenta/models/shared/events_rnn_graph.py
@@ -15,14 +15,13 @@
 
 # internal imports
 import tensorflow as tf
-from tensorflow.contrib.rnn import rnn_cell
 import magenta
 
 
 def make_rnn_cell(rnn_layer_sizes,
                   dropout_keep_prob=1.0,
                   attn_length=0,
-                  base_cell=rnn_cell.BasicLSTMCell,
+                  base_cell=tf.contrib.rnn.rnn_cell.BasicLSTMCell,
                   state_is_tuple=False):
   """Makes a RNN cell from the given hyperparameters.
 
@@ -32,21 +31,23 @@ def make_rnn_cell(rnn_layer_sizes,
     dropout_keep_prob: The float probability to keep the output of any given
         sub-cell.
     attn_length: The size of the attention vector.
-    base_cell: The base rnn_cell.RnnCell to use for sub-cells.
+    base_cell: The base tf.contrib.rnn.rnn_cell.RnnCell to use for sub-cells.
     state_is_tuple: A boolean specifying whether to use tuple of hidden matrix
         and cell matrix as a state instead of a concatenated matrix.
 
   Returns:
-      A rnn_cell.MultiRNNCell based on the given hyperparameters.
+      A tf.contrib.rnn.rnn_cell.MultiRNNCell based on the given
+      hyperparameters.
   """
   cells = []
   for num_units in rnn_layer_sizes:
     cell = base_cell(num_units, state_is_tuple=state_is_tuple)
-    cell = rnn_cell.DropoutWrapper(
+    cell = tf.contrib.rnn.rnn_cell.DropoutWrapper(
         cell, output_keep_prob=dropout_keep_prob)
     cells.append(cell)
 
-  cell = rnn_cell.MultiRNNCell(cells, state_is_tuple=state_is_tuple)
+  cell = tf.contrib.rnn.rnn_cell.MultiRNNCell(
+      cells, state_is_tuple=state_is_tuple)
   if attn_length:
     cell = tf.contrib.rnn.AttentionCellWrapper(
         cell, attn_length, state_is_tuple=state_is_tuple)

--- a/magenta/models/shared/events_rnn_graph.py
+++ b/magenta/models/shared/events_rnn_graph.py
@@ -21,7 +21,7 @@ import magenta
 def make_rnn_cell(rnn_layer_sizes,
                   dropout_keep_prob=1.0,
                   attn_length=0,
-                  base_cell=tf.contrib.rnn.rnn_cell.BasicLSTMCell,
+                  base_cell=tf.contrib.rnn.BasicLSTMCell,
                   state_is_tuple=False):
   """Makes a RNN cell from the given hyperparameters.
 
@@ -31,23 +31,21 @@ def make_rnn_cell(rnn_layer_sizes,
     dropout_keep_prob: The float probability to keep the output of any given
         sub-cell.
     attn_length: The size of the attention vector.
-    base_cell: The base tf.contrib.rnn.rnn_cell.RnnCell to use for sub-cells.
+    base_cell: The base tf.contrib.rnn.RNNCell to use for sub-cells.
     state_is_tuple: A boolean specifying whether to use tuple of hidden matrix
         and cell matrix as a state instead of a concatenated matrix.
 
   Returns:
-      A tf.contrib.rnn.rnn_cell.MultiRNNCell based on the given
-      hyperparameters.
+      A tf.contrib.rnn.MultiRNNCell based on the given hyperparameters.
   """
   cells = []
   for num_units in rnn_layer_sizes:
     cell = base_cell(num_units, state_is_tuple=state_is_tuple)
-    cell = tf.contrib.rnn.rnn_cell.DropoutWrapper(
+    cell = tf.contrib.rnn.DropoutWrapper(
         cell, output_keep_prob=dropout_keep_prob)
     cells.append(cell)
 
-  cell = tf.contrib.rnn.rnn_cell.MultiRNNCell(
-      cells, state_is_tuple=state_is_tuple)
+  cell = tf.contrib.rnn.MultiRNNCell(cells, state_is_tuple=state_is_tuple)
   if attn_length:
     cell = tf.contrib.rnn.AttentionCellWrapper(
         cell, attn_length, state_is_tuple=state_is_tuple)

--- a/magenta/models/shared/events_rnn_graph.py
+++ b/magenta/models/shared/events_rnn_graph.py
@@ -15,13 +15,14 @@
 
 # internal imports
 import tensorflow as tf
+from tensorflow.contrib.rnn import rnn_cell
 import magenta
 
 
 def make_rnn_cell(rnn_layer_sizes,
                   dropout_keep_prob=1.0,
                   attn_length=0,
-                  base_cell=tf.nn.rnn_cell.BasicLSTMCell,
+                  base_cell=rnn_cell.BasicLSTMCell,
                   state_is_tuple=False):
   """Makes a RNN cell from the given hyperparameters.
 
@@ -31,21 +32,21 @@ def make_rnn_cell(rnn_layer_sizes,
     dropout_keep_prob: The float probability to keep the output of any given
         sub-cell.
     attn_length: The size of the attention vector.
-    base_cell: The base tf.nn.rnn_cell.RnnCell to use for sub-cells.
+    base_cell: The base rnn_cell.RnnCell to use for sub-cells.
     state_is_tuple: A boolean specifying whether to use tuple of hidden matrix
         and cell matrix as a state instead of a concatenated matrix.
 
   Returns:
-      A tf.nn.rnn_cell.MultiRNNCell based on the given hyperparameters.
+      A rnn_cell.MultiRNNCell based on the given hyperparameters.
   """
   cells = []
   for num_units in rnn_layer_sizes:
     cell = base_cell(num_units, state_is_tuple=state_is_tuple)
-    cell = tf.nn.rnn_cell.DropoutWrapper(
+    cell = rnn_cell.DropoutWrapper(
         cell, output_keep_prob=dropout_keep_prob)
     cells.append(cell)
 
-  cell = tf.nn.rnn_cell.MultiRNNCell(cells, state_is_tuple=state_is_tuple)
+  cell = rnn_cell.MultiRNNCell(cells, state_is_tuple=state_is_tuple)
   if attn_length:
     cell = tf.contrib.rnn.AttentionCellWrapper(
         cell, attn_length, state_is_tuple=state_is_tuple)


### PR DESCRIPTION
rnn_cell has moved to tensorflow.contrib.rnn. This change was made in
v0.12 [1].

[1] See https://github.com/tensorflow/tensorflow/commit/37fbebdd6c3c8f274896cc36e6feb5b7e2097a59