### PR TITLE
Adding ranges for the softmax temperature control.

### DIFF
--- a/magenta/interfaces/midi/magenta_midi.py
+++ b/magenta/interfaces/midi/magenta_midi.py
@@ -90,8 +90,8 @@ tf.app.flags.DEFINE_integer(
     'temperature_control_number',
     None,
     'The control change number to use for controlling softmax temperature.'
-    'This should be an integer between 0 and 127 corresponding to a softmax '
-    'temperature between 0.1 and 2.')
+    'The value of control changes with this number will be used to set the '
+    'temperature in a linear range between 0.1 and 2.') 
 tf.app.flags.DEFINE_boolean(
     'allow_overlap',
     False,

--- a/magenta/interfaces/midi/magenta_midi.py
+++ b/magenta/interfaces/midi/magenta_midi.py
@@ -89,7 +89,7 @@ tf.app.flags.DEFINE_integer(
 tf.app.flags.DEFINE_integer(
     'temperature_control_number',
     None,
-    'The control change number to use for controlling softmax temperature.')
+    'The control change number to use for controlling softmax temperature. This should be an integer between 0 and 127 corresponding to a softmax temperature between 0.1 and 2.')
 tf.app.flags.DEFINE_boolean(
     'allow_overlap',
     False,

--- a/magenta/interfaces/midi/magenta_midi.py
+++ b/magenta/interfaces/midi/magenta_midi.py
@@ -89,7 +89,9 @@ tf.app.flags.DEFINE_integer(
 tf.app.flags.DEFINE_integer(
     'temperature_control_number',
     None,
-    'The control change number to use for controlling softmax temperature. This should be an integer between 0 and 127 corresponding to a softmax temperature between 0.1 and 2.')
+    'The control change number to use for controlling softmax temperature.'
+    'This should be an integer between 0 and 127 corresponding to a softmax '
+    'temperature between 0.1 and 2.')
 tf.app.flags.DEFINE_boolean(
     'allow_overlap',
     False,


### PR DESCRIPTION
The temperature_control_number on magenta_midi represents a temperature, but the range is not immediately clear. By adding details in the flag definition users can more easily understand how to tune the temperature.