### PR TITLE
Specify dep for IPython

### DIFF
--- a/magenta/tools/pip/setup.py
+++ b/magenta/tools/pip/setup.py
@@ -24,13 +24,14 @@ execfile('magenta/version.py')
 
 
 REQUIRED_PACKAGES = [
-    'intervaltree >= 2.1.0',
-    'mido >= 1.1.17',
+    'IPython',
     'Pillow >= 3.4.2',
+    'intervaltree >= 2.1.0',
+    'matplotlib >= 1.5.3',
+    'mido >= 1.1.17',
     'pretty_midi >= 0.2.6',
     'scipy >= 0.18.1',
     'tensorflow >= 1.0.0',
-    'matplotlib >= 1.5.3',
     'wheel',
 ]
 


### PR DESCRIPTION
Required by notebook_utils. It's usually already installed in a conda environment, but we should specify it for people not using conda.

Fixes #540.