### PR TITLE
Fixed polyphony generate index error when primer melody present

### DIFF
--- a/magenta/music/encoder_decoder.py
+++ b/magenta/music/encoder_decoder.py
@@ -288,7 +288,8 @@ class EventSequenceEncoderDecoder(object):
       loglik = 0.0
       for position in range(len(event_sequences[i]) - 1):
         index = self.events_to_label(event_sequences[i], position + 1)
-        loglik += np.log(softmax[i][position][index])
+        if position < len(softmax[i]):
+          loglik += np.log(softmax[i][position][index])
       all_loglik.append(loglik)
     return all_loglik
 


### PR DESCRIPTION
Fixed index out of bound error when executing polyphony_rnn_generate with --primer_melody parameter.

Fixes this error:
`IndexError: index 2 is out of bounds for axis 0 with size 2`

This error can be recreated by executing this command that can be found on the official polyphony_rnn page [here](https://github.com/tensorflow/magenta/tree/master/magenta/models/polyphony_rnn)
`polyphony_rnn_generate \
--bundle_file=${BUNDLE_PATH} \
--output_dir=/tmp/polyphony_rnn/generated \
--num_outputs=10 \
--num_steps=64 \
--primer_melody="[60, -2, -2, -2, 60, -2, -2, -2, "\
"67, -2, -2, -2, 67, -2, -2, -2, 69, -2, -2, -2, "\
"69, -2, -2, -2, 67, -2, -2, -2, -2, -2, -2, -2]" \
--condition_on_primer=false \
--inject_primer_during_generation=true`


Full traceback:
`Traceback (most recent call last):
  File "/home/mark/miniconda2/envs/magenta/bin/polyphony_rnn_generate", line 11, in <module>
    sys.exit(console_entry_point())
  File "/home/mark/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/models/polyphony_rnn/polyphony_rnn_generate.py", line 278, in console_entry_point
    tf.app.run(main)
  File "/home/mark/miniconda2/envs/magenta/lib/python2.7/site-packages/tensorflow/python/platform/app.py", line 43, in run
    sys.exit(main(sys.argv[:1] + flags_passthrough))
  File "/home/mark/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/models/polyphony_rnn/polyphony_rnn_generate.py", line 274, in main
    run_with_flags(generator)
  File "/home/mark/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/models/polyphony_rnn/polyphony_rnn_generate.py", line 244, in run_with_flags
    generated_sequence = generator.generate(primer_sequence, generator_options)
  File "/home/mark/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/music/sequence_generator.py", line 204, in generate
    return self._generate(input_sequence, generator_options)
  File "/home/mark/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/models/polyphony_rnn/polyphony_sequence_generator.py", line 172, in _generate
    len(poly_seq) + rnn_steps_to_gen, poly_seq, **args)
  File "/home/mark/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/models/polyphony_rnn/polyphony_model.py", line 54, in generate_polyphonic_sequence
    modify_events_callback=modify_events_callback)
  File "/home/mark/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/models/shared/events_rnn_model.py", line 409, in _generate_events
    control_events, modify_events_callback)
  File "/home/mark/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/models/shared/events_rnn_model.py", line 343, in _beam_search
    final_state, temperature)
  File "/home/mark/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/models/shared/events_rnn_model.py", line 214, in _generate_branches
    all_event_sequences, all_inputs, all_final_state, temperature)
  File "/home/mark/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/models/shared/events_rnn_model.py", line 153, in _generate_step
    temperature)
  File "/home/mark/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/models/shared/events_rnn_model.py", line 111, in _generate_step_for_batch
    event_sequences, softmax)
  File "/home/mark/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/music/encoder_decoder.py", line 291, in evaluate_log_likelihood
    loglik += np.log(softmax[i][position][index])
IndexError: index 2 is out of bounds for axis 0 with size 2`