### PR TITLE
Support output files in current directory without './'

### DIFF
--- a/magenta/scripts/convert_dir_to_note_sequences.py
+++ b/magenta/scripts/convert_dir_to_note_sequences.py
@@ -168,9 +168,10 @@ def main(unused_argv):
     return
 
   input_dir = os.path.expanduser(FLAGS.input_dir)
+  output_dir = os.path.dirname(output_file)
   output_file = os.path.expanduser(FLAGS.output_file)
 
-  if not os.path.exists(os.path.dirname(output_file)):
+  if output_dir != '' and not os.path.exists(output_dir):
     os.makedirs(os.path.dirname(output_file))
 
   with note_sequence_io.NoteSequenceRecordWriter(

--- a/magenta/scripts/convert_dir_to_note_sequences.py
+++ b/magenta/scripts/convert_dir_to_note_sequences.py
@@ -171,8 +171,8 @@ def main(unused_argv):
   output_dir = os.path.dirname(output_file)
   output_file = os.path.expanduser(FLAGS.output_file)
 
-  if output_dir != '' and not os.path.exists(output_dir):
-    os.makedirs(os.path.dirname(output_file))
+  if output_dir:
+    tf.gfile.MakeDirs(output_dir)
 
   with note_sequence_io.NoteSequenceRecordWriter(
       output_file) as sequence_writer:


### PR DESCRIPTION
convert_dir_to_note_sequences.py doesn't support specifying an output file in the current directory unless the user prefixes it with './' or uses the full path. This is because the script tries to create the output dir '' (empty string) which fails. This fixes the problem by not creating an output_dir if the output_file doesn't contain a directory component. 

Example command that is fixed by this change:
$ convert_dir_to_note_sequences --input_dir=lmd_matched --output_file output.tfrecord --recursive