### PR TITLE
Fix processing a sequence without notes

### DIFF
--- a/magenta/music/midi_io.py
+++ b/magenta/music/midi_io.py
@@ -197,7 +197,7 @@ def sequence_proto_to_pretty_midi(
                        else constants.STANDARD_PPQ)
 
   max_event_time = None
-  if drop_events_n_seconds_after_last_note is not None:
+  if drop_events_n_seconds_after_last_note is not None and sequence.notes:
     max_event_time = (max([n.end_time for n in sequence.notes]) +
                       drop_events_n_seconds_after_last_note)
 

--- a/magenta/music/midi_io.py
+++ b/magenta/music/midi_io.py
@@ -197,8 +197,8 @@ def sequence_proto_to_pretty_midi(
                        else constants.STANDARD_PPQ)
 
   max_event_time = None
-  if drop_events_n_seconds_after_last_note is not None and sequence.notes:
-    max_event_time = (max([n.end_time for n in sequence.notes]) +
+  if drop_events_n_seconds_after_last_note is not None:
+    max_event_time = (max([n.end_time for n in sequence.notes] or [0]) +
                       drop_events_n_seconds_after_last_note)
 
   # Try to find a tempo at time zero. The list is not guaranteed to be in order.

--- a/magenta/music/midi_io_test.py
+++ b/magenta/music/midi_io_test.py
@@ -265,6 +265,21 @@ class MidiIoTest(tf.test.TestCase):
         multi_tempo_sequence_proto, drop_events_n_seconds_after_last_note=30)
     self.CheckPrettyMidiAndSequence(translated_midi, multi_tempo_sequence_proto)
 
+  def testEmptySequenceToPrettyMidi_DropEventsAfterLastNote(self):
+    source_sequence = music_pb2.NoteSequence()
+
+    # Translate without dropping.
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        source_sequence)
+    self.assertEqual(1, len(translated_midi.instruments))
+    self.assertEqual(0, len(translated_midi.instruments[0].notes))
+
+    # Translate dropping anything after 30 seconds.
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        source_sequence, drop_events_n_seconds_after_last_note=30)
+    self.assertEqual(1, len(translated_midi.instruments))
+    self.assertEqual(0, len(translated_midi.instruments[0].notes))
+
   def testSimpleReadWriteMidi(self):
     self.CheckReadWriteMidi(self.midi_simple_filename)
 

--- a/magenta/music/midi_io_test.py
+++ b/magenta/music/midi_io_test.py
@@ -123,7 +123,7 @@ class MidiIoTest(tf.test.TestCase):
         seq_instruments.keys(),
         key=lambda (instr, program, is_drum): (instr, program, is_drum))
 
-    if len(seq_instruments) > 0:
+    if seq_instruments:
       self.assertEqual(len(midi.instruments), len(seq_instruments))
     else:
       self.assertEqual(1, len(midi.instruments))

--- a/magenta/music/midi_io_test.py
+++ b/magenta/music/midi_io_test.py
@@ -123,7 +123,13 @@ class MidiIoTest(tf.test.TestCase):
         seq_instruments.keys(),
         key=lambda (instr, program, is_drum): (instr, program, is_drum))
 
-    self.assertEqual(len(midi.instruments), len(seq_instruments))
+    if len(seq_instruments) > 0:
+      self.assertEqual(len(midi.instruments), len(seq_instruments))
+    else:
+      self.assertEqual(1, len(midi.instruments))
+      self.assertEqual(0, len(midi.instruments[0].notes))
+      self.assertEqual(0, len(midi.instruments[0].pitch_bends))
+
     for midi_instrument, seq_instrument_key in zip(
         midi.instruments, sorted_seq_instrument_keys):
 
@@ -279,6 +285,23 @@ class MidiIoTest(tf.test.TestCase):
         source_sequence, drop_events_n_seconds_after_last_note=30)
     self.assertEqual(1, len(translated_midi.instruments))
     self.assertEqual(0, len(translated_midi.instruments[0].notes))
+
+  def testNonEmptySequenceWithNoNotesToPrettyMidi_DropEventsAfterLastNote(self):
+    source_sequence = music_pb2.NoteSequence()
+    source_sequence.tempos.add(time=0, qpm=120)
+    source_sequence.tempos.add(time=10, qpm=160)
+    source_sequence.tempos.add(time=40, qpm=240)
+
+    # Translate without dropping.
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        source_sequence)
+    self.CheckPrettyMidiAndSequence(translated_midi, source_sequence)
+
+    # Translate dropping anything after 30 seconds.
+    translated_midi = midi_io.sequence_proto_to_pretty_midi(
+        source_sequence, drop_events_n_seconds_after_last_note=30)
+    del source_sequence.tempos[-1]
+    self.CheckPrettyMidiAndSequence(translated_midi, source_sequence)
 
   def testSimpleReadWriteMidi(self):
     self.CheckReadWriteMidi(self.midi_simple_filename)


### PR DESCRIPTION
Bug occurred only when drop_events_n_seconds_after_last_note was used.