### PR TITLE
Fixed decoder implicit transpose in rl_tuner_ops

### DIFF
--- a/magenta/models/rl_tuner/rl_tuner_ops.py
+++ b/magenta/models/rl_tuner/rl_tuner_ops.py
@@ -200,7 +200,7 @@ def decoder(event_list, transpose_amount):
     Integer list of MIDI values.
   """
   return [e - NUM_SPECIAL_EVENTS if e < NUM_SPECIAL_EVENTS else
-          e + INITIAL_MIDI_VALUE - transpose_amount for e in event_list]
+          e - NUM_SPECIAL_EVENTS + INITIAL_MIDI_VALUE - transpose_amount for e in event_list]
 
 
 def make_onehot(int_list, one_hot_length):


### PR DESCRIPTION
Each entry in event_list is a list where 0 and 1 are special values, 2 is C, and so on. When transpose_amount is 0 (ie stay in C major) and e is 2 (ie C),we expect 48 since that is the midi value for C. In the original code,

e + INITIAL_MIDI_VALUE - transpose_amount = 2 + 48 - 0 = 50 != 48

As a result, C major melodies are transposed to D major without specifying it.