### PR TITLE
Modify sustain handling to behave more like how the MAPS dataset interprets sustain

### DIFF
--- a/magenta/music/BUILD
+++ b/magenta/music/BUILD
@@ -507,7 +507,6 @@ py_library(
         "//magenta/pipelines:pipeline",
         "//magenta/pipelines:statistics",
         "//magenta/protobuf:music_py_pb2",
-        # intervaltree dep
         # tensorflow dep
     ],
 )


### PR DESCRIPTION
Start with this sequence of repeated notes of the same pitch:

```
x-- x-- x--
```

After applying sustain, the previous version would have modified it to be:

```
x----------
    x------
        x--
```

This version modifies it to be:

```
x---x---x--
```