### PR TITLE
add hparams to drums_rnn_generate example command

### DIFF
--- a/magenta/models/drums_rnn/README.md
+++ b/magenta/models/drums_rnn/README.md
@@ -107,6 +107,7 @@ At least one note needs to be fed to the model before it can start generating co
 drums_rnn_generate \
 --config=drum_kit \
 --run_dir=/tmp/drums_rnn/logdir/run1 \
+--hparams="{'batch_size':64,'rnn_layer_sizes':[64,64]}" \
 --output_dir=/tmp/drums_rnn/generated \
 --num_outputs=10 \
 --num_steps=128 \


### PR DESCRIPTION
otherwise i get a crash:
```
Traceback (most recent call last):
  File "/Users/jon/miniconda2/envs/magenta/bin/drums_rnn_generate", line 11, in <module>
    sys.exit(console_entry_point())
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/models/drums_rnn/drums_rnn_generate.py", line 248, in console_entry_point
    tf.app.run(main)
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/tensorflow/python/platform/app.py", line 48, in run
    _sys.exit(main(_sys.argv[:1] + flags_passthrough))
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/models/drums_rnn/drums_rnn_generate.py", line 244, in main
    run_with_flags(generator)
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/models/drums_rnn/drums_rnn_generate.py", line 215, in run_with_flags
    generated_sequence = generator.generate(input_sequence, generator_options)
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/music/sequence_generator.py", line 203, in generate
    self.initialize()
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/music/sequence_generator.py", line 149, in initialize
    self._model.initialize_with_checkpoint(checkpoint_file)
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/music/model.py", line 63, in initialize_with_checkpoint
    saver.restore(self._session, checkpoint_file)
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/tensorflow/python/training/saver.py", line 1457, in restore
    {self.saver_def.filename_tensor_name: save_path})
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/tensorflow/python/client/session.py", line 778, in run
    run_metadata_ptr)
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/tensorflow/python/client/session.py", line 982, in _run
    feed_dict_string, options, run_metadata)
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/tensorflow/python/client/session.py", line 1032, in _do_run
    target_list, options, run_metadata)
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/tensorflow/python/client/session.py", line 1052, in _do_call
    raise type(e)(node_def, op, message)
tensorflow.python.framework.errors_impl.NotFoundError: Key rnn/attention_cell_wrapper/multi_rnn_cell/cell_2/basic_lstm_cell/weights not found in checkpoint
	 [[Node: save/RestoreV2_14 = RestoreV2[dtypes=[DT_FLOAT], _device="/job:localhost/replica:0/task:0/cpu:0"](_recv_save/Const_0, save/RestoreV2_14/tensor_names, save/RestoreV2_14/shape_and_slices)]]

Caused by op u'save/RestoreV2_14', defined at:
  File "/Users/jon/miniconda2/envs/magenta/bin/drums_rnn_generate", line 11, in <module>
    sys.exit(console_entry_point())
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/models/drums_rnn/drums_rnn_generate.py", line 248, in console_entry_point
    tf.app.run(main)
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/tensorflow/python/platform/app.py", line 48, in run
    _sys.exit(main(_sys.argv[:1] + flags_passthrough))
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/models/drums_rnn/drums_rnn_generate.py", line 244, in main
    run_with_flags(generator)
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/models/drums_rnn/drums_rnn_generate.py", line 215, in run_with_flags
    generated_sequence = generator.generate(input_sequence, generator_options)
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/music/sequence_generator.py", line 203, in generate
    self.initialize()
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/music/sequence_generator.py", line 149, in initialize
    self._model.initialize_with_checkpoint(checkpoint_file)
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/magenta/music/model.py", line 60, in initialize_with_checkpoint
    saver = tf.train.Saver()
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/tensorflow/python/training/saver.py", line 1056, in __init__
    self.build()
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/tensorflow/python/training/saver.py", line 1086, in build
    restore_sequentially=self._restore_sequentially)
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/tensorflow/python/training/saver.py", line 691, in build
    restore_sequentially, reshape)
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/tensorflow/python/training/saver.py", line 407, in _AddRestoreOps
    tensors = self.restore_op(filename_tensor, saveable, preferred_shard)
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/tensorflow/python/training/saver.py", line 247, in restore_op
    [spec.tensor.dtype])[0])
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/tensorflow/python/ops/gen_io_ops.py", line 669, in restore_v2
    dtypes=dtypes, name=name)
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/tensorflow/python/framework/op_def_library.py", line 768, in apply_op
    op_def=op_def)
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/tensorflow/python/framework/ops.py", line 2336, in create_op
    original_op=self._default_original_op, op_def=op_def)
  File "/Users/jon/miniconda2/envs/magenta/lib/python2.7/site-packages/tensorflow/python/framework/ops.py", line 1228, in __init__
    self._traceback = _extract_stack()

NotFoundError (see above for traceback): Key rnn/attention_cell_wrapper/multi_rnn_cell/cell_2/basic_lstm_cell/weights not found in checkpoint
	 [[Node: save/RestoreV2_14 = RestoreV2[dtypes=[DT_FLOAT], _device="/job:localhost/replica:0/task:0/cpu:0"](_recv_save/Const_0, save/RestoreV2_14/tensor_names, save/RestoreV2_14/shape_and_slices)]]
```