### PR TITLE
sketch_rnn training bugfix: eval_model_params.is_training=1

### DIFF
--- a/magenta/models/sketch_rnn/sketch_rnn_train.py
+++ b/magenta/models/sketch_rnn/sketch_rnn_train.py
@@ -131,7 +131,7 @@ def load_dataset(data_dir, model_params, inference_mode=False):
   eval_model_params.use_input_dropout = 0
   eval_model_params.use_recurrent_dropout = 0
   eval_model_params.use_output_dropout = 0
-  eval_model_params.is_training = 0
+  eval_model_params.is_training = 1
 
   sample_model_params = sketch_rnn_model.copy_hparams(eval_model_params)
   sample_model_params.batch_size = 1  # only sample one at a time


### PR DESCRIPTION
hmm, perhaps i'm the first person to attempt training a sketch_rnn model?

when I tried the code as-is, I get the stacktrace:

```bash
Traceback (most recent call last):
  File "sketch_rnn_train.py", line 435, in <module>
    console_entry_point()
  File "sketch_rnn_train.py", line 431, in console_entry_point
    tf.app.run(main)
  File ".../lib/python2.7/site-packages/tensorflow/python/platform/app.py", line 48, in run
    _sys.exit(main(_sys.argv[:1] + flags_passthrough))
  File "sketch_rnn_train.py", line 427, in main
    trainer(model_params)
  File "sketch_rnn_train.py", line 419, in trainer
    train(sess, model, eval_model, train_set, valid_set, test_set)
  File "sketch_rnn_train.py", line 302, in train
    sess, eval_model, valid_set)
  File "sketch_rnn_train.py", line 184, in evaluate_model
    kl_cost) = sess.run([model.cost, model.r_cost, model.kl_cost], feed)
AttributeError: 'Model' object has no attribute 'cost'
```

the simplest fix seemed to be to set `eval_model_params.is_training=1` since evaluate_model references model.cost, but that is only initialized if the model is training.

this change at least resolved the issue for me.
