### PR TITLE
Fast WaveNet generation using queues (NSynth)

### DIFF
--- a/magenta/models/nsynth/wavenet/BUILD
+++ b/magenta/models/nsynth/wavenet/BUILD
@@ -31,6 +31,27 @@ py_library(
 )
 
 py_library(
+    name = "fastgen",
+    srcs = ["fastgen.py"],
+    deps = [
+        # tensorflow dep
+    ],
+)
+
+py_library(
+    name = "generate",
+    srcs = [
+        "generate.py",
+    ],
+    deps = [
+        ":configs",
+        "//magenta/models/nsynth:utils",
+        # numpy dep
+        # tensorflow dep
+    ],
+)
+
+py_library(
     name = "config_library",
     deps = [
         "//magenta/models/nsynth:reader",

--- a/magenta/models/nsynth/wavenet/fastgen.py
+++ b/magenta/models/nsynth/wavenet/fastgen.py
@@ -1,0 +1,93 @@
+"""Utilities for "fast" wavenet generation with queues.
+
+For more information, see:
+
+Ramachandran, P., Le Paine, T., Khorrami, P., Babaeizadeh, M.,
+Chang, S., Zhang, Y., … Huang, T. (2017).
+Fast Generation For Convolutional Autoregressive Models, 1–5.
+"""
+import tensorflow as tf
+
+
+def causal_linear(x, n_inputs, n_outputs, name, filter_length, rate, batch_size):
+  """Applies dilated convolution using queues.
+
+  Assumes a filter_length of 3.
+
+  Args:
+    x: The [mb, time, channels] tensor input.
+    n_inputs: The input number of channels.
+    n_outputs: The output number of channels.
+    name: The variable scope to provide to W and biases.
+    filter_length: The length of the convolution, assumed to be 3.
+    rate: The rate or dilation
+    batch_size: Non-symbolic value for batch_size.
+
+  Returns:
+    y: The output of the operation
+    (init_1, init_2): Initialization operations for the queues
+    (push_1, push_2): Push operations for the queues
+  """
+  assert(filter_length == 3)
+
+  # create queue
+  q_1 = tf.FIFOQueue(
+      rate,
+      dtypes=tf.float32,
+      shapes=(batch_size, n_inputs))
+  q_2 = tf.FIFOQueue(
+      rate,
+      dtypes=tf.float32,
+      shapes=(batch_size, n_inputs))
+  init_1 = q_1.enqueue_many(
+      tf.zeros((rate, batch_size, n_inputs)))
+  init_2 = q_2.enqueue_many(
+      tf.zeros((rate, batch_size, n_inputs)))
+  state_1 = q_1.dequeue()
+  push_1 = q_1.enqueue(x)
+  state_2 = q_2.dequeue()
+  push_2 = q_2.enqueue(state_1)
+
+  # get pretrained weights
+  W = tf.get_variable(
+      name=name + '/W',
+      shape=[1, filter_length, n_inputs, n_outputs],
+      dtype=tf.float32)
+  b = tf.get_variable(
+      name=name + '/biases',
+      shape=[n_outputs],
+      dtype=tf.float32)
+  W_q_2 = tf.slice(W, [0, 0, 0, 0], [-1, 1, -1, -1])
+  W_q_1 = tf.slice(W, [0, 1, 0, 0], [-1, 1, -1, -1])
+  W_x = tf.slice(W, [0, 2, 0, 0], [-1, 1, -1, -1])
+
+  # perform op w/ cached states
+  y = tf.expand_dims(tf.nn.bias_add(
+      tf.matmul(state_2, W_q_2[0][0]) +
+      tf.matmul(state_1, W_q_1[0][0]) +
+      tf.matmul(x, W_x[0][0]),
+      b), 0)
+  return y, (init_1, init_2), (push_1, push_2)
+
+
+def linear(x, n_inputs, n_outputs, name):
+  """Simple linear layer.
+
+  Args:
+    x: The [mb, time, channels] tensor input.
+    n_inputs: The input number of channels.
+    n_outputs: The output number of channels.
+    name: The variable scope to provide to W and biases.
+
+  Returns:
+    y: The output of the operation.
+  """
+  W = tf.get_variable(
+      name=name + '/W',
+      shape=[1, 1, n_inputs, n_outputs],
+      dtype=tf.float32)
+  b = tf.get_variable(
+      name=name + '/biases',
+      shape=[n_outputs],
+      dtype=tf.float32)
+  return tf.expand_dims(tf.nn.bias_add(tf.matmul(x[0], W[0][0]), b), 0)

--- a/magenta/models/nsynth/wavenet/generate.py
+++ b/magenta/models/nsynth/wavenet/generate.py
@@ -1,0 +1,146 @@
+import tensorflow as tf
+from scipy.io import wavfile
+from magenta.models.nsynth import utils
+from magenta.models.nsynth.wavenet.h512_bo16 import Config, FastGenerationConfig
+import numpy as np
+
+
+def inv_mu_law(x, mu=255.0):
+  """A numpy implementation of inverse Mu-Law.
+  Args:
+    x: The Mu-Law samples to decode.
+    mu: The Mu we used to encode these samples.
+  Returns:
+    out: The decoded data.
+  """
+  x = np.array(x).astype(np.float32)
+  out = (x + 0.5) * 2. / (mu + 1)
+  out = np.sign(out) / mu * ((1 + mu)**np.abs(out) - 1)
+  out = np.where(np.equal(x, 0), x, out)
+  return out
+
+
+def load_audio(wav_file, sample_length=64000):
+  """Padded loading of a wave file.
+  Args:
+    wav_file: Location of a wave file to load.
+    sample_length: The total length of the final wave file, padded with 0s.
+  Returns:
+    out: The padded audio in samples from -1.0 to 1.0
+  """
+  wav_data = np.array([utils.load_wav(wav_file)[:sample_length]])
+  wav_data_padded = np.zeros((1, sample_length))
+  wav_data_padded[0, :min(sample_length, wav_data.shape[1])] = wav_data
+  wav_data = wav_data_padded
+  return wav_data
+
+
+def load_nsynth(batch_size=1, sample_length=64000):
+  """Load the NSynth autoencoder network.
+  Args:
+    batch_size: Batch size number of observations to process. [1]
+    sample_length: Number of samples in the input audio. [64000]
+  Returns:
+    graph: The network as a dict with input placeholder in {'X'}
+  """
+  config = Config()
+  with tf.device('/gpu:0'):
+    X = tf.placeholder(
+      tf.float32, shape=[batch_size, sample_length])
+    graph = config.build({"wav": X}, is_training=False)
+    graph.update({'X': X})
+  return graph
+
+
+def load_fastgen_nsynth(batch_size=1, sample_length=64000):
+  """Load the NSynth fast generation network.
+  Args:
+    batch_size: Batch size number of observations to process. [1]
+    sample_length: Number of samples in the input audio. [64000]
+  Returns:
+    graph: The network as a dict with input placeholder in {'X'}
+  """
+  config = FastGenerationConfig()
+  X = tf.placeholder(
+    tf.float32, shape=[batch_size, 1])
+  graph = config.build({"wav": X})
+  graph.update({'X': X})
+  return graph
+
+
+def encode(wav_file, ckpt_path, sample_length=64000):
+  """Padded loading of a wave file.
+  Args:
+    wav_file: Location of a wave file to load.
+    ckpt_path: Location of the pretrained model.
+    sample_length: The total length of the final wave file, padded with 0s.
+  Returns:
+    encoding: a [mb, 125, 16] encoding (for 64000 sample audio file).
+  """
+
+  # Audio to resynthesize
+  wav_data = load_audio(wav_file, sample_length)
+
+  # Load up the model for encoding and find the encoding of 'wav_data'
+  with tf.Graph().as_default(), tf.Session(
+          config=tf.ConfigProto(allow_soft_placement=True)) as sess:
+    net = load_nsynth()
+    saver = tf.train.Saver()
+    saver.restore(sess, ckpt_path)
+    encoding = sess.run(net['encoding'], feed_dict={
+      net['X']: wav_data})[0]
+
+  return encoding
+
+
+def synthesize(wav_file,
+               ckpt_path='model.ckpt-200000',
+               out_file='synthesis.wav',
+               sample_length=64000,
+               synth_length=64000):
+  """Resynthesize an input audio file.
+
+  Args:
+    wav_file: Location of a wave file to load.
+    ckpt_path: Location of the pretrained model. [model.ckpt-200000]
+    out_file: Location to save the synthesized wave file. [synthesis.wav]
+    sample_length: The total length of the input wave file, padded with 0s. [64000]
+    synth_length: The total length to synthesize. [64000]
+  """
+
+  # Load up the model for encoding and find the encoding
+  encoding = encode(wav_file, ckpt_path)
+  encoding_length = encoding.shape[0]
+
+  with tf.Graph().as_default(), tf.Session(
+          config=tf.ConfigProto(allow_soft_placement=True)) as sess:
+    net = load_fastgen_nsynth()
+    saver = tf.train.Saver()
+    saver.restore(sess, ckpt_path)
+
+    # initialize queues w/ 0s
+    sess.run(net['init_ops'])
+
+    # Regenerate the audio file sample by sample
+    wav_synth = np.zeros((sample_length,),
+        dtype=np.float32)
+    audio = np.float32(0)
+
+    for sample_i in range(synth_length):
+      enc_i = int(sample_i /
+        float(sample_length) *
+        float(encoding_length))
+      res = sess.run(
+          [net['predictions'], net['push_ops']],
+          feed_dict={
+            net['X']: np.atleast_2d(audio),
+            net['encoding']: encoding[enc_i]})[0]
+      cdf = np.cumsum(res)
+      idx = np.random.rand()
+      i = 0
+      while(cdf[i] < idx):
+        i = i + 1
+      audio = inv_mu_law(i - 128)
+      wav_synth[sample_i] = audio
+
+  wavfile.write(out_file, 16000, wav_synth)

--- a/magenta/models/nsynth/wavenet/h512_bo16.py
+++ b/magenta/models/nsynth/wavenet/h512_bo16.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""A WaveNet-style AutoEncoder Configuration."""
+"""A WaveNet-style AutoEncoder Configuration and FastGeneration Config."""
 
 # internal imports
 import tensorflow as tf
@@ -19,6 +19,116 @@ import tensorflow as tf
 from magenta.models.nsynth import reader
 from magenta.models.nsynth import utils
 from magenta.models.nsynth.wavenet import masked
+from magenta.models.nsynth.wavenet import fastgen
+
+
+class FastGenerationConfig(object):
+  """Configuration object that helps manage the graph."""
+
+  def __init__(self):
+    """."""
+
+
+  def build(self, inputs):
+    """Build the graph for this configuration.
+
+    Args:
+      inputs: A dict of inputs. For training, should contain 'wav'.
+      is_training: Whether we are training or not. Not used in this config.
+
+    Returns:
+      A dict of outputs that includes the 'predictions', 'init_ops', the 'push_ops',
+      and the 'quantized_input'.
+    """
+    num_stages = 10
+    num_layers = 30
+    filter_length = 3
+    width = 512
+    skip_width = 256
+    num_z = 16
+
+    # Encode the source with 8-bit Mu-Law.
+    x = inputs['wav']
+    batch_size = 1
+    x_quantized = utils.mu_law(x)
+    x_scaled = tf.cast(x_quantized, tf.float32) / 128.0
+    x_scaled = tf.expand_dims(x_scaled, 2)
+
+    encoding = tf.placeholder(
+        name='encoding',
+        shape=[num_z],
+        dtype=tf.float32)
+    en = tf.expand_dims(tf.expand_dims(encoding, 0), 0)
+
+    init_ops, push_ops = [], []
+
+    ###
+    # The WaveNet Decoder.
+    ###
+    l = x_scaled
+    l, inits, pushs = fastgen.causal_linear(
+        x=l[0],
+        n_inputs=1,
+        n_outputs=width,
+        name='startconv',
+        rate=1,
+        batch_size=batch_size,
+        filter_length=filter_length)
+    [init_ops.append(init) for init in inits]
+    [push_ops.append(push) for push in pushs]
+
+    # Set up skip connections.
+    s = fastgen.linear(l, width, skip_width, name='skip_start')
+
+    # Residual blocks with skip connections.
+    for i in range(num_layers):
+      dilation = 2**(i % num_stages)
+
+      # dilated masked cnn
+      d, inits, pushs = fastgen.causal_linear(
+          x=l[0],
+          n_inputs=width,
+          n_outputs=width * 2,
+          name='dilatedconv_%d' % (i + 1),
+          rate=dilation,
+          batch_size=batch_size,
+          filter_length=filter_length)
+      [init_ops.append(init) for init in inits]
+      [push_ops.append(push) for push in pushs]
+
+      # local conditioning
+      d = d + fastgen.linear(en, num_z, width * 2, name='cond_map_%d' % (i + 1))
+
+      # gated cnn
+      assert d.get_shape().as_list()[2] % 2 == 0
+      m = d.get_shape().as_list()[2] // 2
+      d = tf.sigmoid(d[:, :, :m]) * tf.tanh(d[:, :, m:])
+
+      # residuals
+      l += fastgen.linear(d, width, width, name='res_%d' % (i + 1))
+
+      # skips
+      s += fastgen.linear(d, width, skip_width, name='skip_%d' % (i + 1))
+
+    s = tf.nn.relu(s)
+    s = fastgen.linear(s, skip_width, skip_width, name='out1') + \
+        fastgen.linear(en, num_z, skip_width, name='cond_map_out1')
+    s = tf.nn.relu(s)
+
+    ###
+    # Compute the logits and get the loss.
+    ###
+    logits = fastgen.linear(s, skip_width, 256, name='logits')
+    logits = tf.reshape(logits, [-1, 256])
+    probs = tf.nn.softmax(logits, name='softmax')
+
+    return {
+      'init_ops': init_ops,
+      'push_ops': push_ops,
+      'predictions': probs,
+      'encoding': encoding,
+      'quantized_input': x_quantized,
+    }
 
 
 class Config(object):

--- a/magenta/tools/pip/BUILD
+++ b/magenta/tools/pip/BUILD
@@ -74,5 +74,16 @@ sh_binary(
         # SketchRNN Model and Scripts
         "//magenta/models/sketch_rnn",
         "//magenta/models/sketch_rnn:sketch_rnn_train",
+
+        # NSynth
+        "//magenta/models/nsynth:utils",
+        "//magenta/models/nsynth:reader",
+        "//magenta/models/nsynth/wavenet:train.py",
+        "//magenta/models/nsynth/wavenet:h512_bo16.py",
+        "//magenta/models/nsynth/wavenet:masked.py",
+        "//magenta/models/nsynth/wavenet:generate.py",
+        "//magenta/models/nsynth/wavenet:fastgen.py",
+        "//magenta/models/nsynth/wavenet:save_embeddings.py",
+
     ],
 )


### PR DESCRIPTION
Here is an implementation of using queues for the WaveNet decoder in NSynth as described in:
Ramachandran, P., Le Paine, T., Khorrami, P., Babaeizadeh, M., Chang, S., Zhang, Y., … Huang, T. (2017). Fast Generation For Convolutional Autoregressive Models, 1–5.

This should let you encode using the existing NSynth model and then synthesize from any encoding using a much faster method than the current approach.  You can generate a 4 second audio file in a few minutes this way, which isn't terrible.  I can get about 100 samples per second using this method (not at all accurate measurements), which means a 4 second clip @ 16 KHz can be synthesized in about 10 minutes.  You can potentially use this to also explore different encodings from interpolation or encode your own sounds and explore their syntheses with this generation method much more easily than before.

There is no CLI tool I'm afraid but I'm hoping someone else can develop that to make it easier for others!  This just includes a simple python module `magenta.models.nsynth.wavenet.generate` which includes a function `synthesize` showing how to use the `FastGenerationConfig` to load an audio file, encode it, and then synthesize from the encoding.

Lastly, I wasn't familiar with the BUILD system so please let me know if that looks okay.