### PR TITLE
sketch_rnn: allow loading of multiple datasets

### DIFF
--- a/magenta/models/sketch_rnn/sketch_rnn_train.py
+++ b/magenta/models/sketch_rnn/sketch_rnn_train.py
@@ -102,19 +102,44 @@ def load_dataset(data_dir, model_params, inference_mode=False):
   # normalizes the x and y columns usint the training set.
   # applies same scaling factor to valid and test set.
 
-  data_filepath = os.path.join(data_dir, model_params.data_set)
-  if data_dir.startswith('http://') or data_dir.startswith('https://'):
-    tf.logging.info('Downloading %s', data_filepath)
-    response = requests.get(data_filepath)
-    data = np.load(StringIO(response.content))
+  datasets = []
+  if isinstance(model_params.data_set, list):
+    datasets = model_params.data_set
   else:
-    data = np.load(data_filepath)  # load this into dictionary
+    datasets = [model_params.data_set]
 
-  train_strokes = data['train']
-  valid_strokes = data['valid']
-  test_strokes = data['test']
+  train_strokes = None
+  valid_strokes = None
+  test_strokes = None
+
+  for dataset in datasets:
+    data_filepath = os.path.join(data_dir, dataset)
+    if data_dir.startswith('http://') or data_dir.startswith('https://'):
+      tf.logging.info('Downloading %s', data_filepath)
+      response = requests.get(data_filepath)
+      data = np.load(StringIO(response.content))
+    else:
+      data = np.load(data_filepath)  # load this into dictionary
+    tf.logging.info("Loaded {}/{}/{} from {}".format(
+      len(data['train']), len(data['valid']), len(data['test']),
+      dataset))
+    if train_strokes is None:
+      train_strokes = data['train']
+      valid_strokes = data['valid']
+      test_strokes = data['test']
+    else:
+      train_strokes = np.concatenate((train_strokes, data['train']))
+      valid_strokes = np.concatenate((valid_strokes, data['valid']))
+      test_strokes = np.concatenate((test_strokes, data['test']))
 
   all_strokes = np.concatenate((train_strokes, valid_strokes, test_strokes))
+  num_points = 0
+  for stroke in all_strokes:
+    num_points += len(stroke)
+  avg_len = num_points / len(all_strokes)
+  tf.logging.info("Dataset combined: {} ({}/{}/{}), avg len {}".format(
+    len(all_strokes), len(train_strokes), len(valid_strokes),
+    len(test_strokes), int(avg_len)))
 
   # calculate the max strokes we need.
   max_seq_len = utils.get_max_len(all_strokes)


### PR DESCRIPTION
A simple extension to allow training on the concatenation of multiple
datasets, as was done in the paper. This is done by passing an array in the existing
hparams.data_set field. Change was made backwards compatible.

Some dataset diagnostics were also added to the output. Sample output below.
```bash
INFO:tensorflow:data_set = ['horse.npz', 'zebra.npz']
...
INFO:tensorflow:Loading data files.
INFO:tensorflow:Loaded 70000/2500/2500 from horse.npz
INFO:tensorflow:Loaded 70000/2500/2500 from zebra.npz
INFO:tensorflow:Dataset combined: 150000 (140000/5000/5000), avg len 60
```