### PR TITLE
AttributeError: 'module' object has no attribute 'ZeroDivisionError'

### DIFF
--- a/magenta/pipelines/melody_pipelines.py
+++ b/magenta/pipelines/melody_pipelines.py
@@ -54,5 +54,9 @@ class MelodyExtractor(pipeline.Pipeline):
       tf.logging.warning('Skipped sequence: %s', detail)
       melodies = []
       stats = [statistics.Counter('non_integer_steps_per_bar', 1)]
+    except ZeroDivisionError as detail:
+      tf.logging.warning('Skipped sequence: %s', detail)
+      melodies = []
+      stats = [statistics.Counter('zero_division_error', 1)]
     self._set_stats(stats)
     return melodies

--- a/magenta/scripts/convert_dir_to_note_sequences.py
+++ b/magenta/scripts/convert_dir_to_note_sequences.py
@@ -70,7 +70,7 @@ def convert_directory(root_dir, sub_dir, sequence_writer, recursive=False):
   """
   dir_to_convert = os.path.join(root_dir, sub_dir)
   tf.logging.info("Converting files in '%s'.", dir_to_convert)
-  files_in_dir = tf.gfile.ListDirectory(os.path.join(dir_to_convert))
+  files_in_dir = tf.gfile.ListDirectory(os.path.join(dir_to_convert)).lower()
   recurse_sub_dirs = []
   sequences_written = 0
   sequences_skipped = 0


### PR DESCRIPTION
This pull request is from #673.
When I am trying to convert sequence to sequence examples for training rnn model.
I got this error message.

> Traceback (most recent call last):
> File "/Users/user/Desktop/magenta2/magenta/models/melody_rnn/melody_rnn_create_dataset.py", line 139, in 
> console_entry_point()
> File "/Users/user/Desktop/magenta2/magenta/models/melody_rnn/melody_rnn_create_dataset.py", line 135, in console_entry_point
> tf.app.run(main)
> File "/anaconda/envs/python27/lib/python2.7/site-packages/tensorflow/python/platform/app.py", line 48, in run
> _sys.exit(main(sys.argv[:1] + flags_passthrough))
> File "/Users/user/Desktop/magenta2/magenta/models/melody_rnn/melody_rnn_create_dataset.py", line 131, in main
> FLAGS.output_dir)
> File "/Users/user/Desktop/magenta2/magenta/pipelines/pipeline.py", line 371, in run_pipeline_serial
> for name, outputs in guarantee_dict(pipeline.transform(input),
> File "/Users/user/Desktop/magenta2/magenta/pipelines/dag_pipeline.py", line 509, in transform
> stats_accumulator(unit, unit_inputs, stats))
> File "/Users/user/Desktop/magenta2/magenta/pipelines/dag_pipeline.py", line 489, in stats_accumulator
> results = unit.transform(single_input)
> File "/Users/user/Desktop/magenta2/magenta/pipelines/melody_pipelines.py", line 57, in transform
> except events_lib.ZeroDivisionError as detail:
> AttributeError: 'module' object has no attribute 'ZeroDivisionError'

To work with magenta, I temporarily modified the
`except events_lib.ZeroDivisionError as detail:`
to
`except ZeroDivisionError as detail:`
in the
/piplines/melody_pipelines.py file