### PR TITLE
hparams fix: update -> parse_json

### DIFF
--- a/magenta/models/sketch_rnn/sketch_rnn_train.py
+++ b/magenta/models/sketch_rnn/sketch_rnn_train.py
@@ -72,8 +72,7 @@ def load_env(data_dir, model_dir):
   """Loads environment for inference mode, used in jupyter notebook."""
   model_params = sketch_rnn_model.get_default_hparams()
   with tf.gfile.Open(os.path.join(model_dir, 'model_config.json'), 'r') as f:
-    model_config = json.load(f)
-    model_params.update(model_config)
+    model_params.parse_json(f.read())
   return load_dataset(data_dir, model_params, inference_mode=True)
 
 
@@ -81,8 +80,7 @@ def load_model(model_dir):
   """Loads model for inference mode, used in jupyter notebook."""
   model_params = sketch_rnn_model.get_default_hparams()
   with tf.gfile.Open(os.path.join(model_dir, 'model_config.json'), 'r') as f:
-    model_config = json.load(f)
-    model_params.update(model_config)
+    model_params.parse_json(f.read())
 
   model_params.batch_size = 1  # only sample one at a time
   eval_model_params = sketch_rnn_model.copy_hparams(model_params)


### PR DESCRIPTION
TF's native HParams does not have an `update` to add/override hyperparams compared with (now retired) magenta HParams class; this PR updates those references to use `parse_json` (https://www.tensorflow.org/versions/r1.2/api_docs/python/tf/contrib/training/HParams#parse_json)