### PR TITLE
NSynth docstring changes. Optional Int8.

### DIFF
--- a/magenta/models/nsynth/utils.py
+++ b/magenta/models/nsynth/utils.py
@@ -66,18 +66,21 @@ def load_audio(path, sample_length=64000, sr=16000):
   return audio
 
 
-def mu_law(x, mu=255):
+def mu_law(x, mu=255, int8=False):
   """A TF implementation of Mu-Law encoding.
 
   Args:
     x: The audio samples to encode.
     mu: The Mu to use in our Mu-Law.
+    int8: Use int8 encoding.
 
   Returns:
     out: The Mu-Law encoded int8 data.
   """
   out = tf.sign(x) * tf.log(1 + mu * tf.abs(x)) / np.log(1 + mu)
-  out = tf.cast(tf.floor(out * 128), tf.int8)
+  out = tf.floor(out * 128)
+  if int8:
+    out = tf.cast(out, tf.int8)
   return out
 
 


### PR DESCRIPTION
Update NSynth docstring and make mu_law tf encoding optionally go through casting to int8 (int8 not used anywhere and it stops gradient flow).