### PR TITLE
fix data_dir of sketch_rnn

### DIFF
--- a/magenta/models/sketch_rnn/sketch_rnn_train.py
+++ b/magenta/models/sketch_rnn/sketch_rnn_train.py
@@ -40,7 +40,7 @@ FLAGS = tf.app.flags.FLAGS
 
 tf.app.flags.DEFINE_string(
     'data_dir',
-    'https://github.com/hardmaru/magenta/raw/master',
+    'https://github.com/hardmaru/sketch-rnn-datasets/raw/master/aaron_sheep',
     'The directory in which to find the dataset specified in model hparams. '
     'If data_dir starts with "http://" or "https://", the file will be fetched '
     'remotely.')


### PR DESCRIPTION
Change the URL of data_dir to 'sketch-rnn-datasets' (Old one was looking at a 404 page).