### PR TITLE
Fix UnboundLocalError in nsynth (#788)

### DIFF
--- a/magenta/models/nsynth/wavenet/nsynth_generate.py
+++ b/magenta/models/nsynth/wavenet/nsynth_generate.py
@@ -61,7 +61,7 @@ def main(unused_argv=None):
         if fname.lower().endswith(postfix)
     ])
 
-  elif source_path.lower().endswith(postfix):
+  elif source_path.lower().endswith((".wav", ".npy")):
     files = [source_path]
   else:
     files = []


### PR DESCRIPTION
Addresses issue #788—enables users to run `nsynth_generate` on a path that is just a filename.