### PR TITLE
Disable midi_hub_test from running unless directly specified.

### DIFF
--- a/magenta/interfaces/midi/BUILD
+++ b/magenta/interfaces/midi/BUILD
@@ -43,6 +43,9 @@ py_test(
     name = "midi_hub_test",
     srcs = ["midi_hub_test.py"],
     srcs_version = "PY2AND3",
+    tags = [
+        "manual",  # TODO(adarob): Remove manual tag once timeout is fixed. #759
+    ],
     deps = [
         ":midi_hub",
         "//magenta",


### PR DESCRIPTION
Until we fix #759.