### PR TITLE
Update links in README.md files throughout the repo to point to jupyter notebooks

### DIFF
--- a/magenta/models/image_stylization/README.md
+++ b/magenta/models/image_stylization/README.md
@@ -11,8 +11,8 @@ Manjunath Kudlur*.
 Whether you want to stylize an image with one of our pre-trained models or train your own model, you need to set up your [Magenta environment](/README.md).
 
 # Jupyter notebook
-There is a [Jupyter notebook][https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/Image_Stylization_demo.ipynb] 
-in our magenta-demos repository which shows how to apply style transfer from a trained model. 
+There is a Jupyter notebook [Image_Stylization.ipynb](https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/Image_Stylization_demo.ipynb) 
+in our [Magenta Demos](https://github.com/tensorflow/magenta-demos) repository showing how to apply style transfer from a trained model. 
 
 # Stylizing an Image
 First, download one of our pre-trained models:

--- a/magenta/models/image_stylization/README.md
+++ b/magenta/models/image_stylization/README.md
@@ -10,6 +10,10 @@ Manjunath Kudlur*.
 # Setup
 Whether you want to stylize an image with one of our pre-trained models or train your own model, you need to set up your [Magenta environment](/README.md).
 
+# Jupyter notebook
+There is a [Jupyter notebook][https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/Image_Stylization_demo.ipynb] 
+in our magenta-demos repository which shows how to apply style transfer from a trained model. 
+
 # Stylizing an Image
 First, download one of our pre-trained models:
 

--- a/magenta/models/image_stylization/README.md
+++ b/magenta/models/image_stylization/README.md
@@ -11,7 +11,7 @@ Manjunath Kudlur*.
 Whether you want to stylize an image with one of our pre-trained models or train your own model, you need to set up your [Magenta environment](/README.md).
 
 # Jupyter notebook
-There is a Jupyter notebook [Image_Stylization.ipynb](https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/Image_Stylization_demo.ipynb) 
+There is a Jupyter notebook [Image_Stylization.ipynb](https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/Image_Stylization.ipynb) 
 in our [Magenta Demos](https://github.com/tensorflow/magenta-demos) repository showing how to apply style transfer from a trained model. 
 
 # Stylizing an Image

--- a/magenta/models/nsynth/README.md
+++ b/magenta/models/nsynth/README.md
@@ -19,8 +19,8 @@ employing a WaveNet-style autoencoder to learn its own temporal embeddings.
 A full description of the algorithm and accompanying dataset can be found in our
 [arXiv paper][arXiv] and [blog post][blog].
 
-We've also provided a Jupyter notebook [NSynth.ipynb](https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/NSynth.ipynb) 
-in our [Magenta Demos](https://github.com/tensorflow/magenta-demos) repository which demonstrates some of the basics of the model.
+A Jupyter notebook [NSynth.ipynb](https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/NSynth.ipynb) 
+found in our [Magenta Demos](https://github.com/tensorflow/magenta-demos) repository shows some creative uses of NSYmth.
 
 # The Models
 

--- a/magenta/models/nsynth/README.md
+++ b/magenta/models/nsynth/README.md
@@ -20,7 +20,7 @@ A full description of the algorithm and accompanying dataset can be found in our
 [arXiv paper][arXiv] and [blog post][blog].
 
 A Jupyter notebook [NSynth.ipynb](https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/NSynth.ipynb) 
-found in our [Magenta Demos](https://github.com/tensorflow/magenta-demos) repository shows some creative uses of NSYmth.
+found in our [Magenta Demos](https://github.com/tensorflow/magenta-demos) repository shows some creative uses of NSynth.
 
 # The Models
 

--- a/magenta/models/nsynth/README.md
+++ b/magenta/models/nsynth/README.md
@@ -19,6 +19,9 @@ employing a WaveNet-style autoencoder to learn its own temporal embeddings.
 A full description of the algorithm and accompanying dataset can be found in our
 [arXiv paper][arXiv] and [blog post][blog].
 
+We've also provided a Jupyter notebook [NSynth.ipynb](https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/NSynth.ipynb) 
+in our [Magenta Demos](https://github.com/tensorflow/magenta-demos) repository which demonstrates some of the basics of the model.
+
 # The Models
 
 This repository contains a baseline spectral autoencoder model and a WaveNet autoencoder model, each in their respective directories. The baseline model uses a spectrogram with fft_size 1024 and hop_size 256, MSE loss on the magnitudes, and the Griffin-Lim algorithm for reconstruction. The WaveNet model trains on mu-law encoded waveform chunks of size 6144. It learns embeddings with 16 dimensions that are downsampled by 512 in time.

--- a/magenta/models/performance_rnn/README.md
+++ b/magenta/models/performance_rnn/README.md
@@ -17,6 +17,11 @@ At generation time, a few undesired behaviors can occur: note-off events with no
 
 First, set up your [Magenta environment](/README.md). Next, you can either use a pre-trained model or train your own.
 
+## Jupyter notebook
+
+There is a Jupyter notebook [Performance_RNN.ipynb](https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/Performance_RNN.ipynb) 
+in our [Magenta Demos](https://github.com/tensorflow/magenta-demos) repository showing how to generate performances from a trained model.
+
 ## Pre-trained
 
 If you want to get started right away, you can use a few models that we've pre-trained on [real performances from the Yamaha e-Piano Competition](http://www.piano-e-competition.com/midiinstructions.asp):

--- a/magenta/models/rl_tuner/README.md
+++ b/magenta/models/rl_tuner/README.md
@@ -69,8 +69,8 @@ environment](/README.md).
 you can either use a pre-trained model or train your own.
 
 To train the model you can use the jupyter notebook
-[RL_Tuner.ipynb](https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/RL_tuner.ipynb) found
-in our [Magenta Demos](https://github.com/tensorflow/magenta-demos) repository or, you can simply run:
+[RL_Tuner.ipynb](https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/RL_Tuner.ipynb) found
+in our [Magenta Demos](https://github.com/tensorflow/magenta-demos) repository or you can simply run:
 
 ```
 rl_tuner_train

--- a/magenta/models/rl_tuner/README.md
+++ b/magenta/models/rl_tuner/README.md
@@ -69,8 +69,8 @@ environment](/README.md).
 you can either use a pre-trained model or train your own.
 
 To train the model you can use the jupyter notebook
-([https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/RL_tuner.ipynb][RL_Tuner.ipynb])
-from the tensorflow/magenta-demos github repository, or, you can simply run:
+[RL_Tuner.ipynb](https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/RL_tuner.ipynb) found
+in our [Magenta Demos](https://github.com/tensorflow/magenta-demos) repository or, you can simply run:
 
 ```
 rl_tuner_train

--- a/magenta/models/rl_tuner/README.md
+++ b/magenta/models/rl_tuner/README.md
@@ -68,8 +68,9 @@ To start using the model, first set up your [Magenta
 environment](/README.md).
 you can either use a pre-trained model or train your own.
 
-To train the model you can use the provided jupyter notebook
-([rl_tuner.ipynb][ipynb]), or, you can simply run:
+To train the model you can use the jupyter notebook
+([https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/RL_tuner.ipynb][RL_Tuner.ipynb])
+from the tensorflow/magenta-demos github repository, or, you can simply run:
 
 ```
 rl_tuner_train

--- a/magenta/models/sketch_rnn/README.md
+++ b/magenta/models/sketch_rnn/README.md
@@ -130,7 +130,7 @@ In addition, we have provided pre-trained models for selected QuickDraw datasets
 
 *Let's get the model to interpolate between a cat and a bus!*
 
-We've included a simple [Jupyter Notebook](http://github.com/tensorflow/magenta/blob/master/magenta/models/sketch_rnn/sketch_rnn.ipynb) to show you how to load a pre-trained model and generate vector sketches.  You will be able to encode, decode, and morph between two vector images, and also generate new random ones.  When sampling images, you can tune the `temperature` parameter to control the level of uncertainty.
+We've included a simple [Jupyter Notebook](http://github.com/tensorflow/magenta-demos/blob/master/jupyter_notebooks/Sketch_RNN.ipynb) to show you how to load a pre-trained model and generate vector sketches.  You will be able to encode, decode, and morph between two vector images, and also generate new random ones.  When sampling images, you can tune the `temperature` parameter to control the level of uncertainty.
 
 # Citation
 

--- a/magenta/models/sketch_rnn/README.md
+++ b/magenta/models/sketch_rnn/README.md
@@ -130,7 +130,7 @@ In addition, we have provided pre-trained models for selected QuickDraw datasets
 
 *Let's get the model to interpolate between a cat and a bus!*
 
-We've included a simple [Jupyter Notebook](http://github.com/tensorflow/magenta-demos/blob/master/jupyter_notebooks/Sketch_RNN.ipynb) to show you how to load a pre-trained model and generate vector sketches.  You will be able to encode, decode, and morph between two vector images, and also generate new random ones.  When sampling images, you can tune the `temperature` parameter to control the level of uncertainty.
+We've included a simple [Jupyter Notebook](https://github.com/tensorflow/magenta-demos/blob/master/jupyter_notebooks/Sketch_RNN.ipynb) to show you how to load a pre-trained model and generate vector sketches.  You will be able to encode, decode, and morph between two vector images, and also generate new random ones.  When sampling images, you can tune the `temperature` parameter to control the level of uncertainty.
 
 # Citation
 

--- a/magenta/models/sketch_rnn/README.md
+++ b/magenta/models/sketch_rnn/README.md
@@ -7,7 +7,7 @@ Before jumping in on any code examples, please first set up your [Magenta enviro
 *Examples of vector images produced by this generative model.*
 
 This repo contains the TensorFlow code for `sketch-rnn`, the recurrent neural network model described in [Teaching Machines to Draw](https://research.googleblog.com/2017/04/teaching-machines-to-draw.html) and [A Neural Representation of Sketch Drawings](https://arxiv.org/abs/1704.03477).
-There is also a Jupyter notebook [Sketch_RNN.ipynb](https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/Sketch_RNN.ipynb) 
+We've also provided a Jupyter notebook [Sketch_RNN.ipynb](https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/Sketch_RNN.ipynb) 
 in our [Magenta Demos](https://github.com/tensorflow/magenta-demos) repository which demonstrates many of the examples discussed here.
 
 

--- a/magenta/models/sketch_rnn/README.md
+++ b/magenta/models/sketch_rnn/README.md
@@ -2,16 +2,13 @@
 
 Before jumping in on any code examples, please first set up your [Magenta environment](/README.md).
 
-## Jupyter notebook
-There is a Jupyter notebook [Sketch_RNN.ipynb](https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/Sketch_RNN.ipynb) 
-in our [Magenta Demos](https://github.com/tensorflow/magenta-demos) repository which demonstrates many of the examples discussed here.
-
 ![Example Images](https://cdn.rawgit.com/tensorflow/magenta/master/magenta/models/sketch_rnn/assets/sketch_rnn_examples.svg)
 
 *Examples of vector images produced by this generative model.*
 
 This repo contains the TensorFlow code for `sketch-rnn`, the recurrent neural network model described in [Teaching Machines to Draw](https://research.googleblog.com/2017/04/teaching-machines-to-draw.html) and [A Neural Representation of Sketch Drawings](https://arxiv.org/abs/1704.03477).
-
+There is also a Jupyter notebook [Sketch_RNN.ipynb](https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/Sketch_RNN.ipynb) 
+in our [Magenta Demos](https://github.com/tensorflow/magenta-demos) repository which demonstrates many of the examples discussed here.
 
 
 

--- a/magenta/models/sketch_rnn/README.md
+++ b/magenta/models/sketch_rnn/README.md
@@ -2,11 +2,18 @@
 
 Before jumping in on any code examples, please first set up your [Magenta environment](/README.md).
 
+## Jupyter notebook
+There is a Jupyter notebook [Sketch_RNN.ipynb](https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/Sketch_RNN.ipynb) 
+in our [Magenta Demos](https://github.com/tensorflow/magenta-demos) repository which demonstrates many of the examples discussed here.
+
 ![Example Images](https://cdn.rawgit.com/tensorflow/magenta/master/magenta/models/sketch_rnn/assets/sketch_rnn_examples.svg)
 
 *Examples of vector images produced by this generative model.*
 
 This repo contains the TensorFlow code for `sketch-rnn`, the recurrent neural network model described in [Teaching Machines to Draw](https://research.googleblog.com/2017/04/teaching-machines-to-draw.html) and [A Neural Representation of Sketch Drawings](https://arxiv.org/abs/1704.03477).
+
+
+
 
 # Overview of Model
 


### PR DESCRIPTION
In some cases, existing links are updated to point to the new location for the notebooks (in magenta-demos). In other cases, a line is added to README.md to help readers find the notebooks.  