### PR TITLE
Add visibility for performance lib to discrete_music_gan.

### DIFF
--- a/magenta/models/performance_rnn/BUILD
+++ b/magenta/models/performance_rnn/BUILD
@@ -31,6 +31,9 @@ py_library(
     name = "performance_lib",
     srcs = ["performance_lib.py"],
     srcs_version = "PY2AND3",
+    visibility = [
+        # internal model:discrete_music_gan
+    ]
     deps = [
         "//magenta",
         # tensorflow dep
@@ -99,6 +102,9 @@ py_library(
     name = "performance_encoder_decoder",
     srcs = ["performance_encoder_decoder.py"],
     srcs_version = "PY2AND3",
+    visibility = [
+        # internal model:discrete_music_gan
+    ]
     deps = [
         ":performance_lib",
         "//magenta",

--- a/magenta/models/performance_rnn/BUILD
+++ b/magenta/models/performance_rnn/BUILD
@@ -33,7 +33,7 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = [
         # internal model:discrete_music_gan
-    ]
+    ],
     deps = [
         "//magenta",
         # tensorflow dep
@@ -104,7 +104,7 @@ py_library(
     srcs_version = "PY2AND3",
     visibility = [
         # internal model:discrete_music_gan
-    ]
+    ],
     deps = [
         ":performance_lib",
         "//magenta",


### PR DESCRIPTION
Eventually these libraries should be moved to magenta/lib but we need this change ASAP.