### PR TITLE
Fix bazel test command for py3

### DIFF
--- a/magenta/common/BUILD
+++ b/magenta/common/BUILD
@@ -38,11 +38,13 @@ py_library(
 py_library(
     name = "beam_search",
     srcs = ["beam_search.py"],
+    srcs_version = "PY2AND3",
 )
 
 py_test(
     name = "beam_search_test",
     srcs = ["beam_search_test.py"],
+    srcs_version = "PY2AND3",
     deps = [
         ":beam_search",
         # tensorflow dep

--- a/magenta/music/BUILD
+++ b/magenta/music/BUILD
@@ -354,6 +354,13 @@ py_library(
     name = "musicnet_io",
     srcs = ["musicnet_io.py"],
     srcs_version = "PY2ONLY",
+    tags = [
+        # Include this tag in order to filter this test out of the suite when
+        # using py3 with --test_tag_filters=-py2only. Necessary because the
+        # musicnet dataset was pickled using py2 and is therefore incompatible
+        # with py3.
+        "py2only"
+    ],
     deps = [
         "//magenta/protobuf:music_py_pb2",
         # intervaltree dep

--- a/magenta/music/BUILD
+++ b/magenta/music/BUILD
@@ -356,7 +356,7 @@ py_library(
     srcs_version = "PY2ONLY",
     tags = [
         # Include this tag in order to filter this target out of the suite when
-        # using py3 with --test_tag_filters=-py2only. Necessary because the
+        # using py3 with --build_tag_filters=-py2only. Necessary because the
         # musicnet dataset was pickled using py2 and is therefore incompatible
         # with py3.
         "py2only"

--- a/magenta/music/BUILD
+++ b/magenta/music/BUILD
@@ -355,7 +355,7 @@ py_library(
     srcs = ["musicnet_io.py"],
     srcs_version = "PY2ONLY",
     tags = [
-        # Include this tag in order to filter this test out of the suite when
+        # Include this tag in order to filter this target out of the suite when
         # using py3 with --test_tag_filters=-py2only. Necessary because the
         # musicnet dataset was pickled using py2 and is therefore incompatible
         # with py3.


### PR DESCRIPTION
Run bazel test //magenta/... --force_python=py3 --test_tag_filters=-py2only --build_tag_filters=-py2only

References #304 