### PR TITLE
Bump version

### DIFF
--- a/magenta/tools/pip/setup.py
+++ b/magenta/tools/pip/setup.py
@@ -90,6 +90,7 @@ setup(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Libraries',

--- a/magenta/version.py
+++ b/magenta/version.py
@@ -17,4 +17,4 @@ Stored in a separate file so that setup.py can reference the version without
 pulling in all the dependencies in __init__.py.
 """
 
-__version__ = '0.2.4'
+__version__ = '0.3.0'


### PR DESCRIPTION
Jumping to 0.3.0 because this is the first pip package that supports Python 3.