### PR TITLE
from six.moves import xrange for Python 3

### DIFF
--- a/magenta/models/nsynth/utils.py
+++ b/magenta/models/nsynth/utils.py
@@ -23,6 +23,7 @@ import os
 # internal imports
 import librosa
 import numpy as np
+from six.moves import xrange
 import tensorflow as tf
 
 slim = tf.contrib.slim


### PR DESCRIPTION
xrange() is called on line 279.