### PR TITLE
Fix encoding issue in pipeline(#861)

### DIFF
--- a/magenta/common/testing_lib.py
+++ b/magenta/common/testing_lib.py
@@ -15,6 +15,7 @@
 
 # internal imports
 import numpy as np
+import six
 
 from google.protobuf import text_format
 
@@ -74,7 +75,11 @@ class MockStringProto(object):
     return MockStringProto(string)
 
   def SerializeToString(self):  # pylint: disable=invalid-name
-    return 'serialized:' + self.string
+    # protobuf's SerializeToString returns binary string
+    if six.PY3:
+      return ('serialized:' + self.string).encode("utf-8")
+    else:
+      return 'serialized:' + self.string
 
   def __eq__(self, other):
     return isinstance(other, MockStringProto) and self.string == other.string

--- a/magenta/pipelines/pipeline.py
+++ b/magenta/pipelines/pipeline.py
@@ -377,10 +377,7 @@ def run_pipeline_serial(pipeline,
     for name, outputs in _guarantee_dict(pipeline.transform(input_),
                                          list(output_names)[0]).items():
       for output in outputs:
-        if six.PY3:
-          writers[name].write(output.SerializeToString().encode('utf-8'))
-        else:
-          writers[name].write(output.SerializeToString())
+        writers[name].write(output.SerializeToString())
       total_outputs += len(outputs)
     stats = statistics.merge_statistics(stats + pipeline.get_stats())
     if total_inputs % 500 == 0:


### PR DESCRIPTION
Fix the issue in pipeline.

* `SerializeToString` returns bytes, so `encode` is needless.
* At the `pipeline_test.py`, `MockStringProto.SerializeToString` behavior differ according to Python2 or Python3. Because Python2 `str` is byte string but Python3 `str` is not.  So `MockStringProto.SerializeToString` returns bytes in Python2 but str in Python3. `SerializeToString` should return bytes as its definition in protobuf, so Python3 behavior has to be fixed.
