### PR TITLE
Change manual install instructions to Python 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ If the automated script fails for any reason, or you'd prefer to install by
 hand, do the following steps.
 
 First, download the
-[Python 2.7 Miniconda installer](http://conda.pydata.org/miniconda.html) (you
+[Python 3.5 Miniconda installer](http://conda.pydata.org/miniconda.html) (you
 can skip this step if you already have any variant of conda installed).
 
-Next, create and activate a Magenta conda environment using Python 2.7 with
+Next, create and activate a Magenta conda environment using Python 3.5 with
 Jupyter notebook support:
 
 ```
-conda create -n magenta python=2.7 jupyter
+conda create -n magenta python=3.5 jupyter
 source activate magenta
 ```
 


### PR DESCRIPTION
Tensorflow recommends Python 3.5 for all operating systems. On windows, using 2.7 will cause an issue where you can't install magenta through pip because Tensorflow for windows doesn't support 2.7. Also, magenta supports Python 3 anyways, so it shouldn't be an issue.