### PR TITLE
Support parsing simple ABC repeats

### DIFF
--- a/magenta/music/BUILD
+++ b/magenta/music/BUILD
@@ -621,6 +621,7 @@ py_test(
     deps = [
         ":midi_io",
         ":abc_parser",
+        ":sequences_lib",
         "//magenta/common:testing_lib",
         "//magenta/protobuf:music_py_pb2",
         # tensorflow dep

--- a/magenta/music/BUILD
+++ b/magenta/music/BUILD
@@ -615,6 +615,7 @@ py_test(
         "testdata/english1.mid",
         "testdata/english2.mid",
         "testdata/english3.mid",
+        "testdata/zocharti_loch.abc",
     ],
     srcs_version = "PY2AND3",
     deps = [

--- a/magenta/music/abc_parser.py
+++ b/magenta/music/abc_parser.py
@@ -512,7 +512,6 @@ class ABCTune(object):
           sg.num_times = 1
 
         self._current_expected_repeats = forward_repeats
-        print('{} - {}/{}'.format(match.group(1), backward_repeats, forward_repeats))
       elif match.re == ABCTune.TEXT_ANNOTATION_PATTERN:
         # Text annotation
         # http://abcnotation.com/wiki/abc:standard:v2.1#chord_symbols

--- a/magenta/music/abc_parser.py
+++ b/magenta/music/abc_parser.py
@@ -294,7 +294,8 @@ class ABCTune(object):
     # This happens if the last line in the piece ends with a :| symbol. A new
     # section is set up to handle upcoming notes, but then the end of the piece
     # is reached.
-    if self._ns.section_annotations[-1].time == self._ns.notes[-1].end_time:
+    if (self._ns.section_annotations and
+        self._ns.section_annotations[-1].time == self._ns.notes[-1].end_time):
       del self._ns.section_annotations[-1]
 
   def _apply_broken_rhythm(self, broken_rhythm):
@@ -410,7 +411,7 @@ class ABCTune(object):
         # http://abcnotation.com/wiki/abc:standard:v2.1#note_lengths
         if match.group(4):
           slash_count = match.group(4).count('/')
-          if slash_count == len(note_match.group(4)):
+          if slash_count == len(match.group(4)):
             # Handle A// shorthand case.
             length /= 2 ** slash_count
           elif match.group(4).startswith('/'):

--- a/magenta/music/abc_parser.py
+++ b/magenta/music/abc_parser.py
@@ -370,7 +370,6 @@ class ABCTune(object):
   # http://abcnotation.com/wiki/abc:standard:v2.1#annotations
   TEXT_ANNOTATION_PATTERN = re.compile(r'"([^"]*)"')
 
-
   def _parse_music_code(self, line):
     """Parse the music code within an ABC file."""
 
@@ -482,7 +481,7 @@ class ABCTune(object):
             raise RepeatParseException(
                 'Colon-only repeats must be divisible by 2: {}'.format(
                     match.group(1)))
-            backward_repeats = forward_repeats = colon_count / 2
+          backward_repeats = forward_repeats = colon_count / 2
         else:
           repeat_match = ABCTune.REPEAT_SYMBOLS_PATTERN.match(match.group(1))
           if not repeat_match:

--- a/magenta/music/abc_parser.py
+++ b/magenta/music/abc_parser.py
@@ -50,6 +50,10 @@ class VariantEndingException(ABCParseException):
   """Variant endings are not yet supported."""
 
 
+class PartException(ABCParseException):
+  """ABC Parts are not yet supported."""
+
+
 def parse_tunebook_file(filename):
   """Parse an ABC Tunebook file."""
   # 'r' mode will decode the file as utf-8 in py3.
@@ -704,7 +708,7 @@ class ABCTune(object):
       pass
     elif field_name == 'P':
       # TODO(fjord): implement part parsing.
-      pass
+      raise PartException('ABC parts are not yet supported.')
     elif field_name == 'Q':
       # Tempo
       # http://abcnotation.com/wiki/abc:standard:v2.1#qtempo

--- a/magenta/music/abc_parser.py
+++ b/magenta/music/abc_parser.py
@@ -232,6 +232,9 @@ class ABCTune(object):
       self._set_values_from_header()
     self._finalize_sections()
 
+    if self._ns.notes:
+      self._ns.total_time = self._ns.notes[-1].end_time
+
   @property
   def note_sequence(self):
     return self._ns

--- a/magenta/music/abc_parser.py
+++ b/magenta/music/abc_parser.py
@@ -97,8 +97,8 @@ def parse_tunebook(tunebook):
       ns = abc_tune.note_sequence
       if ns.reference_number in tunes:
         raise ABCParseException(
-            'ABC Reference number {} appears more than once in this tunebook'.format(
-                ns.reference_number))
+            'ABC Reference number {} appears more than once in this '
+            'tunebook'.format(ns.reference_number))
       tunes[ns.reference_number] = ns
 
   return tunes, exceptions
@@ -378,8 +378,6 @@ class ABCTune(object):
     pos = 0
     broken_rhythm = None
     while pos < len(line):
-      char = line[pos]
-
       match = None
       for regex in [
           ABCTune.NOTE_PATTERN,

--- a/magenta/music/abc_parser.py
+++ b/magenta/music/abc_parser.py
@@ -645,7 +645,7 @@ class ABCTune(object):
     elif field_name == 'U':
       pass
     elif field_name == 'V':
-      pass
+      raise ValueError('Multi-voice files are not currently supported.')
     elif field_name == 'W':
       pass
     elif field_name == 'w':

--- a/magenta/music/abc_parser_test.py
+++ b/magenta/music/abc_parser_test.py
@@ -45,13 +45,6 @@ class AbcParserTest(tf.test.TestCase):
     abc2midi = midi_io.midi_file_to_sequence_proto(
         os.path.join(tf.resource_loader.get_data_files_path(), midi_path))
 
-    # We don't yet support repeats, so just check the first 10 notes and only
-    # the first time signature.
-    del abc2midi.notes[10:]
-    del test.notes[10:]
-    del abc2midi.time_signatures[1:]
-    del test.time_signatures[1:]
-
     # abc2midi adds a 1-tick delay to the start of every note, but we don't.
     tick_length = ((1 / (abc2midi.tempos[0].qpm / 60)) /
                    abc2midi.ticks_per_quarter)

--- a/magenta/music/abc_parser_test.py
+++ b/magenta/music/abc_parser_test.py
@@ -51,7 +51,6 @@ class AbcParserTest(tf.test.TestCase):
                            test.section_groups)
     expanded_test = sequences_lib.expand_section_groups(test)
 
-
     abc2midi = midi_io.midi_file_to_sequence_proto(
         os.path.join(tf.resource_loader.get_data_files_path(), midi_path))
 
@@ -208,7 +207,8 @@ class AbcParserTest(tf.test.TestCase):
                      'testdata/english.abc'))
     self.assertEqual(1, len(tunes))
     self.assertEqual(2, len(exceptions))
-    self.assertTrue(isinstance(exceptions[0], abc_parser.VariantEndingException))
+    self.assertTrue(isinstance(exceptions[0],
+                               abc_parser.VariantEndingException))
     self.assertTrue(isinstance(exceptions[1], abc_parser.PartException))
 
     expected_metadata1 = common_testing_lib.parse_test_proto(

--- a/magenta/music/abc_parser_test.py
+++ b/magenta/music/abc_parser_test.py
@@ -219,6 +219,20 @@ class AbcParserTest(tf.test.TestCase):
         key_signatures {
           key: G
         }
+        section_annotations {
+        }
+        section_annotations {
+          time: 6.0
+          section_id: 1
+        }
+        section_annotations {
+          time: 12.0
+          section_id: 2
+        }
+        section_annotations {
+          time: 18.0
+          section_id: 3
+        }
         """)
     self.compareToAbc2midiAndMetadata(
         'testdata/english1.mid', expected_ns1_metadata, tunes[0])

--- a/magenta/music/abc_parser_test.py
+++ b/magenta/music/abc_parser_test.py
@@ -220,6 +220,8 @@ class AbcParserTest(tf.test.TestCase):
           key: G
         }
         section_annotations {
+          time: 0.0
+          section_id: 0
         }
         section_annotations {
           time: 6.0
@@ -228,10 +230,6 @@ class AbcParserTest(tf.test.TestCase):
         section_annotations {
           time: 12.0
           section_id: 2
-        }
-        section_annotations {
-          time: 18.0
-          section_id: 3
         }
         """)
     self.compareToAbc2midiAndMetadata(

--- a/magenta/music/abc_parser_test.py
+++ b/magenta/music/abc_parser_test.py
@@ -505,5 +505,11 @@ class AbcParserTest(tf.test.TestCase):
         """)
     self.assertProtoEquals(expected_ns1, tunes[0])
 
+  def testMultiVoice(self):
+    with self.assertRaises(abc_parser.MultiVoiceException):
+      abc_parser.parse_tunebook_file(
+          os.path.join(tf.resource_loader.get_data_files_path(),
+                       'testdata/zocharti_loch.abc'))
+
 if __name__ == '__main__':
   tf.test.main()

--- a/magenta/music/abc_parser_test.py
+++ b/magenta/music/abc_parser_test.py
@@ -199,9 +199,10 @@ class AbcParserTest(tf.test.TestCase):
     tunes, exceptions = abc_parser.parse_tunebook_file(
         os.path.join(tf.resource_loader.get_data_files_path(),
                      'testdata/english.abc'))
-    self.assertEqual(2, len(tunes))
-    self.assertEqual(1, len(exceptions))
+    self.assertEqual(1, len(tunes))
+    self.assertEqual(2, len(exceptions))
     self.assertTrue(isinstance(exceptions[0], abc_parser.VariantEndingException))
+    self.assertTrue(isinstance(exceptions[1], abc_parser.PartException))
 
     expected_ns1_metadata = common_testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
@@ -277,29 +278,29 @@ class AbcParserTest(tf.test.TestCase):
     # self.compareToAbc2midiAndMetadata(
     #     'testdata/english2.mid', expected_ns2_metadata, tunes[1])
 
-    expected_ns3_metadata = common_testing_lib.parse_test_proto(
-        music_pb2.NoteSequence,
-        """
-        ticks_per_quarter: 220
-        source_info: {
-          source_type: SCORE_BASED
-          encoding_type: ABC
-          parser: MAGENTA_ABC
-        }
-        reference_number: 3
-        sequence_metadata {
-          title: "William and Nancy; New Mown Hay; Legacy, The"
-          artist: "Trad."
-          composers: "Trad."
-        }
-        key_signatures {
-          key: G
-        }
-        """)
-    # TODO(fjord): verify chord annotations
-    del tunes[3].text_annotations[:]
-    self.compareToAbc2midiAndMetadata(
-        'testdata/english3.mid', expected_ns3_metadata, tunes[3])
+    # expected_ns3_metadata = common_testing_lib.parse_test_proto(
+    #     music_pb2.NoteSequence,
+    #     """
+    #     ticks_per_quarter: 220
+    #     source_info: {
+    #       source_type: SCORE_BASED
+    #       encoding_type: ABC
+    #       parser: MAGENTA_ABC
+    #     }
+    #     reference_number: 3
+    #     sequence_metadata {
+    #       title: "William and Nancy; New Mown Hay; Legacy, The"
+    #       artist: "Trad."
+    #       composers: "Trad."
+    #     }
+    #     key_signatures {
+    #       key: G
+    #     }
+    #     """)
+    # # TODO(fjord): verify chord annotations
+    # del tunes[3].text_annotations[:]
+    # self.compareToAbc2midiAndMetadata(
+    #     'testdata/english3.mid', expected_ns3_metadata, tunes[3])
 
   def testParseOctaves(self):
     tunes, exceptions = abc_parser.parse_tunebook("""X:1

--- a/magenta/music/abc_parser_test.py
+++ b/magenta/music/abc_parser_test.py
@@ -231,6 +231,24 @@ class AbcParserTest(tf.test.TestCase):
           time: 12.0
           section_id: 2
         }
+        section_groups {
+          sections {
+            section_id: 0
+          }
+          num_times: 2
+        }
+        section_groups {
+          sections {
+            section_id: 1
+          }
+          num_times: 2
+        }
+        section_groups {
+          sections {
+            section_id: 2
+          }
+          num_times: 2
+        }
         """)
     self.compareToAbc2midiAndMetadata(
         'testdata/english1.mid', expected_ns1_metadata, tunes[0])

--- a/magenta/music/sequences_lib.py
+++ b/magenta/music/sequences_lib.py
@@ -384,6 +384,7 @@ def expand_section_groups(sequence):
     A new, expanded version of the sequence.
   """
   sections = {}
+  section_durations = {}
   for i in range(len(sequence.section_annotations)):
     section_id = sequence.section_annotations[i].section_id
     start_time = sequence.section_annotations[i].time
@@ -401,6 +402,7 @@ def expand_section_groups(sequence):
     subsequence.section_annotations.add(time=0, section_id=section_id)
 
     sections[section_id] = subsequence
+    section_durations[section_id] = end_time - start_time
 
   # Recursively expand section_groups.
   def sections_in_group(section_group):
@@ -417,7 +419,10 @@ def expand_section_groups(sequence):
   for section_group in sequence.section_groups:
     sections_to_concat.extend(sections_in_group(section_group))
 
-  return concatenate_sequences(*[sections[i] for i in sections_to_concat])
+  import pdb;pdb.set_trace()
+  return concatenate_sequences(
+      [sections[i] for i in sections_to_concat],
+      [section_durations[i] for i in sections_to_concat])
 
 
 def _is_power_of_2(x):

--- a/magenta/music/sequences_lib.py
+++ b/magenta/music/sequences_lib.py
@@ -419,7 +419,6 @@ def expand_section_groups(sequence):
   for section_group in sequence.section_groups:
     sections_to_concat.extend(sections_in_group(section_group))
 
-  import pdb;pdb.set_trace()
   return concatenate_sequences(
       [sections[i] for i in sections_to_concat],
       [section_durations[i] for i in sections_to_concat])

--- a/magenta/music/sequences_lib.py
+++ b/magenta/music/sequences_lib.py
@@ -375,6 +375,14 @@ def concatenate_sequences(sequences, sequence_durations=None):
 
 
 def expand_section_groups(sequence):
+  """Expands a NoteSequence based on its section_groups.
+
+  Args:
+    sequence: The sequence to expand.
+
+  Returns:
+    A new, expanded version of the sequence.
+  """
   sections = {}
   for i in range(len(sequence.section_annotations)):
     section_id = sequence.section_annotations[i].section_id

--- a/magenta/music/sequences_lib_test.py
+++ b/magenta/music/sequences_lib_test.py
@@ -1063,16 +1063,13 @@ class SequencesLibTest(tf.test.TestCase):
   def testRemoveRedundantDataOutOfOrder(self):
     sequence = copy.copy(self.note_sequence)
     meaningful_tempo = sequence.tempos.add()
-    meaningful_tempo.CopyFrom(sequence.tempos[0])
     meaningful_tempo.time = 5.0
     meaningful_tempo.qpm = 50
     redundant_tempo = sequence.tempos.add()
     redundant_tempo.CopyFrom(sequence.tempos[0])
-    redundant_tempo.time = 0.0
 
     expected_sequence = copy.copy(self.note_sequence)
     expected_meaningful_tempo = expected_sequence.tempos.add()
-    expected_meaningful_tempo.CopyFrom(expected_sequence.tempos[0])
     expected_meaningful_tempo.time = 5.0
     expected_meaningful_tempo.qpm = 50
 
@@ -1130,23 +1127,6 @@ class SequencesLibTest(tf.test.TestCase):
     expected.section_annotations.add(time=9, section_id=2)
     expected.section_annotations.add(time=10, section_id=3)
     self.assertProtoEquals(expected, expanded)
-
-
-  def testRemoveRedundantEventsOutOfOrder(self):
-    sequence = copy.copy(self.note_sequence)
-    meaningful_tempo = sequence.tempos.add()
-    meaningful_tempo.time = 5.0
-    meaningful_tempo.qpm = 50
-    redundant_tempo = sequence.tempos.add()
-    redundant_tempo.CopyFrom(sequence.tempos[0])
-
-    expected_sequence = copy.copy(self.note_sequence)
-    expected_meaningful_tempo = expected_sequence.tempos.add()
-    expected_meaningful_tempo.time = 5.0
-    expected_meaningful_tempo.qpm = 50
-
-    fixed_sequence = sequences_lib.remove_redundant_events(sequence)
-    self.assertProtoEquals(expected_sequence, fixed_sequence)
 
 if __name__ == '__main__':
   tf.test.main()

--- a/magenta/music/sequences_lib_test.py
+++ b/magenta/music/sequences_lib_test.py
@@ -1060,6 +1060,25 @@ class SequencesLibTest(tf.test.TestCase):
 
     self.assertProtoEquals(expected_sequence, fixed_sequence)
 
+  def testRemoveRedundantDataOutOfOrder(self):
+    sequence = copy.copy(self.note_sequence)
+    meaningful_tempo = sequence.tempos.add()
+    meaningful_tempo.CopyFrom(sequence.tempos[0])
+    meaningful_tempo.time = 5.0
+    meaningful_tempo.qpm = 50
+    redundant_tempo = sequence.tempos.add()
+    redundant_tempo.CopyFrom(sequence.tempos[0])
+    redundant_tempo.time = 0.0
+
+    expected_sequence = copy.copy(self.note_sequence)
+    expected_meaningful_tempo = expected_sequence.tempos.add()
+    expected_meaningful_tempo.CopyFrom(expected_sequence.tempos[0])
+    expected_meaningful_tempo.time = 5.0
+    expected_meaningful_tempo.qpm = 50
+
+    fixed_sequence = sequences_lib.remove_redundant_data(sequence)
+    self.assertProtoEquals(expected_sequence, fixed_sequence)
+
   def testExpandSectionGroups(self):
     sequence = copy.copy(self.note_sequence)
     testing_lib.add_track_to_sequence(

--- a/magenta/music/sequences_lib_test.py
+++ b/magenta/music/sequences_lib_test.py
@@ -1039,14 +1039,26 @@ class SequencesLibTest(tf.test.TestCase):
         sequence_durations=[2, 1.5, 2])
     self.assertProtoEquals(expected_sequence, cat_seq)
 
-  def testRemoveRedundantEvents(self):
+  def testRemoveRedundantData(self):
     sequence = copy.copy(self.note_sequence)
     redundant_tempo = sequence.tempos.add()
     redundant_tempo.CopyFrom(sequence.tempos[0])
     redundant_tempo.time = 5.0
+    sequence.sequence_metadata.composers.append('Foo')
+    sequence.sequence_metadata.composers.append('Bar')
+    sequence.sequence_metadata.composers.append('Foo')
+    sequence.sequence_metadata.composers.append('Bar')
+    sequence.sequence_metadata.genre.append('Classical')
+    sequence.sequence_metadata.genre.append('Classical')
 
-    fixed_sequence = sequences_lib.remove_redundant_events(sequence)
-    self.assertProtoEquals(self.note_sequence, fixed_sequence)
+    fixed_sequence = sequences_lib.remove_redundant_data(sequence)
+
+    expected_sequence = copy.copy(self.note_sequence)
+    expected_sequence.sequence_metadata.composers.append('Foo')
+    expected_sequence.sequence_metadata.composers.append('Bar')
+    expected_sequence.sequence_metadata.genre.append('Classical')
+
+    self.assertProtoEquals(expected_sequence, fixed_sequence)
 
   def testExpandSectionGroups(self):
     sequence = copy.copy(self.note_sequence)

--- a/magenta/music/testdata/zocharti_loch.abc
+++ b/magenta/music/testdata/zocharti_loch.abc
@@ -1,0 +1,22 @@
+X:1
+T:Zocharti Loch
+C:Louis Lewandowski (1821-1894)
+M:C
+Q:1/4=76
+%%score (T1 T2) (B1 B2)
+V:T1           clef=treble-8  name="Tenore I"   snm="T.I"
+V:T2           clef=treble-8  name="Tenore II"  snm="T.II"
+V:B1  middle=d clef=bass      name="Basso I"    snm="B.I"  transpose=-24
+V:B2  middle=d clef=bass      name="Basso II"   snm="B.II" transpose=-24
+K:Gm
+%            End of header, start of tune body:
+% 1
+[V:T1]  (B2c2 d2g2)  | f6e2      | (d2c2 d2)e2 | d4 c2z2 |
+[V:T2]  (G2A2 B2e2)  | d6c2      | (B2A2 B2)c2 | B4 A2z2 |
+[V:B1]       z8      | z2f2 g2a2 | b2z2 z2 e2  | f4 f2z2 |
+[V:B2]       x8      |     x8    |      x8     |    x8   |
+% 5
+[V:T1]  (B2c2 d2g2)  | f8        | d3c (d2fe)  | H d6    ||
+[V:T2]       z8      |     z8    | B3A (B2c2)  | H A6    ||
+[V:B1]  (d2f2 b2e'2) | d'8       | g3g  g4     | H^f6    ||
+[V:B2]       x8      | z2B2 c2d2 | e3e (d2c2)  | H d6    ||

--- a/magenta/protobuf/music.proto
+++ b/magenta/protobuf/music.proto
@@ -365,6 +365,9 @@ message NoteSequence {
     int64 section_id = 4;
   }
 
+  // A section.
+  // Either a section_id, which references a SectionAnnotation or a nested
+  // SectionGroup.
   message Section {
     oneof section_type {
       int64 section_id = 1;
@@ -372,6 +375,10 @@ message NoteSequence {
     }
   }
 
+  // A group of sections and an indication of how many times to play them.
+  // Note that a SectionGroup may contain nested SectionGroups. This is to
+  // capture some of the more complex structure in ABC files with part
+  // directives like P:((AB)3(CD)3)2.
   message SectionGroup {
     repeated Section sections = 1;
     int32 num_times = 2;

--- a/magenta/protobuf/music.proto
+++ b/magenta/protobuf/music.proto
@@ -77,7 +77,7 @@ message NoteSequence {
   repeated SectionAnnotation section_annotations = 20;
 
   // Instructions on how to play back the sections within a piece.
-  SectionGroup section_playback = 21;
+  repeated SectionGroup section_groups = 21;
 
   // Information about how/if this sequence was quantized.
   QuantizationInfo quantization_info = 15;

--- a/magenta/protobuf/music.proto
+++ b/magenta/protobuf/music.proto
@@ -23,7 +23,7 @@ package tensorflow.magenta;
 // For details see https://www.midi.org/specifications.
 // Note that repeated fields in this proto are not guaranteed to be sorted
 // by time.
-// Next tag: 20
+// Next tag: 22
 message NoteSequence {
   // Unique id.
   string id = 1;
@@ -72,6 +72,12 @@ message NoteSequence {
 
   // Arbitrary textual annotations.
   repeated TextAnnotation text_annotations = 14;
+
+  // Annotations indicating sections within a piece.
+  repeated SectionAnnotation section_annotations = 20;
+
+  // Instructions on how to play back the sections within a piece.
+  SectionGroup section_playback = 21;
 
   // Information about how/if this sequence was quantized.
   QuantizationInfo quantization_info = 15;
@@ -346,6 +352,29 @@ message NoteSequence {
     // Time in seconds from the end of this sequence to the end of the source
     // sequence.
     double end_time_offset = 2;
+  }
+
+  // Information about a section within a piece.
+  // A section is considered to be active from its indicated time until either a
+  // new section is defined or the end of the piece is reached.
+  message SectionAnnotation {
+    // Time in seconds.
+    double time = 1;
+    // The id of the section.
+    // Section ids must be unique within a piece.
+    int64 section_id = 4;
+  }
+
+  message Section {
+    oneof section_type {
+      int64 section_id = 1;
+      SectionGroup section_group = 2;
+    }
+  }
+
+  message SectionGroup {
+    repeated Section sections = 1;
+    int32 num_times = 2;
   }
 }
 


### PR DESCRIPTION
Adds that information as SectionAnnotations and SectionGroups and then "expands" the resulting notesequence so that the repeats are played as indicated. Compares correctly against abc2midi ground truth.

Additional changes:
- Created more specific exceptions
- When parsing a tunebook, some tunes can fail with an exception and others can succeed (instead of the entire file failing)
- Explicitly disallow multi-voice files and files with ABC parts (for now)