### PR TITLE
More abc parser fixes

### DIFF
--- a/magenta/music/abc_parser.py
+++ b/magenta/music/abc_parser.py
@@ -419,7 +419,7 @@ class ABCTune(object):
       r'(__|_|=|\^|\^\^)?([A-Ga-g])([\',]*)(\d*/*\d*)')
 
   # http://abcnotation.com/wiki/abc:standard:v2.1#chords_and_unisons
-  CHORD_PATTERN = re.compile(r'\[(' + NOTE_PATTERN.pattern + ')+\]')
+  CHORD_PATTERN = re.compile(r'\[(' + NOTE_PATTERN.pattern + r')+\]')
 
   # http://abcnotation.com/wiki/abc:standard:v2.1#broken_rhythm
   BROKEN_RHYTHM_PATTERN = re.compile(r'(<+|>+)')

--- a/magenta/music/abc_parser.py
+++ b/magenta/music/abc_parser.py
@@ -571,7 +571,7 @@ class ABCTune(object):
           if not is_repeat:
             if len(match.group(2)) >= 2:
               # This is a double bar that isn't a repeat.
-              if not self._current_expected_repeats:
+              if not self._current_expected_repeats and self._current_time > 0:
                 # There was no previous forward repeat symbol.
                 # Add a new section so that if there is a backward repeat later
                 # on, it will repeat to this bar.

--- a/magenta/music/abc_parser.py
+++ b/magenta/music/abc_parser.py
@@ -58,6 +58,10 @@ class InvalidCharacterException(ABCParseException):
   """Invalid character."""
 
 
+class ChordException(ABCParseException):
+  """Chords are not supported."""
+
+
 def parse_tunebook_file(filename):
   """Parse an ABC Tunebook file."""
   # 'r' mode will decode the file as utf-8 in py3.
@@ -390,6 +394,9 @@ class ABCTune(object):
   NOTE_PATTERN = re.compile(
       r'(__|_|=|\^|\^\^)?([A-Ga-g])([\',]*)(\d*/*\d*)')
 
+  # http://abcnotation.com/wiki/abc:standard:v2.1#chords_and_unisons
+  CHORD_PATTERN = re.compile(r'\[(' + NOTE_PATTERN.pattern + ')+\]')
+
   # http://abcnotation.com/wiki/abc:standard:v2.1#broken_rhythm
   BROKEN_RHYTHM_PATTERN = re.compile(r'(<+|>+)')
 
@@ -419,6 +426,7 @@ class ABCTune(object):
       match = None
       for regex in [
           ABCTune.NOTE_PATTERN,
+          ABCTune.CHORD_PATTERN,
           ABCTune.BROKEN_RHYTHM_PATTERN,
           ABCTune.INLINE_INFORMATION_FIELD_PATTERN,
           ABCTune.BAR_AND_VARIANT_ENDINGS_PATTERN,
@@ -504,6 +512,8 @@ class ABCTune(object):
         if broken_rhythm:
           self._apply_broken_rhythm(broken_rhythm)
           broken_rhythm = None
+      elif match.re == ABCTune.CHORD_PATTERN:
+        raise ChordException('Chords are not supported.')
       elif match.re == ABCTune.BROKEN_RHYTHM_PATTERN:
         if broken_rhythm:
           raise ABCParseException(

--- a/magenta/music/abc_parser_test.py
+++ b/magenta/music/abc_parser_test.py
@@ -863,5 +863,77 @@ class AbcParserTest(tf.test.TestCase):
     self.assertTrue(isinstance(exceptions[0],
                                abc_parser.ChordException))
 
+  def testNoteAccidentalsPerBar(self):
+    tunes, exceptions = abc_parser.parse_tunebook("""
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        GF^GGg|Gg
+        """)
+    self.assertEqual(1, len(tunes))
+    self.assertEqual(0, len(exceptions))
+    expected_ns1 = common_testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        """
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 1
+        sequence_metadata {
+          title: "Test"
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 67
+          velocity: 90
+          start_time: 0.0
+          end_time: 0.5
+        }
+        notes {
+          pitch: 65
+          velocity: 90
+          start_time: 0.5
+          end_time: 1.0
+        }
+        notes {
+          pitch: 68
+          velocity: 90
+          start_time: 1.0
+          end_time: 1.5
+        }
+        notes {
+          pitch: 68
+          velocity: 90
+          start_time: 1.5
+          end_time: 2.0
+        }
+        notes {
+          pitch: 80
+          velocity: 90
+          start_time: 2.0
+          end_time: 2.5
+        }
+        notes {
+          pitch: 67
+          velocity: 90
+          start_time: 2.5
+          end_time: 3.0
+        }
+        notes {
+          pitch: 79
+          velocity: 90
+          start_time: 3.0
+          end_time: 3.5
+        }
+        total_time: 3.5
+        """)
+    self.assertProtoEquals(expected_ns1, tunes[1])
+
 if __name__ == '__main__':
   tf.test.main()

--- a/magenta/music/abc_parser_test.py
+++ b/magenta/music/abc_parser_test.py
@@ -677,8 +677,15 @@ class AbcParserTest(tf.test.TestCase):
         L:1/4
         T:Test
         |:: Bcd ::| Bcd || Bcd :|
+
+        % Ensure double bar doesn't confuse declared repeat.
+        X:8
+        Q:1/4=120
+        L:1/4
+        T:Test
+        |:: B || cd ::| Bcd || |: Bcd :|
         """)
-    self.assertEqual(5, len(tunes))
+    self.assertEqual(6, len(tunes))
     self.assertEqual(2, len(exceptions))
     self.assertTrue(isinstance(exceptions[0], abc_parser.RepeatParseException))
     self.assertTrue(isinstance(exceptions[1], abc_parser.RepeatParseException))
@@ -863,6 +870,12 @@ class AbcParserTest(tf.test.TestCase):
         }
         section_groups {
           sections {
+            section_id: 1
+          }
+          num_times: 1
+        }
+        section_groups {
+          sections {
             section_id: 2
           }
           num_times: 2
@@ -870,6 +883,10 @@ class AbcParserTest(tf.test.TestCase):
         total_time: 4.5
         """)
     self.assertProtoEquals(expected_ns7, tunes[7])
+
+    expected_ns8 = copy.deepcopy(expected_ns7)
+    expected_ns8.reference_number = 8
+    self.assertProtoEquals(expected_ns8, tunes[8])
 
 
   def testInvalidCharacter(self):

--- a/magenta/music/abc_parser_test.py
+++ b/magenta/music/abc_parser_test.py
@@ -899,7 +899,6 @@ class AbcParserTest(tf.test.TestCase):
     expected_ns9.reference_number = 9
     self.assertProtoEquals(expected_ns9, tunes[9])
 
-
   def testInvalidCharacter(self):
     tunes, exceptions = abc_parser.parse_tunebook("""
         X:1

--- a/magenta/music/abc_parser_test.py
+++ b/magenta/music/abc_parser_test.py
@@ -663,8 +663,22 @@ class AbcParserTest(tf.test.TestCase):
         L:1/4
         T:Test
         |:: Bcd ::|: Bcd |
+
+        % Ambiguous repeat that should go to the last repeat symbol.
+        X:6
+        Q:1/4=120
+        L:1/4
+        T:Test
+        |:: Bcd ::| Bcd :|
+
+        % Ambiguous repeat that should go to the last double bar.
+        X:7
+        Q:1/4=120
+        L:1/4
+        T:Test
+        |:: Bcd ::| Bcd || Bcd :|
         """)
-    self.assertEqual(3, len(tunes))
+    self.assertEqual(5, len(tunes))
     self.assertEqual(2, len(exceptions))
     self.assertTrue(isinstance(exceptions[0], abc_parser.RepeatParseException))
     self.assertTrue(isinstance(exceptions[1], abc_parser.RepeatParseException))
@@ -749,9 +763,114 @@ class AbcParserTest(tf.test.TestCase):
     expected_ns2.reference_number = 2
     self.assertProtoEquals(expected_ns2, tunes[2])
 
-    expected_ns3 = copy.deepcopy(expected_ns2)
+    expected_ns3 = copy.deepcopy(expected_ns1)
     expected_ns3.reference_number = 3
     self.assertProtoEquals(expected_ns3, tunes[3])
+
+    # Also identical, except the last section is played only twice.
+    expected_ns6 = copy.deepcopy(expected_ns1)
+    expected_ns6.reference_number = 6
+    expected_ns6.section_groups[-1].num_times = 2
+    self.assertProtoEquals(expected_ns6, tunes[6])
+
+    expected_ns7 = common_testing_lib.parse_test_proto(
+        music_pb2.NoteSequence,
+        """
+        ticks_per_quarter: 220
+        source_info: {
+          source_type: SCORE_BASED
+          encoding_type: ABC
+          parser: MAGENTA_ABC
+        }
+        reference_number: 7
+        sequence_metadata {
+          title: "Test"
+        }
+        tempos {
+          qpm: 120
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 0.0
+          end_time: 0.5
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 0.5
+          end_time: 1.0
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 1.0
+          end_time: 1.5
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 1.5
+          end_time: 2.0
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 2.0
+          end_time: 2.5
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 2.5
+          end_time: 3.0
+        }
+        notes {
+          pitch: 71
+          velocity: 90
+          start_time: 3.0
+          end_time: 3.5
+        }
+        notes {
+          pitch: 72
+          velocity: 90
+          start_time: 3.5
+          end_time: 4.0
+        }
+        notes {
+          pitch: 74
+          velocity: 90
+          start_time: 4.0
+          end_time: 4.5
+        }
+        section_annotations {
+          time: 0
+          section_id: 0
+        }
+        section_annotations {
+          time: 1.5
+          section_id: 1
+        }
+        section_annotations {
+          time: 3.0
+          section_id: 2
+        }
+        section_groups {
+          sections {
+            section_id: 0
+          }
+          num_times: 3
+        }
+        section_groups {
+          sections {
+            section_id: 2
+          }
+          num_times: 2
+        }
+        total_time: 4.5
+        """)
+    self.assertProtoEquals(expected_ns7, tunes[7])
+
 
   def testInvalidCharacter(self):
     tunes, exceptions = abc_parser.parse_tunebook("""

--- a/magenta/music/abc_parser_test.py
+++ b/magenta/music/abc_parser_test.py
@@ -65,13 +65,12 @@ class AbcParserTest(tf.test.TestCase):
                    abc2midi.ticks_per_quarter)
 
     for note in abc2midi.notes:
+      # For now, don't compare velocities.
+      note.velocity = 90
       note.start_time -= tick_length
 
-    self.assertEqual(len(abc2midi.notes), len(expanded_test.notes))
-    for exp_note, test_note in zip(abc2midi.notes, expanded_test.notes):
-      # For now, don't compare velocities.
-      exp_note.velocity = test_note.velocity
-      self.assertProtoEquals(exp_note, test_note)
+    self.compareProtoList(abc2midi.notes, expanded_test.notes)
+
     self.assertEqual(abc2midi.total_time, expanded_test.total_time)
 
     self.compareProtoList(abc2midi.time_signatures,
@@ -851,6 +850,18 @@ class AbcParserTest(tf.test.TestCase):
         total_time: 3.0
         """)
     self.assertProtoEquals(expected_ns1, tunes[1])
+
+  def testChords(self):
+    tunes, exceptions = abc_parser.parse_tunebook("""
+        X:1
+        Q:1/4=120
+        L:1/4
+        T:Test
+        [CEG]""")
+    self.assertEqual(0, len(tunes))
+    self.assertEqual(1, len(exceptions))
+    self.assertTrue(isinstance(exceptions[0],
+                               abc_parser.ChordException))
 
 if __name__ == '__main__':
   tf.test.main()

--- a/magenta/music/abc_parser_test.py
+++ b/magenta/music/abc_parser_test.py
@@ -678,14 +678,21 @@ class AbcParserTest(tf.test.TestCase):
         T:Test
         |:: Bcd ::| Bcd || Bcd :|
 
-        % Ensure double bar doesn't confuse declared repeat.
+        % Ambiguous repeat that should go to the last double bar.
         X:8
+        Q:1/4=120
+        L:1/4
+        T:Test
+        || Bcd ::| Bcd || Bcd :|
+
+        % Ensure double bar doesn't confuse declared repeat.
+        X:9
         Q:1/4=120
         L:1/4
         T:Test
         |:: B || cd ::| Bcd || |: Bcd :|
         """)
-    self.assertEqual(6, len(tunes))
+    self.assertEqual(7, len(tunes))
     self.assertEqual(2, len(exceptions))
     self.assertTrue(isinstance(exceptions[0], abc_parser.RepeatParseException))
     self.assertTrue(isinstance(exceptions[1], abc_parser.RepeatParseException))
@@ -887,6 +894,10 @@ class AbcParserTest(tf.test.TestCase):
     expected_ns8 = copy.deepcopy(expected_ns7)
     expected_ns8.reference_number = 8
     self.assertProtoEquals(expected_ns8, tunes[8])
+
+    expected_ns9 = copy.deepcopy(expected_ns7)
+    expected_ns9.reference_number = 9
+    self.assertProtoEquals(expected_ns9, tunes[9])
 
 
   def testInvalidCharacter(self):

--- a/magenta/scripts/abc_compare.py
+++ b/magenta/scripts/abc_compare.py
@@ -41,11 +41,12 @@ tf.app.flags.DEFINE_string('input_dir', None,
 
 
 class CompareDirectory(tf.test.TestCase):
-  def runTest():
+
+  def runTest(self):
     pass
 
   def compare_directory(self, directory):
-    self.maxDiff = None
+    self.maxDiff = None  # pylint: disable=invalid-name
 
     files_in_dir = tf.gfile.ListDirectory(directory)
     files_parsed = 0
@@ -85,7 +86,7 @@ class CompareDirectory(tf.test.TestCase):
         for midi_note, test_note in zip(midi_ns.notes, expanded_tune.notes):
           try:
             self.assertProtoEquals(midi_note, test_note)
-          except Exception as e:
+          except Exception as e: # pylint: disable=broad-except
             print(e)
             pdb.set_trace()
         self.assertEqual(midi_ns.total_time, expanded_tune.total_time)

--- a/magenta/scripts/abc_compare.py
+++ b/magenta/scripts/abc_compare.py
@@ -86,7 +86,7 @@ class CompareDirectory(tf.test.TestCase):
         for midi_note, test_note in zip(midi_ns.notes, expanded_tune.notes):
           try:
             self.assertProtoEquals(midi_note, test_note)
-          except Exception as e: # pylint: disable=broad-except
+          except Exception as e:  # pylint: disable=broad-except
             print(e)
             pdb.set_trace()
         self.assertEqual(midi_ns.total_time, expanded_tune.total_time)


### PR DESCRIPTION
- Explicitly don't parse chords
- Handle per-bar accidentals
- Handle ambiguous repeats
