### PR TITLE
Fix BUILD file

### DIFF
--- a/magenta/models/image_stylization/BUILD
+++ b/magenta/models/image_stylization/BUILD
@@ -102,7 +102,7 @@ py_library(
     name = "image_utils",
     srcs = ["image_utils.py"],
     data = [
-        "evaluation_images",
+        "//magenta/models/image_stylization/evaluation_images:evaluation_images",
     ],
     srcs_version = "PY2AND3",
     deps = [

--- a/magenta/models/image_stylization/evaluation_images/BUILD
+++ b/magenta/models/image_stylization/evaluation_images/BUILD
@@ -20,6 +20,6 @@ filegroup(
     name = "evaluation_images",
     srcs = glob(["*.jpg"]),
     visibility = [
-        "//learning/brain/research/image_stylization:__subpackages__",
+        "//magenta/models/image_stylization:__subpackages__",
     ],
 )


### PR DESCRIPTION
Before this change, `image_utils` is not really referencing `//magenta/models/image_stylization/evaluation_images:evaluation_images`.
This is causing https://github.com/bazelbuild/bazel/issues/3803