### PR TITLE
README: fix typo in Jupyter Notebook link

### DIFF
--- a/magenta/models/sketch_rnn/README.md
+++ b/magenta/models/sketch_rnn/README.md
@@ -134,7 +134,7 @@ In addition, we have provided pre-trained models for selected QuickDraw datasets
 
 *Let's get the model to interpolate between a cat and a bus!*
 
-We've included a simple [Jupyter Notebook](https://github.com/tensorflow/magenta-demos/blob/master/jupyter_notebooks/Sketch_RNN.ipynb) to show you how to load a pre-trained model and generate vector sketches.  You will be able to encode, decode, and morph between two vector images, and also generate new random ones.  When sampling images, you can tune the `temperature` parameter to control the level of uncertainty.
+We've included a simple [Jupyter Notebook](https://github.com/tensorflow/magenta-demos/blob/master/jupyter-notebooks/Sketch_RNN.ipynb) to show you how to load a pre-trained model and generate vector sketches.  You will be able to encode, decode, and morph between two vector images, and also generate new random ones.  When sampling images, you can tune the `temperature` parameter to control the level of uncertainty.
 
 # Citation
 


### PR DESCRIPTION
`s/_/-/`