### PR TITLE
include hparams in generate example

### DIFF
--- a/magenta/models/polyphony_rnn/README.md
+++ b/magenta/models/polyphony_rnn/README.md
@@ -146,6 +146,7 @@ See above for more information on other command line options.
 ```
 polyphony_rnn_generate \
 --run_dir=/tmp/polyphony_rnn/logdir/run1 \
+--hparams="batch_size=64,rnn_layer_sizes=[64,64]" \
 --output_dir=/tmp/polyphony_rnn/generated \
 --num_outputs=10 \
 --num_steps=128 \


### PR DESCRIPTION
For Generate Tracks, we include the following note: 

```markdown
--hparams should be the same hyperparameters used for the training job, although some of them will be ignored, like the batch size.
```

However in our example, we don't actually include the same hparams. 

I suggest we add this, as that note can be easy to miss, and the error that it causes can lead one to some searching
