### PR TITLE
modify Polyphony_RNN README.txt

### DIFF
--- a/magenta/models/polyphony_rnn/README.md
+++ b/magenta/models/polyphony_rnn/README.md
@@ -161,10 +161,8 @@ The [bundle format](/magenta/protobuf/generator.proto)
 is a convenient way of combining the model checkpoint, metagraph, and
 some metadata about the model into a single file.
 
-To generate a bundle, use the
-[create_bundle_file](/magenta/music/sequence_generator.py)
-method within SequenceGenerator. Our generator script
-supports a ```--save_generator_bundle``` flag that calls this method. When using the --save_generator_bundle mode, you need to supply the --hparams flag with the same values used during training.
+To generate a bundle, use the [create_bundle_file](/magenta/music/sequence_generator.py) method within SequenceGenerator. Our generator script supports a `--save_generator_bundle` flag that calls this method. When using the `--save_generator_bundle` mode, you need to supply the `--hparams` flag with the same values used during training.
+
 Example:
 
 ```

--- a/magenta/models/polyphony_rnn/README.md
+++ b/magenta/models/polyphony_rnn/README.md
@@ -164,7 +164,8 @@ some metadata about the model into a single file.
 To generate a bundle, use the
 [create_bundle_file](/magenta/music/sequence_generator.py)
 method within SequenceGenerator. Our generator script
-supports a ```--save_generator_bundle``` flag that calls this method. In addition, you need add `--hparams` which is used for the training job.Example:
+supports a ```--save_generator_bundle``` flag that calls this method. When using the --save_generator_bundle mode, you need to supply the --hparams flag with the same values used during training.
+Example:
 
 ```
 polyphony_rnn_generate \

--- a/magenta/models/polyphony_rnn/README.md
+++ b/magenta/models/polyphony_rnn/README.md
@@ -164,11 +164,12 @@ some metadata about the model into a single file.
 To generate a bundle, use the
 [create_bundle_file](/magenta/music/sequence_generator.py)
 method within SequenceGenerator. Our generator script
-supports a ```--save_generator_bundle``` flag that calls this method. Example:
+supports a ```--save_generator_bundle``` flag that calls this method. In addition, you need add `--hparams` which is used for the training job.Example:
 
 ```
 polyphony_rnn_generate \
 --run_dir=/tmp/polyphony_rnn/logdir/run1 \
+--hparams="batch_size=64,rnn_layer_sizes=[64,64]" \
 --bundle_file=/tmp/polyphony_rnn.mag \
 --save_generator_bundle
 ```


### PR DESCRIPTION
if you forget to add the "--hparam" optional,it will cause some errors like "NotFoundError (see above for traceback): Key rnn/multi_rnn_cell/cell_2/basic_lstm_cell/weights not found in checkpoint
[[Node: save/RestoreV2_7 = RestoreV2[dtypes=[DT_FLOAT], _device="/job:localhost/replica:0/task:0/cpu:0"](_recv_save/Const_0, save/RestoreV2_7/tensor_names, save/RestoreV2_7/shape_and_slices)]]".   when you runing the generate_bundle_file script.