### PR TITLE
Coconet fix eval lr

### DIFF
--- a/magenta/models/coconet/coconet_sample.py
+++ b/magenta/models/coconet/coconet_sample.py
@@ -244,7 +244,7 @@ class TFGenerator(object):
     # Update the length of piece to be generated.
     self.hparams.crop_piece_len = piece_length
     shape = [gen_batch_size] + self.hparams.pianoroll_shape
-    tf.logging.info("Tentative shape of pianorolls to be generated: r", shape)
+    tf.logging.info("Tentative shape of pianorolls to be generated: %r", shape)
 
     # Generates.
     if midi_in is not None:

--- a/magenta/models/coconet/coconet_train.py
+++ b/magenta/models/coconet/coconet_train.py
@@ -157,7 +157,8 @@ def run_epoch(supervisor, sess, m, dataset, hparams, eval_op, experiment_type,
   run_stats['loss_unmask'] = losses_unmask.mean
   run_stats['loss_total'] = losses_total.mean
   run_stats['loss'] = losses.mean
-  run_stats['learning_rate'] = float(learning_rate)
+  if experiment_type == 'train':
+    run_stats['learning_rate'] = float(learning_rate)
 
   # Make summaries.
   if FLAGS.log_progress:
@@ -172,7 +173,8 @@ def run_epoch(supervisor, sess, m, dataset, hparams, eval_op, experiment_type,
                   'loss (total): %.4f, log lr: %.4f, time taken: %.4f',
                   experiment_type, epoch_count, run_stats['loss_mask'],
                   run_stats['loss_unmask'], run_stats['loss_total'],
-                  np.log2(run_stats['learning_rate']),
+                  np.log2(run_stats['learning_rate'])
+                  if 'learning_rate' in run_stats else 0,
                   time.time() - start_time)
 
   return run_stats['loss']

--- a/magenta/models/coconet/lib_graph.py
+++ b/magenta/models/coconet/lib_graph.py
@@ -114,7 +114,8 @@ class CoconetGraph(object):
     """Instantiates learning rate, decay op and train_op among others."""
     # If not training, don't need to add optimizer to the graph.
     if not self.is_training:
-      self.train_op = tf.no_op
+      #self.train_op = tf.no_op
+      self.learning_rate = tf.no_op()
       return
 
     self.learning_rate = tf.Variable(

--- a/magenta/models/coconet/lib_graph.py
+++ b/magenta/models/coconet/lib_graph.py
@@ -114,7 +114,7 @@ class CoconetGraph(object):
     """Instantiates learning rate, decay op and train_op among others."""
     # If not training, don't need to add optimizer to the graph.
     if not self.is_training:
-      #self.train_op = tf.no_op
+      self.train_op = tf.no_op()
       self.learning_rate = tf.no_op()
       return
 


### PR DESCRIPTION
Make learning_rate for the non-training case an no-op to support backward compatibility with sample graph that needs learning_rate.