### PR TITLE
 Removed log statement that prints too frequently

### DIFF
--- a/magenta/music/sequences_lib.py
+++ b/magenta/music/sequences_lib.py
@@ -1009,9 +1009,9 @@ def transpose_note_sequence(ns,
     ns: The NoteSequence proto to be transposed.
     amount: Number of half-steps to transpose up or down.
     min_allowed_pitch: Minimum pitch allowed in transposed NoteSequence.
-        Notes assigned lower pitched will be deleted.
+        Notes assigned lower pitches will be deleted.
     max_allowed_pitch: Maximum pitch allowed in transposed NoteSequence.
-        Notes assigned higher pitched will be deleted.
+        Notes assigned higher pitches will be deleted.
     in_place: If True, the input note_sequence is edited directly.
 
   Returns:

--- a/magenta/music/sequences_lib.py
+++ b/magenta/music/sequences_lib.py
@@ -998,21 +998,23 @@ def quantize_note_sequence_absolute(note_sequence, steps_per_second):
   return qns
 
 
-def transpose_note_sequence(ns, amount,
+def transpose_note_sequence(ns,
+                            amount,
                             min_allowed_pitch=constants.MIN_MIDI_PITCH,
                             max_allowed_pitch=constants.MAX_MIDI_PITCH,
                             in_place=False):
   """Transposes note sequence specified amount, deleting out-of-bound notes.
-  
-  Args: 
+
+  Args:
     ns: The NoteSequence proto to be transposed.
+    amount: Number of half-steps to transpose up or down.
     min_allowed_pitch: Minimum pitch allowed in transposed NoteSequence.
         Notes assigned lower pitched will be deleted.
     max_allowed_pitch: Maximum pitch allowed in transposed NoteSequence.
         Notes assigned higher pitched will be deleted.
     in_place: If True, the input note_sequence is edited directly.
 
-  Returns: 
+  Returns:
     The transposed NoteSequence and a count of how many notes were deleted.
   """
   if not in_place:
@@ -1060,7 +1062,7 @@ def transpose_note_sequence(ns, amount,
   # Remove key signature information because it will now be wrong.
   del ns.key_signatures[:]
 
-  return ns, delete_count
+  return ns, deleted_note_count
 
 
 def _clamp_transpose(transpose_amount, ns_min_pitch, ns_max_pitch,

--- a/magenta/music/sequences_lib.py
+++ b/magenta/music/sequences_lib.py
@@ -1002,7 +1002,19 @@ def transpose_note_sequence(ns, amount,
                             min_allowed_pitch=constants.MIN_MIDI_PITCH,
                             max_allowed_pitch=constants.MAX_MIDI_PITCH,
                             in_place=False):
-  """Transposes note sequence specified amount, deleting out-of-bound notes."""
+  """Transposes note sequence specified amount, deleting out-of-bound notes.
+  
+  Args: 
+    ns: The NoteSequence proto to be transposed.
+    min_allowed_pitch: Minimum pitch allowed in transposed NoteSequence.
+        Notes assigned lower pitched will be deleted.
+    max_allowed_pitch: Maximum pitch allowed in transposed NoteSequence.
+        Notes assigned higher pitched will be deleted.
+    in_place: If True, the input note_sequence is edited directly.
+
+  Returns: 
+    The transposed NoteSequence and a count of how many notes were deleted.
+  """
   if not in_place:
     new_ns = music_pb2.NoteSequence()
     new_ns.CopyFrom(ns)
@@ -1028,8 +1040,6 @@ def transpose_note_sequence(ns, amount,
       deleted_note_count += 1
 
   if deleted_note_count > 0:
-    tf.logging.info(
-        'Transposing removed %d notes from NoteSequence' % (deleted_note_count))
     del ns.notes[:]
     ns.notes.extend(new_note_list)
 
@@ -1050,7 +1060,7 @@ def transpose_note_sequence(ns, amount,
   # Remove key signature information because it will now be wrong.
   del ns.key_signatures[:]
 
-  return ns
+  return ns, delete_count
 
 
 def _clamp_transpose(transpose_amount, ns_min_pitch, ns_max_pitch,
@@ -1156,7 +1166,7 @@ def augment_note_sequence(
                                        max_allowed_pitch)
       transposition_amount = random.randint(min_transpose, max_transpose)
 
-    ns = transpose_note_sequence(
+    ns, _ = transpose_note_sequence(
         ns,
         transposition_amount,
         min_allowed_pitch, max_allowed_pitch,

--- a/magenta/music/sequences_lib_test.py
+++ b/magenta/music/sequences_lib_test.py
@@ -52,18 +52,19 @@ class SequencesLibTest(tf.test.TestCase):
     sequence.text_annotations.add(
         time=2, annotation_type=CHORD_SYMBOL, text='E7')
 
-    expected_subsequence = copy.copy(self.note_sequence)
+    expected_sequence = copy.copy(self.note_sequence)
     testing_lib.add_track_to_sequence(
-        expected_subsequence, 0,
+        expected_sequence, 0,
         [(13, 100, 0.01, 10.0), (12, 55, 0.22, 0.50), (41, 45, 2.50, 3.50),
          (56, 120, 4.0, 4.01), (53, 99, 4.75, 5.0)])
-    expected_subsequence.text_annotations.add(
+    expected_sequence.text_annotations.add(
         time=1, annotation_type=CHORD_SYMBOL, text='N.C.')
-    expected_subsequence.text_annotations.add(
+    expected_sequence.text_annotations.add(
         time=2, annotation_type=CHORD_SYMBOL, text='F7')
 
-    subsequence = sequences_lib.transpose_note_sequence(sequence, 1)
-    self.assertProtoEquals(expected_subsequence, subsequence)
+    transposed_sequence, delete_count = sequences_lib.transpose_note_sequence(sequence, 1)
+    self.assertProtoEquals(expected_sequence, transposed_sequence)
+    self.assertEquals(delete_count, 0)
 
   def testTransposeNoteSequenceOutOfRange(self):
     sequence = copy.copy(self.note_sequence)
@@ -72,24 +73,27 @@ class SequencesLibTest(tf.test.TestCase):
         [(35, 100, 0.01, 10.0), (36, 55, 0.22, 0.50), (37, 45, 2.50, 3.50),
          (38, 120, 4.0, 4.01), (39, 99, 4.75, 5.0)])
 
-    expected_subsequence_1 = copy.copy(self.note_sequence)
+    expected_sequence_1 = copy.copy(self.note_sequence)
     testing_lib.add_track_to_sequence(
-        expected_subsequence_1, 0,
+        expected_sequence_1, 0,
         [(39, 100, 0.01, 10.0), (40, 55, 0.22, 0.50)])
 
-    expected_subsequence_2 = copy.copy(self.note_sequence)
+    expected_sequence_2 = copy.copy(self.note_sequence)
     testing_lib.add_track_to_sequence(
-        expected_subsequence_2, 0,
+        expected_sequence_2, 0,
         [(30, 120, 4.0, 4.01), (31, 99, 4.75, 5.0)])
 
     sequence_copy = copy.copy(sequence)
-    subsequence = sequences_lib.transpose_note_sequence(
+    transposed_sequence, delete_count = sequences_lib.transpose_note_sequence(
         sequence_copy, 4, 30, 40)
-    self.assertProtoEquals(expected_subsequence_1, subsequence)
+    self.assertProtoEquals(expected_sequence_1, transposed_sequence)
+    self.assertEqual(3, delete_count)
 
     sequence_copy = copy.copy(sequence)
-    subsequence = sequences_lib.transpose_note_sequence(sequence, -8, 30, 40)
-    self.assertProtoEquals(expected_subsequence_2, subsequence)
+    transposed_sequence, delete_count = sequences_lib.transpose_note_sequence(
+        sequence_copy, -8, 30, 40)
+    self.assertProtoEquals(expected_sequence_2, transposed_sequence)
+    self.assertEqual(3, delete_count)
 
   def testClampTranspose(self):
     clamped = sequences_lib._clamp_transpose(

--- a/magenta/music/sequences_lib_test.py
+++ b/magenta/music/sequences_lib_test.py
@@ -88,13 +88,13 @@ class SequencesLibTest(tf.test.TestCase):
     transposed_sequence, delete_count = sequences_lib.transpose_note_sequence(
         sequence_copy, 4, 30, 40)
     self.assertProtoEquals(expected_sequence_1, transposed_sequence)
-    self.assertEqual(3, delete_count)
+    self.assertEqual(delete_count, 3)
 
     sequence_copy = copy.copy(sequence)
     transposed_sequence, delete_count = sequences_lib.transpose_note_sequence(
         sequence_copy, -8, 30, 40)
     self.assertProtoEquals(expected_sequence_2, transposed_sequence)
-    self.assertEqual(3, delete_count)
+    self.assertEqual(delete_count, 3)
 
   def testClampTranspose(self):
     clamped = sequences_lib._clamp_transpose(

--- a/magenta/music/sequences_lib_test.py
+++ b/magenta/music/sequences_lib_test.py
@@ -62,7 +62,8 @@ class SequencesLibTest(tf.test.TestCase):
     expected_sequence.text_annotations.add(
         time=2, annotation_type=CHORD_SYMBOL, text='F7')
 
-    transposed_sequence, delete_count = sequences_lib.transpose_note_sequence(sequence, 1)
+    transposed_sequence, delete_count = sequences_lib.transpose_note_sequence(
+        sequence, 1)
     self.assertProtoEquals(expected_sequence, transposed_sequence)
     self.assertEquals(delete_count, 0)
 


### PR DESCRIPTION
And instead have the `transpose_note_sequence` method return the number of deleted notes.