### PR TITLE
Check-in Latent Transfer Model

### DIFF
--- a/magenta/models/latent_transfer/BUILD
+++ b/magenta/models/latent_transfer/BUILD
@@ -1,0 +1,172 @@
+# Research code for "latent transfer"
+
+# licenses(["notice"])  # Apache 2.0
+
+py_library(
+    name = "configs",
+    srcs = glob([
+        "configs/*.py",
+        "configs/*/*.py",
+        "configs/*/*/*.py",
+        "configs/*/*/*/*.py",
+    ]),
+    srcs_version = "PY2AND3",
+    visibility = ["//magenta/tools/pip:__subpackages__"],
+    deps = [
+        ":nn",
+        # numpy dep
+        # tensorflow dep
+    ],
+)
+
+py_library(
+    name = "common",
+    srcs = ["common.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//magenta/tools/pip:__subpackages__"],
+    deps = [
+        ":local_mnist",
+        # PIL dep
+        # numpy dep
+        # scipy dep
+        # sonnet dep
+        # tensorflow dep
+        # tqdm dep
+    ],
+)
+
+py_library(
+    name = "common_joint",
+    srcs = ["common_joint.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//magenta/tools/pip:__subpackages__"],
+    deps = [
+        ":local_mnist",
+        # numpy dep
+        # scipy dep
+        # sonnet dep
+        # tensorflow dep
+        # tqdm dep
+    ],
+)
+
+py_binary(
+    name = "encode_dataspace",
+    srcs = ["encode_dataspace.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//magenta/tools/pip:__subpackages__"],
+    deps = [
+        ":common",
+        ":configs",
+        ":model_dataspace",
+    ],
+)
+
+py_library(
+    name = "local_mnist",
+    srcs = ["local_mnist.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//magenta/tools/pip:__subpackages__"],
+    deps = [
+        # numpy dep
+        # tensorflow dep
+    ],
+)
+
+py_library(
+    name = "nn",
+    srcs = ["nn.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//magenta/tools/pip:__subpackages__"],
+    deps = [
+        # numpy dep
+        # sonnet dep
+        # tensorflow dep
+    ],
+)
+
+py_library(
+    name = "model_dataspace",
+    srcs = ["model_dataspace.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//magenta/tools/pip:__subpackages__"],
+    deps = [
+        ":nn",
+        # numpy dep
+        # sonnet dep
+        # tensorflow dep
+    ],
+)
+
+py_library(
+    name = "model_joint",
+    srcs = ["model_joint.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//magenta/tools/pip:__subpackages__"],
+    deps = [
+        ":nn",
+        # numpy dep
+        # sonnet dep
+        # tensorflow dep
+    ],
+)
+
+py_binary(
+    name = "sample_dataspace",
+    srcs = ["sample_dataspace.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//magenta/tools/pip:__subpackages__"],
+    deps = [
+        ":common",
+        ":configs",
+        ":model_dataspace",
+    ],
+)
+
+py_binary(
+    name = "sample_wavegan",
+    srcs = ["sample_wavegan.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//magenta/tools/pip:__subpackages__"],
+    deps = [
+        ":common",
+        ":configs",
+    ],
+)
+
+py_binary(
+    name = "train_dataspace",
+    srcs = ["train_dataspace.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//magenta/tools/pip:__subpackages__"],
+    deps = [
+        ":common",
+        ":configs",
+        ":model_dataspace",
+    ],
+)
+
+py_binary(
+    name = "train_dataspace_classifier",
+    srcs = ["train_dataspace_classifier.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//magenta/tools/pip:__subpackages__"],
+    deps = [
+        ":common",
+        ":configs",
+        ":model_dataspace",
+    ],
+)
+
+py_binary(
+    name = "train_joint",
+    srcs = ["train_joint.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//magenta/tools/pip:__subpackages__"],
+    deps = [
+        ":common",
+        ":common_joint",
+        ":configs",
+        ":model_dataspace",
+    ],
+)

--- a/magenta/models/latent_transfer/BUILD
+++ b/magenta/models/latent_transfer/BUILD
@@ -1,6 +1,20 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Research code for "latent transfer"
 
-# licenses(["notice"])  # Apache 2.0
+licenses(["notice"])  # Apache 2.0
 
 py_library(
     name = "configs",

--- a/magenta/models/latent_transfer/BUILD
+++ b/magenta/models/latent_transfer/BUILD
@@ -25,7 +25,6 @@ py_library(
         "configs/*/*/*/*.py",
     ]),
     srcs_version = "PY2AND3",
-    visibility = ["//magenta/tools/pip:__subpackages__"],
     deps = [
         ":nn",
         # numpy dep
@@ -37,7 +36,6 @@ py_library(
     name = "common",
     srcs = ["common.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//magenta/tools/pip:__subpackages__"],
     deps = [
         ":local_mnist",
         # PIL dep
@@ -53,7 +51,6 @@ py_library(
     name = "common_joint",
     srcs = ["common_joint.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//magenta/tools/pip:__subpackages__"],
     deps = [
         ":local_mnist",
         # numpy dep
@@ -68,7 +65,6 @@ py_binary(
     name = "encode_dataspace",
     srcs = ["encode_dataspace.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//magenta/tools/pip:__subpackages__"],
     deps = [
         ":common",
         ":configs",
@@ -80,7 +76,6 @@ py_library(
     name = "local_mnist",
     srcs = ["local_mnist.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//magenta/tools/pip:__subpackages__"],
     deps = [
         # numpy dep
         # tensorflow dep
@@ -91,7 +86,6 @@ py_library(
     name = "nn",
     srcs = ["nn.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//magenta/tools/pip:__subpackages__"],
     deps = [
         # numpy dep
         # sonnet dep
@@ -116,7 +110,6 @@ py_library(
     name = "model_joint",
     srcs = ["model_joint.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//magenta/tools/pip:__subpackages__"],
     deps = [
         ":nn",
         # numpy dep
@@ -129,7 +122,6 @@ py_binary(
     name = "sample_dataspace",
     srcs = ["sample_dataspace.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//magenta/tools/pip:__subpackages__"],
     deps = [
         ":common",
         ":configs",
@@ -141,7 +133,6 @@ py_binary(
     name = "sample_wavegan",
     srcs = ["sample_wavegan.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//magenta/tools/pip:__subpackages__"],
     deps = [
         ":common",
         ":configs",
@@ -152,7 +143,6 @@ py_binary(
     name = "train_dataspace",
     srcs = ["train_dataspace.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//magenta/tools/pip:__subpackages__"],
     deps = [
         ":common",
         ":configs",
@@ -164,7 +154,6 @@ py_binary(
     name = "train_dataspace_classifier",
     srcs = ["train_dataspace_classifier.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//magenta/tools/pip:__subpackages__"],
     deps = [
         ":common",
         ":configs",
@@ -176,7 +165,6 @@ py_binary(
     name = "train_joint",
     srcs = ["train_joint.py"],
     srcs_version = "PY2AND3",
-    visibility = ["//magenta/tools/pip:__subpackages__"],
     deps = [
         ":common",
         ":common_joint",

--- a/magenta/models/latent_transfer/common.py
+++ b/magenta/models/latent_transfer/common.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Common functions/helpers for dataspace model.
 
 This library contains many common functions and helpers used to for the

--- a/magenta/models/latent_transfer/common.py
+++ b/magenta/models/latent_transfer/common.py
@@ -1,4 +1,21 @@
-"""Common functions/helpers.
+"""Common functions/helpers for dataspace model.
+
+This library contains many common functions and helpers used to for the
+dataspace model (defined in `train_dataspace.py`) that is used in training
+(`train_dataspace.py` and `train_dataspace_classifier.py`), sampling
+(`sample_dataspace.py`) and encoding (`encode_dataspace.py`).
+These components are classified in the following categories:
+
+  - Loading helper that makes dealing with config / dataset easier. This
+    includes:
+        `get_model_uid`, `load_config`, `dataset_is_mnist_family`,
+        `load_dataset`, `get_index_grouped_by_label`.
+
+  - Helper making dumping dataspace data easier. This includes:
+        `batch_image`, `save_image`, `make_grid`, `post_proc`
+
+  - Miscellaneous Helpers, including
+        `get_default_scratch`, `ObjectBlob`,
 
 """
 from __future__ import absolute_import

--- a/magenta/models/latent_transfer/common.py
+++ b/magenta/models/latent_transfer/common.py
@@ -1,0 +1,233 @@
+"""Common functions/helpers.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from functools import partial
+import importlib
+import os
+
+import numpy as np
+from PIL import Image
+import tensorflow as tf
+from tensorflow import flags
+
+import local_mnist
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string(
+    'default_scratch', '/tmp/', 'The default root directory for scratching. '
+    'It can contain \'~\' which would be handled correctly.')
+
+
+def get_default_scratch():
+  """Get the default directory for scratching."""
+  return os.path.expanduser(FLAGS.default_scratch)
+
+
+class ObjectBlob(object):
+  """Helper object storing key-value pairs as attributes."""
+
+  def __init__(self, **kwargs):
+    for k, v in kwargs.items():
+      self.__dict__[k] = v
+
+
+def get_model_uid(config_name, exp_uid):
+  """Helper function returning model's uid."""
+  return config_name + exp_uid
+
+
+def load_config(config_name):
+  """Load config from corresponding configs.<config_name> module."""
+  return importlib.import_module('configs.%s' % config_name).config
+
+
+def _load_celeba(data_path, postfix):
+  """Load the CelebA dataset."""
+  with tf.gfile.Open(os.path.join(data_path, 'train' + postfix), 'rb') as f:
+    train_data = np.load(f)
+  with tf.gfile.Open(os.path.join(data_path, 'eval' + postfix), 'rb') as f:
+    eval_data = np.load(f)
+  with tf.gfile.Open(os.path.join(data_path, 'test' + postfix), 'rb') as f:
+    test_data = np.load(f)
+  with tf.gfile.Open(os.path.join(data_path, 'attr_train.npy'), 'rb') as f:
+    attr_train = np.load(f)
+  with tf.gfile.Open(os.path.join(data_path, 'attr_eval.npy'), 'rb') as f:
+    attr_eval = np.load(f)
+  with tf.gfile.Open(os.path.join(data_path, 'attr_test.npy'), 'rb') as f:
+    attr_test = np.load(f)
+  attr_mask = [4, 8, 9, 11, 15, 20, 24, 31, 35, 39]
+  attribute_names = [
+      'Bald',
+      'Black_Hair',
+      'Blond_Hair',
+      'Brown_Hair',
+      'Eyeglasses',
+      'Male',
+      'No_Beard',
+      'Smiling',
+      'Wearing_Hat',
+      'Young',
+  ]
+  attr_train = attr_train[:, attr_mask]
+  attr_eval = attr_eval[:, attr_mask]
+  attr_test = attr_test[:, attr_mask]
+  return (train_data, eval_data, test_data, attr_train, attr_eval, attr_test,
+          attribute_names)
+
+
+def dataset_is_mnist_family(dataset):
+  """returns if dataset is of MNIST family."""
+  return dataset.lower() == 'mnist' or dataset.lower() == 'fashion-mnist'
+
+
+def load_dataset(config):
+  """Load dataset following instruction in `config`."""
+  if dataset_is_mnist_family(config['dataset']):
+    crop_width = config.get('crop_width', None)  # unused
+    img_width = config.get('img_width', None)  # unused
+
+    scratch = config.get('scratch', get_default_scratch())
+    basepath = os.path.join(scratch, config['dataset'].lower())
+    data_path = os.path.join(basepath, 'data')
+    save_path = os.path.join(basepath, 'ckpts')
+
+    tf.gfile.MakeDirs(data_path)
+    tf.gfile.MakeDirs(save_path)
+
+    # black-on-white MNIST (harder to learn than white-on-black MNIST)
+    # Running locally (pre-download data locally)
+    mnist_train, mnist_eval, mnist_test = local_mnist.read_data_sets(
+        data_path, one_hot=True)
+
+    train_data = np.concatenate([mnist_train.images, mnist_eval.images], axis=0)
+    attr_train = np.concatenate([mnist_train.labels, mnist_eval.labels], axis=0)
+    eval_data = mnist_test.images
+    attr_eval = mnist_test.labels
+
+    attribute_names = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+
+  elif config['dataset'] == 'CELEBA':
+    crop_width = config['crop_width']
+    img_width = config['img_width']
+    postfix = '_crop_%d_res_%d.npy' % (crop_width, img_width)
+
+    # Load Data
+    scratch = config.get('scratch', get_default_scratch())
+    basepath = os.path.join(scratch, 'celeba')
+    data_path = os.path.join(basepath, 'data')
+    save_path = os.path.join(basepath, 'ckpts')
+
+    (train_data, eval_data, _, attr_train, attr_eval, _,
+     attribute_names) = _load_celeba(data_path, postfix)
+  else:
+    raise NotImplementedError
+
+  return ObjectBlob(
+      crop_width=crop_width,
+      img_width=img_width,
+      basepath=basepath,
+      data_path=data_path,
+      save_path=save_path,
+      train_data=train_data,
+      attr_train=attr_train,
+      eval_data=eval_data,
+      attr_eval=attr_eval,
+      attribute_names=attribute_names,
+  )
+
+
+def get_index_grouped_by_label(label):
+  """Get (an array of) index grouped by label.
+
+  This array is used for label-level sampling.
+  It aims at MNIST and CelebA (in Jesse et al. 2018) with 10 labels.
+
+  Args:
+    label: a list of labels in integer.
+
+  Returns:
+    A (# label - sized) list of lists contatining indices of that label.
+  """
+  index_grouped_by_label = [[] for _ in range(10)]
+  for i, label in enumerate(label):
+    index_grouped_by_label[label].append(i)
+  return index_grouped_by_label
+
+
+def batch_image(b, max_images=64, rows=None, cols=None):
+  """Turn a batch of images into a single image mosaic."""
+  mb = min(b.shape[0], max_images)
+  if rows is None:
+    rows = int(np.ceil(np.sqrt(mb)))
+    cols = rows
+  diff = rows * cols - mb
+  b = np.vstack([b[:mb], np.zeros([diff, b.shape[1], b.shape[2], b.shape[3]])])
+  tmp = b.reshape(-1, cols * b.shape[1], b.shape[2], b.shape[3])
+  img = np.hstack(tmp[i] for i in range(rows))
+  return img
+
+
+def save_image(img, filepath):
+  """Save an image to filepath.
+
+  It assumes `img` is a float numpy array with value in [0, 1]
+
+  Args:
+    img: a float numpy array with value in [0, 1] representing the image.
+    filepath: a string of file path.
+  """
+  img = np.maximum(0, np.minimum(1, img))
+  im = Image.fromarray(np.uint8(img * 255))
+  im.save(filepath)
+
+
+def make_grid(boundary=2.0, number_grid=50, dim_latent=2):
+  """Helper function making 1D or 2D grid for evaluation purpose."""
+  zs = np.linspace(-boundary, boundary, number_grid)
+  z_grid = []
+  if dim_latent == 1:
+    for x in range(number_grid):
+      z_grid.append([zs[x]])
+    dim_grid = 1
+  else:
+    for x in range(number_grid):
+      for y in range(number_grid):
+        z_grid.append([0.] * (dim_latent - 2) + [zs[x], zs[y]])
+    dim_grid = 2
+  z_grid = np.array(z_grid)
+  return ObjectBlob(z_grid=z_grid, dim_grid=dim_grid)
+
+
+def make_batch_image_grid(dim_grid, number_grid):
+  """Returns a patched `make_grid` function for grid."""
+  assert dim_grid in (1, 2)
+  if dim_grid == 1:
+    batch_image_grid = partial(
+        batch_image,
+        max_images=number_grid,
+        rows=1,
+        cols=number_grid,
+    )
+  else:
+    batch_image_grid = partial(
+        batch_image,
+        max_images=number_grid * number_grid,
+        rows=number_grid,
+        cols=number_grid,
+    )
+  return batch_image_grid
+
+
+def post_proc(img, config):
+  """Post process image `img` according to the dataset in `config`."""
+  x = img
+  x = np.minimum(1., np.maximum(0., x))  # clipping
+  if dataset_is_mnist_family(config['dataset']):
+    x = np.reshape(x, (-1, 28, 28))
+    x = np.stack((x,) * 3, -1)  # grey -> rgb
+  return x

--- a/magenta/models/latent_transfer/common.py
+++ b/magenta/models/latent_transfer/common.py
@@ -31,7 +31,7 @@ from PIL import Image
 import tensorflow as tf
 from tensorflow import flags
 
-import local_mnist
+from magenta.models.latent_transfer import local_mnist
 
 FLAGS = flags.FLAGS
 

--- a/magenta/models/latent_transfer/common.py
+++ b/magenta/models/latent_transfer/common.py
@@ -29,13 +29,12 @@ import os
 import numpy as np
 from PIL import Image
 import tensorflow as tf
-from tensorflow import flags
 
 from magenta.models.latent_transfer import local_mnist
 
-FLAGS = flags.FLAGS
+FLAGS = tf.flags.FLAGS
 
-flags.DEFINE_string(
+tf.flags.DEFINE_string(
     'default_scratch', '/tmp/', 'The default root directory for scratching. '
     'It can contain \'~\' which would be handled correctly.')
 

--- a/magenta/models/latent_transfer/common_joint.py
+++ b/magenta/models/latent_transfer/common_joint.py
@@ -38,8 +38,8 @@ from scipy.io import wavfile
 import tensorflow as tf
 from tensorflow import flags
 
-import common
-import model_dataspace
+from magenta.models.latent_transfer import common
+from magenta.models.latent_transfer import model_dataspace
 
 FLAGS = flags.FLAGS
 flags.DEFINE_string(

--- a/magenta/models/latent_transfer/common_joint.py
+++ b/magenta/models/latent_transfer/common_joint.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Common functions/helpers for the joint model.
 
 This library contains many comman functions and helpers used to train (using

--- a/magenta/models/latent_transfer/common_joint.py
+++ b/magenta/models/latent_transfer/common_joint.py
@@ -1,5 +1,29 @@
 """Common functions/helpers for the joint model.
 
+This library contains many comman functions and helpers used to train (using
+script `train_joint.py`) the joint model (defined in `model_joint.py`). These
+components are classified in the following categories:
+
+  - Inetration helper that helps interate through data in the training loop.
+    This includes:
+        `BatchIndexIterator`, `InterGroupSamplingIndexIterator`,
+        `GuasssianDataHelper`, `SingleDataIterator`, `PairedDataIterator`.
+
+  - Summary helper that makes manual sumamrization easiser. This includes:
+        `ManualSummaryHelper`.
+
+  - Loading helper that makes loading config / dataset / model easier. This
+    includes:
+        `config_is_wavegan`, `load_dataset`, `load_dataset_wavegan`,
+        `load_config`, `load_model`, `restore_model`.
+
+  - Model helpers that makes model-related actions such as running,
+    classifying and inferencing easier. This includes:
+        `run_with_batch`, `ModelHelper`, `ModelWaveGANHelper`, `OneSideHelper`.
+
+  - Miscellaneous Helpers, including
+        `prepare_dirs`
+
 """
 from __future__ import absolute_import
 from __future__ import division
@@ -26,30 +50,17 @@ flags.DEFINE_string(
     'The directory to WaveGAN inception (classifier)\'s ckpt. '
     'If WaveGAN is involved, this argument must be set.')
 flags.DEFINE_string(
-    'wavegan_latent_dir', '',
-    'The directory to WaveGAN\'s latent space.'
+    'wavegan_latent_dir', '', 'The directory to WaveGAN\'s latent space.'
     'If WaveGAN is involved, this argument must be set.')
-
-
-def _np_index_arrs(index, *args):
-  """Index arrays with the same given `index`."""
-  return (arr[index] for arr in args)
-
-
-def _np_sample_from_gaussian(mu, sigma):
-  """Sampling from Guassian distribtuion specified by `mu` and `sigma`."""
-  assert mu.shape == sigma.shape
-  return mu + sigma * np.random.randn(*sigma.shape)
 
 
 class BatchIndexIterator(object):
   """An inifite iterator each time yielding batch.
 
-
   This iterator yields the index of data instances rather than data itself.
   This design enables the index to be resuable in indexing multiple arrays.
 
-  Attributes:
+  Args:
     n: An integer indicating total size of dataset.
     batch_size: An integer indictating size of batch.
   """
@@ -59,8 +70,8 @@ class BatchIndexIterator(object):
     self.n = n
     self.batch_size = batch_size
 
-    self.pos = 0
-    self._make_random_order()
+    self._pos = 0
+    self._order = self._make_random_order()
 
   def __iter__(self):
     return self
@@ -70,23 +81,38 @@ class BatchIndexIterator(object):
 
   def __next__(self):
     batch = []
-    for i in range(self.pos, self.pos + self.batch_size):
+    for i in range(self._pos, self._pos + self.batch_size):
       if i % self.n == 0:
-        self._make_random_order()
+        self._order = self._make_random_order()
       batch.append(self._order[i % self.n])
     batch = np.array(batch, dtype=np.int32)
 
-    self.pos += self.batch_size
+    self._pos += self.batch_size
     return batch
 
   def _make_random_order(self):
     """Make a new, shuffled order."""
-    self._order = np.random.permutation(np.arange(0, self.n))
+    return np.random.permutation(np.arange(0, self.n))
 
 
 class InterGroupSamplingIndexIterator(object):
-  '''Radonmly Samples index with a label group.
-  '''
+  """Radonmly samples index with a label group.
+
+  This iterator yields a pair of indices in two dataset that always has the
+  same label. This design enables the index to be resuable in indexing multiple
+  arrays and is needed for the scenario where only label-level alignment is
+  provided.
+
+  Args:
+    group_by_label_A: List of lists for data space A. The i-th list indicates
+        the non-empty list of indices for data instance with i-th (zero-based)
+        label.
+    group_by_label_B: List of lists for data space B. The i-th list indicates
+        the non-empty list of indices for data instance with i-th (zero-based)
+        label.
+    pairing_number: An integer indictating the umber of paired data to be used.
+    batch_size: An integer indictating size of batch.
+  """
 
   # Variable that in its name has A or B indictating their belonging of one side
   # of data has name consider to be invalid by pylint so we disable the warning.
@@ -114,10 +140,10 @@ class InterGroupSamplingIndexIterator(object):
     self.group_by_label_B = group_by_label_B
     self.batch_size = batch_size
 
-    self.pos = 0
+    self._pos = 0
 
-    self.sub_pos_A = [0] * n_label
-    self.sub_pos_B = [0] * n_label
+    self._sub_pos_A = [0] * n_label
+    self._sub_pos_B = [0] * n_label
 
   def __iter__(self):
     return self
@@ -128,14 +154,14 @@ class InterGroupSamplingIndexIterator(object):
 
   def __next__(self):
     batch = []
-    for i in range(self.pos, self.pos + self.batch_size):
+    for i in range(self._pos, self._pos + self.batch_size):
       label = i % self.n_label
-      index_A = self.pick_index(self.sub_pos_A, self.group_by_label_A, label)
-      index_B = self.pick_index(self.sub_pos_B, self.group_by_label_B, label)
+      index_A = self.pick_index(self._sub_pos_A, self.group_by_label_A, label)
+      index_B = self.pick_index(self._sub_pos_B, self.group_by_label_B, label)
       batch.append((index_A, index_B))
     batch = np.array(batch, dtype=np.int32)
 
-    self.pos += self.batch_size
+    self._pos += self.batch_size
     return batch
 
   def pick_index(self, sub_pos, group_by_label, label):
@@ -150,12 +176,13 @@ class InterGroupSamplingIndexIterator(object):
 
 
 class GuasssianDataHelper(object):
-  '''A helper to hold data where each instance is a sampled point.
+  """A helper to hold data where each instance is a sampled point.
 
-    Attributes:
-      mu: Mean of data points
-      sigma: Variance of data points. If it is None, it is treated as zeros.
-    '''
+  Args:
+    mu: Mean of data points.
+    sigma: Variance of data points. If it is None, it is treated as zeros.
+    batch_size: An integer indictating size of batch.
+  """
 
   def __init__(self, mu, sigma=None):
     if sigma is None:
@@ -166,17 +193,33 @@ class GuasssianDataHelper(object):
   def pick_batch(self, batch_index):
     """Pick a batch where instances are sampled from Guassian distributions."""
     mu, sigma = self.mu, self.sigma
-    batch_mu, batch_sigma = _np_index_arrs(batch_index, mu, sigma)
-    batch = _np_sample_from_gaussian(batch_mu, batch_sigma)
+    batch_mu, batch_sigma = self._np_index_arrs(batch_index, mu, sigma)
+    batch = self._np_sample_from_gaussian(batch_mu, batch_sigma)
     return batch
 
   def __len__(self):
     return len(self.mu)
 
+  @staticmethod
+  def _np_sample_from_gaussian(mu, sigma):
+    """Sampling from Guassian distribtuion specified by `mu` and `sigma`."""
+    assert mu.shape == sigma.shape
+    return mu + sigma * np.random.randn(*sigma.shape)
+
+  @staticmethod
+  def _np_index_arrs(index, *args):
+    """Index arrays with the same given `index`."""
+    return (arr[index] for arr in args)
+
 
 class SingleDataIterator(object):
-  '''Iterator of a single-side dataset of encoded representation.
-    '''
+  """Iterator of a single-side dataset of encoded representation.
+
+  Args:
+    mu: Mean of data points.
+    sigma: Variance of data points. If it is None, it is treated as zeros.
+    batch_size: An integer indictating size of batch.
+  """
 
   def __init__(self, mu, sigma, batch_size):
     self.data_helper = GuasssianDataHelper(mu, sigma)
@@ -200,6 +243,25 @@ class SingleDataIterator(object):
 
 class PairedDataIterator(object):
   """Iterator of a paired dataset of encoded representation.
+
+
+  Args:
+    mu_A: Mean of data points in data space A.
+    sigma_A: Variance of data points in data space A. If it is None, it is
+        treated as zeros.
+    label_A: A List of labels for data points in data space A.
+    index_grouped_by_label_A: List of lists for data space A. The i-th list
+        indicates the non-empty list of indices for data instance with i-th
+        (zero-based) label.
+    mu_B: Mean of data points in data space B.
+    sigma_B: Variance of data points in data space B. If it is None, it is
+        treated as zeros.
+    label_B: A List of labels for data points in data space B.
+    index_grouped_by_label_B: List of lists for data space B. The i-th list
+        indicates the non-empty list of indices for data instance with i-th
+        (zero-based) label.
+    pairing_number: An integer indictating the umber of paired data to be used.
+    batch_size: An integer indictating size of batch.
   """
 
   # Variable that in its name has A or B indictating their belonging of one side
@@ -209,8 +271,8 @@ class PairedDataIterator(object):
   def __init__(self, mu_A, sigma_A, train_data_A, label_A,
                index_grouped_by_label_A, mu_B, sigma_B, train_data_B, label_B,
                index_grouped_by_label_B, pairing_number, batch_size):
-    self.data_helper_A = GuasssianDataHelper(mu_A, sigma_A)
-    self.data_helper_B = GuasssianDataHelper(mu_B, sigma_B)
+    self._data_helper_A = GuasssianDataHelper(mu_A, sigma_A)
+    self._data_helper_B = GuasssianDataHelper(mu_B, sigma_B)
 
     self.batch_index_iterator = InterGroupSamplingIndexIterator(
         index_grouped_by_label_A,
@@ -233,8 +295,8 @@ class PairedDataIterator(object):
     batch_index = next(self.batch_index_iterator)
     batch_index_A, batch_index_B = (batch_index[:, 0], batch_index[:, 1])
 
-    batch_A = self.data_helper_A.pick_batch(batch_index_A)
-    batch_B = self.data_helper_B.pick_batch(batch_index_B)
+    batch_A = self._data_helper_A.pick_batch(batch_index_A)
+    batch_B = self._data_helper_B.pick_batch(batch_index_B)
 
     batch_label_A = self.label_A[batch_index_A]
     batch_label_B = self.label_B[batch_index_B]
@@ -252,7 +314,7 @@ class PairedDataIterator(object):
 
 
 class ManualSummaryHelper(object):
-  """A helper making manuall TF summary easier."""
+  """A helper making manual TF summary easier."""
 
   def __init__(self):
     self._key_to_ph_summary_tuple = {}
@@ -288,16 +350,16 @@ def config_is_wavegan(config):
 def load_dataset(config_name, exp_uid):
   """Load a dataset from a config's name.
 
+  The loaded dataset consists of:
+    - original data (dataset_blob, train_data, train_label),
+    - encoded data from a pretrained model (train_mu, train_sigma), and
+    - index grouped by label (index_grouped_by_label).
+
   Args:
     config_name: A string indicating the name of config to parameterize the
         model that associates with the dataset.
     exp_uid: A string representing the unique id of experiment to be used in
         model that associates with the dataset.
-
-  The loaded dataset consists of:
-    - original data (dataset_blob, train_data, train_label),
-    - encoded data from a pretrained model (train_mu, train_sigma), and
-    - index grouped by label (index_grouped_by_label).
 
   Returns:
     An tuple of abovementioned components in the dataset.
@@ -323,7 +385,7 @@ def load_dataset(config_name, exp_uid):
   tf.logging.info('index_grouped_by_label size: %s',
                   [len(_) for _ in index_grouped_by_label])
 
-  tf.logging.info('train loaded from %s' % path_train)
+  tf.logging.info('train loaded from %s', path_train)
   tf.logging.info('train shapes: mu = %s, sigma = %s', train_mu.shape,
                   train_sigma.shape)
   dataset_blob = dataset
@@ -422,9 +484,6 @@ def prepare_dirs(
   sample_dir = join(local_base_path, 'sample', model_uid)
   tf.gfile.MakeDirs(sample_dir)
 
-  os.system('rm -rf "%s/*"' % save_dir)
-  os.system('rm -rf "%s/*"' % sample_dir)
-
   return save_dir, sample_dir
 
 
@@ -458,12 +517,6 @@ class ModelHelper(object):
     classification respectively.
     """
 
-    # pylint:disable=unused-variable
-    # Reason:
-    #   All endpoints are stored as attribute at the end of `_build`.
-    #   Pylint cannot infer this case so it emits false alarm of
-    #   unused-variable if we do not disable this warning.
-
     config_name = self.config_name
     config = load_config(config_name)
     exp_uid = self.exp_uid
@@ -473,11 +526,10 @@ class ModelHelper(object):
       sess = tf.Session(graph=graph)
       m = load_model(model_dataspace.Model, config_name, exp_uid)
 
-    # Add all endpoints as object attributes
-    for k, v in locals().items():
-      self.__dict__[k] = v
-
-    # pylint:enable=unused-variable
+    self.config = config
+    self.graph = graph
+    self.sess = sess
+    self.m = m
 
   def restore_best(self, saver_name, save_path, ckpt_filename_template):
     """Restore the weights of best pre-trained models."""
@@ -499,10 +551,9 @@ class ModelHelper(object):
     Returns:
       A numpy array, the dataspace points from decoding.
     """
-    sess = self.sess
     m = self.m
     batch_size = batch_size or self.DEFAULT_BATCH_SIZE
-    return run_with_batch(sess, m.x_mean, m.z, z, batch_size)
+    return run_with_batch(self.sess, m.x_mean, m.z, z, batch_size)
 
   def classify(self, real_x, batch_size=None):
     """Classify given dataspace points `real_x`.
@@ -515,13 +566,12 @@ class ModelHelper(object):
     Returns:
       A numpy array, the prediction from classifier.
     """
-    sess = self.sess
     m = self.m
     op_target = m.pred_classifier
     op_feed = m.x
     arr_feed = real_x
     batch_size = batch_size or self.DEFAULT_BATCH_SIZE
-    pred = run_with_batch(sess, op_target, op_feed, arr_feed, batch_size)
+    pred = run_with_batch(self.sess, op_target, op_feed, arr_feed, batch_size)
     pred = np.argmax(pred, axis=-1)
     return pred
 
@@ -535,9 +585,8 @@ class ModelHelper(object):
       x_is_real_x: An boolean indicating whether `x` is already in dataspace. If
           not, `x` is converted to dataspace before saving
     """
-    config = self.config
     real_x = x if x_is_real_x else self.decode(x)
-    real_x = common.post_proc(real_x, config)
+    real_x = common.post_proc(real_x, self.config)
     batched_real_x = common.batch_image(real_x)
     sample_file = join(save_dir, '%s.png' % name)
     common.save_image(batched_real_x, sample_file)

--- a/magenta/models/latent_transfer/common_joint.py
+++ b/magenta/models/latent_transfer/common_joint.py
@@ -1,0 +1,729 @@
+"""Common functions/helpers for the joint model.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import importlib
+import os
+from os.path import join
+
+import numpy as np
+from scipy.io import wavfile
+import tensorflow as tf
+from tensorflow import flags
+
+import common
+import model_dataspace
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string(
+    'wavegan_gen_ckpt_dir', '', 'The directory to WaveGAN generator\'s ckpt. '
+    'If WaveGAN is involved, this argument must be set.')
+flags.DEFINE_string(
+    'wavegan_inception_ckpt_dir', '',
+    'The directory to WaveGAN inception (classifier)\'s ckpt. '
+    'If WaveGAN is involved, this argument must be set.')
+flags.DEFINE_string(
+    'wavegan_latent_dir', '',
+    'The directory to WaveGAN\'s latent space.'
+    'If WaveGAN is involved, this argument must be set.')
+
+
+def _np_index_arrs(index, *args):
+  """Index arrays with the same given `index`."""
+  return (arr[index] for arr in args)
+
+
+def _np_sample_from_gaussian(mu, sigma):
+  """Sampling from Guassian distribtuion specified by `mu` and `sigma`."""
+  assert mu.shape == sigma.shape
+  return mu + sigma * np.random.randn(*sigma.shape)
+
+
+class BatchIndexIterator(object):
+  """An inifite iterator each time yielding batch.
+
+
+  This iterator yields the index of data instances rather than data itself.
+  This design enables the index to be resuable in indexing multiple arrays.
+
+  Attributes:
+    n: An integer indicating total size of dataset.
+    batch_size: An integer indictating size of batch.
+  """
+
+  def __init__(self, n, batch_size):
+    """Inits this integer."""
+    self.n = n
+    self.batch_size = batch_size
+
+    self.pos = 0
+    self._make_random_order()
+
+  def __iter__(self):
+    return self
+
+  def next(self):
+    return self.__next__()
+
+  def __next__(self):
+    batch = []
+    for i in range(self.pos, self.pos + self.batch_size):
+      if i % self.n == 0:
+        self._make_random_order()
+      batch.append(self._order[i % self.n])
+    batch = np.array(batch, dtype=np.int32)
+
+    self.pos += self.batch_size
+    return batch
+
+  def _make_random_order(self):
+    """Make a new, shuffled order."""
+    self._order = np.random.permutation(np.arange(0, self.n))
+
+
+class InterGroupSamplingIndexIterator(object):
+  '''Radonmly Samples index with a label group.
+  '''
+
+  # Variable that in its name has A or B indictating their belonging of one side
+  # of data has name consider to be invalid by pylint so we disable the warning.
+  # pylint:disable=invalid-name
+  def __init__(self, group_by_label_A, group_by_label_B, pairing_number,
+               batch_size):
+    assert len(group_by_label_A) == len(group_by_label_B)
+    for _ in group_by_label_A:
+      assert _
+    for _ in group_by_label_B:
+      assert _
+
+    n_label = self.n_label = len(group_by_label_A)
+
+    for i in range(n_label):
+      if pairing_number >= 0:
+        n_use = pairing_number // n_label
+        if pairing_number % n_label != 0:
+          n_use += int(i < pairing_number % n_label)
+      else:
+        n_use = max(len(group_by_label_A[i]), len(group_by_label_B[i]))
+      group_by_label_A[i] = np.array(group_by_label_A[i])[:n_use]
+      group_by_label_B[i] = np.array(group_by_label_B[i])[:n_use]
+    self.group_by_label_A = group_by_label_A
+    self.group_by_label_B = group_by_label_B
+    self.batch_size = batch_size
+
+    self.pos = 0
+
+    self.sub_pos_A = [0] * n_label
+    self.sub_pos_B = [0] * n_label
+
+  def __iter__(self):
+    return self
+
+  def next(self):
+    """Python 2 compatible interface."""
+    return self.__next__()
+
+  def __next__(self):
+    batch = []
+    for i in range(self.pos, self.pos + self.batch_size):
+      label = i % self.n_label
+      index_A = self.pick_index(self.sub_pos_A, self.group_by_label_A, label)
+      index_B = self.pick_index(self.sub_pos_B, self.group_by_label_B, label)
+      batch.append((index_A, index_B))
+    batch = np.array(batch, dtype=np.int32)
+
+    self.pos += self.batch_size
+    return batch
+
+  def pick_index(self, sub_pos, group_by_label, label):
+    if sub_pos[label] == 0:
+      np.random.shuffle(group_by_label[label])
+
+    result = group_by_label[label][sub_pos[label]]
+    sub_pos[label] = (sub_pos[label] + 1) % len(group_by_label[label])
+    return result
+
+  # pylint:enable=invalid-name
+
+
+class GuasssianDataHelper(object):
+  '''A helper to hold data where each instance is a sampled point.
+
+    Attributes:
+      mu: Mean of data points
+      sigma: Variance of data points. If it is None, it is treated as zeros.
+    '''
+
+  def __init__(self, mu, sigma=None):
+    if sigma is None:
+      sigma = np.zeros_like(mu)
+    assert mu.shape == sigma.shape
+    self.mu, self.sigma = mu, sigma
+
+  def pick_batch(self, batch_index):
+    """Pick a batch where instances are sampled from Guassian distributions."""
+    mu, sigma = self.mu, self.sigma
+    batch_mu, batch_sigma = _np_index_arrs(batch_index, mu, sigma)
+    batch = _np_sample_from_gaussian(batch_mu, batch_sigma)
+    return batch
+
+  def __len__(self):
+    return len(self.mu)
+
+
+class SingleDataIterator(object):
+  '''Iterator of a single-side dataset of encoded representation.
+    '''
+
+  def __init__(self, mu, sigma, batch_size):
+    self.data_helper = GuasssianDataHelper(mu, sigma)
+
+    n = len(self.data_helper)
+    self.batch_index_iterator = BatchIndexIterator(n, batch_size)
+
+  def __iter__(self):
+    return self
+
+  def next(self):
+    """Python 2 compatible interface."""
+    return self.__next__()
+
+  def __next__(self):
+    batch_index = next(self.batch_index_iterator)
+    batch = self.data_helper.pick_batch(batch_index)
+    debug_info = (batch_index,)
+    return batch, debug_info
+
+
+class PairedDataIterator(object):
+  """Iterator of a paired dataset of encoded representation.
+  """
+
+  # Variable that in its name has A or B indictating their belonging of one side
+  # of data has name consider to be invalid by pylint so we disable the warning.
+  # pylint:disable=invalid-name
+
+  def __init__(self, mu_A, sigma_A, train_data_A, label_A,
+               index_grouped_by_label_A, mu_B, sigma_B, train_data_B, label_B,
+               index_grouped_by_label_B, pairing_number, batch_size):
+    self.data_helper_A = GuasssianDataHelper(mu_A, sigma_A)
+    self.data_helper_B = GuasssianDataHelper(mu_B, sigma_B)
+
+    self.batch_index_iterator = InterGroupSamplingIndexIterator(
+        index_grouped_by_label_A,
+        index_grouped_by_label_B,
+        pairing_number,
+        batch_size,
+    )
+
+    self.label_A, self.label_B = label_A, label_B
+    self.train_data_A, self.train_data_B = train_data_A, train_data_B
+
+  def __iter__(self):
+    return self
+
+  def next(self):
+    """Python 2 compatible interface."""
+    return self.__next__()
+
+  def __next__(self):
+    batch_index = next(self.batch_index_iterator)
+    batch_index_A, batch_index_B = (batch_index[:, 0], batch_index[:, 1])
+
+    batch_A = self.data_helper_A.pick_batch(batch_index_A)
+    batch_B = self.data_helper_B.pick_batch(batch_index_B)
+
+    batch_label_A = self.label_A[batch_index_A]
+    batch_label_B = self.label_B[batch_index_B]
+    assert np.array_equal(batch_label_A, batch_label_B)
+
+    batch_train_data_A = self.train_data_A[
+        batch_index_A] if self.train_data_A is not None else None
+    batch_train_data_B = self.train_data_B[
+        batch_index_B] if self.train_data_B is not None else None
+    debug_info = (batch_train_data_A, batch_train_data_B)
+
+    return batch_A, batch_B, debug_info
+
+  # pylint:enable=invalid-name
+
+
+class ManualSummaryHelper(object):
+  """A helper making manuall TF summary easier."""
+
+  def __init__(self):
+    self._key_to_ph_summary_tuple = {}
+
+  def get_summary(self, sess, key, value):
+    """Get TF (scalar) summary.
+
+    Args:
+      sess: A TF Session to be used in making summary.
+      key: A string indicating the name of summary.
+      value: A string indicating the value of summary.
+
+    Returns:
+      A TF summary.
+    """
+    self._add_key_if_not_exists(key)
+    placeholder, summary = self._key_to_ph_summary_tuple[key]
+    return sess.run(summary, {placeholder: value})
+
+  def _add_key_if_not_exists(self, key):
+    """Add related TF heads for a key if it is not used before."""
+    if key in self._key_to_ph_summary_tuple:
+      return
+    placeholder = tf.placeholder(tf.float32, shape=(), name=key + '_ph')
+    summary = tf.summary.scalar(key, placeholder)
+    self._key_to_ph_summary_tuple[key] = (placeholder, summary)
+
+
+def config_is_wavegan(config):
+  return config['dataset'].lower() == 'wavegan'
+
+
+def load_dataset(config_name, exp_uid):
+  """Load a dataset from a config's name.
+
+  Args:
+    config_name: A string indicating the name of config to parameterize the
+        model that associates with the dataset.
+    exp_uid: A string representing the unique id of experiment to be used in
+        model that associates with the dataset.
+
+  The loaded dataset consists of:
+    - original data (dataset_blob, train_data, train_label),
+    - encoded data from a pretrained model (train_mu, train_sigma), and
+    - index grouped by label (index_grouped_by_label).
+
+  Returns:
+    An tuple of abovementioned components in the dataset.
+  """
+
+  config = load_config(config_name)
+  if config_is_wavegan(config):
+    return load_dataset_wavegan()
+
+  model_uid = common.get_model_uid(config_name, exp_uid)
+
+  dataset = common.load_dataset(config)
+  train_data = dataset.train_data
+  attr_train = dataset.attr_train
+  path_train = join(dataset.basepath, 'encoded', model_uid,
+                    'encoded_train_data.npz')
+  train = np.load(path_train)
+  train_mu = train['mu']
+  train_sigma = train['sigma']
+  train_label = np.argmax(attr_train, axis=-1)  # from one-hot to label
+  index_grouped_by_label = common.get_index_grouped_by_label(train_label)
+
+  tf.logging.info('index_grouped_by_label size: %s',
+                  [len(_) for _ in index_grouped_by_label])
+
+  tf.logging.info('train loaded from %s' % path_train)
+  tf.logging.info('train shapes: mu = %s, sigma = %s', train_mu.shape,
+                  train_sigma.shape)
+  dataset_blob = dataset
+  return (dataset_blob, train_data, train_label, train_mu, train_sigma,
+          index_grouped_by_label)
+
+
+def load_dataset_wavegan():
+  """Load WaveGAN's dataset.
+
+  The loaded dataset consists of:
+    - original data (dataset_blob, train_data, train_label),
+    - encoded data from a pretrained model (train_mu, train_sigma), and
+    - index grouped by label (index_grouped_by_label).
+
+  Some of these attributes are not avaiable (set as None) but are left here
+  to keep everything aligned with returned value of `load_dataset`.
+
+  Returns:
+    An tuple of abovementioned components in the dataset.
+  """
+
+  latent_dir = os.path.expanduser(FLAGS.wavegan_latent_dir)
+  path_train = os.path.join(latent_dir, 'data_train.npz')
+  train = np.load(path_train)
+  train_z = train['z']
+  train_label = train['label']
+  index_grouped_by_label = common.get_index_grouped_by_label(train_label)
+
+  dataset_blob, train_data = None, None
+  train_mu, train_sigma = train_z, None
+  return (dataset_blob, train_data, train_label, train_mu, train_sigma,
+          index_grouped_by_label)
+
+
+def load_config(config_name):
+  """Load the config from its name."""
+  return importlib.import_module('configs.%s' % config_name).config
+
+
+def load_model(model_cls, config_name, exp_uid):
+  """Load a model.
+
+  Args:
+    model_cls: A sonnet Class that is the factory of model.
+    config_name: A string indicating the name of config to parameterize the
+        model.
+    exp_uid: A string representing the unique id of experiment to be used in
+        model.
+
+  Returns:
+    An instance of sonnet model.
+  """
+
+  config = load_config(config_name)
+  model_uid = common.get_model_uid(config_name, exp_uid)
+
+  m = model_cls(config, name=model_uid)
+  m()
+  return m
+
+
+def restore_model(saver, config_name, exp_uid, sess, save_path,
+                  ckpt_filename_template):
+  model_uid = common.get_model_uid(config_name, exp_uid)
+  saver.restore(
+      sess,
+      join(save_path, model_uid, 'best', ckpt_filename_template % model_uid))
+
+
+def prepare_dirs(
+    signature='unspecified_signature',
+    config_name='unspecified_config_name',
+    exp_uid='unspecified_exp_uid',
+):
+  """Prepare saving and sampling direcotories for training.
+
+  Args:
+    signature: A string of signature of model such as `joint_model`.
+    config_name: A string representing the name of config for joint model.
+    exp_uid: A string representing the unique id of experiment to be used in
+        joint model.
+
+  Returns:
+    A tuple of (save_dir, sample_dir). They are strings and are paths to the
+        directory for saving checkpoints / summaries and path to the directory
+        for saving samplings, respectively.
+  """
+
+  model_uid = common.get_model_uid(config_name, exp_uid)
+
+  local_base_path = os.path.join(common.get_default_scratch(), signature)
+
+  save_dir = join(local_base_path, 'ckpts', model_uid)
+  tf.gfile.MakeDirs(save_dir)
+  sample_dir = join(local_base_path, 'sample', model_uid)
+  tf.gfile.MakeDirs(sample_dir)
+
+  os.system('rm -rf "%s/*"' % save_dir)
+  os.system('rm -rf "%s/*"' % sample_dir)
+
+  return save_dir, sample_dir
+
+
+def run_with_batch(sess, op_target, op_feed, arr_feed, batch_size=None):
+  if batch_size is None:
+    batch_size = len(arr_feed)
+  return np.concatenate([
+      sess.run(op_target, {op_feed: arr_feed[i:i + batch_size]})
+      for i in range(0, len(arr_feed), batch_size)
+  ])
+
+
+class ModelHelper(object):
+  """A Helper that provides sampling and classification for pre-trained WaveGAN.
+
+  This generic helper is for VAE model we trained as dataspace model.
+  For external sourced model use specified helper such as `ModelWaveGANHelper`.
+  """
+  DEFAULT_BATCH_SIZE = 100
+
+  def __init__(self, config_name, exp_uid):
+    self.config_name = config_name
+    self.exp_uid = exp_uid
+
+    self.build()
+
+  def build(self):
+    """Build the TF graph and heads for dataspace model.
+
+    It also prepares different graph, session and heads for sampling and
+    classification respectively.
+    """
+
+    # pylint:disable=unused-variable
+    # Reason:
+    #   All endpoints are stored as attribute at the end of `_build`.
+    #   Pylint cannot infer this case so it emits false alarm of
+    #   unused-variable if we do not disable this warning.
+
+    config_name = self.config_name
+    config = load_config(config_name)
+    exp_uid = self.exp_uid
+
+    graph = tf.Graph()
+    with graph.as_default():
+      sess = tf.Session(graph=graph)
+      m = load_model(model_dataspace.Model, config_name, exp_uid)
+
+    # Add all endpoints as object attributes
+    for k, v in locals().items():
+      self.__dict__[k] = v
+
+    # pylint:enable=unused-variable
+
+  def restore_best(self, saver_name, save_path, ckpt_filename_template):
+    """Restore the weights of best pre-trained models."""
+    config_name = self.config_name
+    exp_uid = self.exp_uid
+    sess = self.sess
+    saver = getattr(self.m, saver_name)
+    restore_model(saver, config_name, exp_uid, sess, save_path,
+                  ckpt_filename_template)
+
+  def decode(self, z, batch_size=None):
+    """Decode from given latant space vectors `z`.
+
+    Args:
+      z: A numpy array of latent space vectors.
+      batch_size: (Optional) a integer to indication batch size for computation
+          which is useful if the sampling requires lots of GPU memory.
+
+    Returns:
+      A numpy array, the dataspace points from decoding.
+    """
+    sess = self.sess
+    m = self.m
+    batch_size = batch_size or self.DEFAULT_BATCH_SIZE
+    return run_with_batch(sess, m.x_mean, m.z, z, batch_size)
+
+  def classify(self, real_x, batch_size=None):
+    """Classify given dataspace points `real_x`.
+
+    Args:
+      real_x: A numpy array of dataspace points.
+      batch_size: (Optional) a integer to indication batch size for computation
+          which is useful if the classification requires lots of GPU memory.
+
+    Returns:
+      A numpy array, the prediction from classifier.
+    """
+    sess = self.sess
+    m = self.m
+    op_target = m.pred_classifier
+    op_feed = m.x
+    arr_feed = real_x
+    batch_size = batch_size or self.DEFAULT_BATCH_SIZE
+    pred = run_with_batch(sess, op_target, op_feed, arr_feed, batch_size)
+    pred = np.argmax(pred, axis=-1)
+    return pred
+
+  def save_data(self, x, name, save_dir, x_is_real_x=False):
+    """Save dataspace instances.
+
+    Args:
+      x: A numpy array of dataspace points.
+      name: A string indicating the name in the saved file.
+      save_dir: A string indicating the directory to put the saved file.
+      x_is_real_x: An boolean indicating whether `x` is already in dataspace. If
+          not, `x` is converted to dataspace before saving
+    """
+    config = self.config
+    real_x = x if x_is_real_x else self.decode(x)
+    real_x = common.post_proc(real_x, config)
+    batched_real_x = common.batch_image(real_x)
+    sample_file = join(save_dir, '%s.png' % name)
+    common.save_image(batched_real_x, sample_file)
+
+
+class ModelWaveGANHelper(object):
+  """A Helper that provides sampling and classification for pre-trained WaveGAN.
+  """
+  DEFAULT_BATCH_SIZE = 100
+
+  def __init__(self):
+    self.build()
+
+  def build(self):
+    """Build the TF graph and heads from pre-trained WaveGAN ckpts.
+
+    It also prepares different graph, session and heads for sampling and
+    classification respectively.
+    """
+
+    # pylint:disable=unused-variable
+    # Reason:
+    #   All endpoints are stored as attribute at the end of `_build`.
+    #   Pylint cannot infer this case so it emits false alarm of
+    #   unused-variable if we do not disable this warning.
+
+    # pylint:disable=invalid-name
+    # Reason:
+    #   Variable useing 'G' in is name to be consistent with WaveGAN's author
+    #   has name consider to be invalid by pylint so we disable the warning.
+
+    # Dataset (SC09, WaveGAN)'s generator
+    graph_sc09_gan = tf.Graph()
+    with graph_sc09_gan.as_default():
+      # Use the retrained, Gaussian priored model
+      gen_ckpt_dir = os.path.expanduser(FLAGS.wavegan_gen_ckpt_dir)
+      sess_sc09_gan = tf.Session(graph=graph_sc09_gan)
+      saver_gan = tf.train.import_meta_graph(
+          join(gen_ckpt_dir, 'infer', 'infer.meta'))
+
+    # Dataset (SC09, WaveGAN)'s  classifier (inception)
+    graph_sc09_class = tf.Graph()
+    with graph_sc09_class.as_default():
+      inception_ckpt_dir = os.path.expanduser(FLAGS.wavegan_inception_ckpt_dir)
+      sess_sc09_class = tf.Session(graph=graph_sc09_class)
+      saver_class = tf.train.import_meta_graph(
+          join(inception_ckpt_dir, 'infer.meta'))
+
+    # Dataset B (SC09, WaveGAN)'s Tensor symbols
+    sc09_gan_z = graph_sc09_gan.get_tensor_by_name('z:0')
+    sc09_gan_G_z = graph_sc09_gan.get_tensor_by_name('G_z:0')[:, :, 0]
+
+    # Classification: Tensor symbols
+    sc09_class_x = graph_sc09_class.get_tensor_by_name('x:0')
+    sc09_class_scores = graph_sc09_class.get_tensor_by_name('scores:0')
+
+    # Add all endpoints as object attributes
+    for k, v in locals().items():
+      self.__dict__[k] = v
+
+  def restore(self):
+    """Restore the weights of models."""
+    gen_ckpt_dir = self.gen_ckpt_dir
+    graph_sc09_gan = self.graph_sc09_gan
+    saver_gan = self.saver_gan
+    sess_sc09_gan = self.sess_sc09_gan
+
+    inception_ckpt_dir = self.inception_ckpt_dir
+    graph_sc09_class = self.graph_sc09_class
+    saver_class = self.saver_class
+    sess_sc09_class = self.sess_sc09_class
+
+    with graph_sc09_gan.as_default():
+      saver_gan.restore(sess_sc09_gan, join(gen_ckpt_dir, 'bridge',
+                                            'model.ckpt'))
+
+    with graph_sc09_class.as_default():
+      saver_class.restore(sess_sc09_class,
+                          join(inception_ckpt_dir, 'best_acc-103005'))
+
+    # pylint:enable=unused-variable
+    # pylint:enable=invalid-name
+
+  def decode(self, z, batch_size=None):
+    """Decode from given latant space vectors `z`.
+
+    Args:
+      z: A numpy array of latent space vectors.
+      batch_size: (Optional) a integer to indication batch size for computation
+          which is useful if the sampling requires lots of GPU memory.
+
+    Returns:
+      A numpy array, the dataspace points from decoding.
+    """
+    batch_size = batch_size or self.DEFAULT_BATCH_SIZE
+    return run_with_batch(self.sess_sc09_gan, self.sc09_gan_G_z,
+                          self.sc09_gan_z, z, batch_size)
+
+  def classify(self, real_x, batch_size=None):
+    """Classify given dataspace points `real_x`.
+
+    Args:
+      real_x: A numpy array of dataspace points.
+      batch_size: (Optional) a integer to indication batch size for computation
+          which is useful if the classification requires lots of GPU memory.
+
+    Returns:
+      A numpy array, the prediction from classifier.
+    """
+    batch_size = batch_size or self.DEFAULT_BATCH_SIZE
+    pred = run_with_batch(self.sess_sc09_class, self.sc09_class_scores,
+                          self.sc09_class_x, real_x, batch_size)
+    pred = np.argmax(pred, axis=-1)
+    return pred
+
+  def save_data(self, x, name, save_dir, x_is_real_x=False):
+    """Save dataspace instances.
+
+    Args:
+      x: A numpy array of dataspace points.
+      name: A string indicating the name in the saved file.
+      save_dir: A string indicating the directory to put the saved file.
+      x_is_real_x: An boolean indicating whether `x` is already in dataspace. If
+          not, `x` is converted to dataspace before saving
+    """
+    real_x = x if x_is_real_x else self.decode(x)
+    real_x = real_x.reshape(-1)
+    sample_file = join(save_dir, '%s.wav' % name)
+    wavfile.write(sample_file, rate=16000, data=real_x)
+
+
+class OneSideHelper(object):
+  """The helper that manages model and classifier in dataspace for joint model.
+
+  Attributes:
+    config_name: A string representing the name of config for model in
+        dataspace.
+    exp_uid: A string representing the unique id of experiment used in
+        the model in dataspace.
+    config_name_classifier: A string representing the name of config for
+        clasisifer in dataspace.
+    exp_uid_classifier: A string representing the unique id of experiment used
+        in the clasisifer in dataspace.
+  """
+
+  def __init__(
+      self,
+      config_name,
+      exp_uid,
+      config_name_classifier,
+      exp_uid_classifier,
+  ):
+    config = load_config(config_name)
+    this_config_is_wavegan = config_is_wavegan(config)
+    if this_config_is_wavegan:
+      # The sample object servers both purpose.
+      m_helper = ModelWaveGANHelper()
+      m_classifier_helper = m_helper
+    else:
+      # In this case two diffent objects serve two purpose.
+      m_helper = ModelHelper(config_name, exp_uid)
+      m_classifier_helper = ModelHelper(config_name_classifier,
+                                        exp_uid_classifier)
+
+    self.config_name = config_name
+    self.this_config_is_wavegan = this_config_is_wavegan
+    self.config = config
+    self.m_helper = m_helper
+    self.m_classifier_helper = m_classifier_helper
+
+  def restore(self, dataset_blob):
+    """Restore the pretrained model and classifier.
+
+    Args:
+      dataset_blob: The object containts `save_path` used for restoring.
+    """
+    this_config_is_wavegan = self.this_config_is_wavegan
+    m_helper = self.m_helper
+    m_classifier_helper = self.m_classifier_helper
+
+    if this_config_is_wavegan:
+      m_helper.restore()
+      # We don't need restore the `m_classifier_helper` again since `m_helper`
+      # and `m_classifier_helper` are two identicial objects.
+    else:
+      m_helper.restore_best('vae_saver', dataset_blob.save_path,
+                            'vae_best_%s.ckpt')
+      m_classifier_helper.restore_best(
+          'classifier_saver', dataset_blob.save_path, 'classifier_best_%s.ckpt')

--- a/magenta/models/latent_transfer/common_joint.py
+++ b/magenta/models/latent_transfer/common_joint.py
@@ -36,20 +36,19 @@ from os.path import join
 import numpy as np
 from scipy.io import wavfile
 import tensorflow as tf
-from tensorflow import flags
 
 from magenta.models.latent_transfer import common
 from magenta.models.latent_transfer import model_dataspace
 
-FLAGS = flags.FLAGS
-flags.DEFINE_string(
+FLAGS = tf.flags.FLAGS
+tf.flags.DEFINE_string(
     'wavegan_gen_ckpt_dir', '', 'The directory to WaveGAN generator\'s ckpt. '
     'If WaveGAN is involved, this argument must be set.')
-flags.DEFINE_string(
+tf.flags.DEFINE_string(
     'wavegan_inception_ckpt_dir', '',
     'The directory to WaveGAN inception (classifier)\'s ckpt. '
     'If WaveGAN is involved, this argument must be set.')
-flags.DEFINE_string(
+tf.flags.DEFINE_string(
     'wavegan_latent_dir', '', 'The directory to WaveGAN\'s latent space.'
     'If WaveGAN is involved, this argument must be set.')
 

--- a/magenta/models/latent_transfer/configs/__init__.py
+++ b/magenta/models/latent_transfer/configs/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/magenta/models/latent_transfer/configs/fashion_mnist_0_nlatent100.py
+++ b/magenta/models/latent_transfer/configs/fashion_mnist_0_nlatent100.py
@@ -5,7 +5,7 @@
 
 from functools import partial
 
-import nn
+from magenta.models.latent_transfer import nn
 
 n_latent = 100
 

--- a/magenta/models/latent_transfer/configs/fashion_mnist_0_nlatent100.py
+++ b/magenta/models/latent_transfer/configs/fashion_mnist_0_nlatent100.py
@@ -1,0 +1,27 @@
+"""Config for Fashion-MNIST with nlatent=64.
+"""
+
+# pylint:disable=invalid-name
+
+from functools import partial
+
+import nn
+
+n_latent = 100
+
+Encoder = partial(nn.EncoderMNIST, n_latent=n_latent)
+Decoder = nn.DecoderMNIST
+Classifier = nn.DFull
+
+config = {
+    'Encoder': Encoder,
+    'Decoder': Decoder,
+    'Classifier': Classifier,
+    'n_latent': n_latent,
+    'dataset': 'FASHION-MNIST',
+    'img_width': 28,
+    'crop_width': 108,
+    'batch_size': 512,
+    'beta': 1.0,
+    'x_sigma': 0.1,
+}

--- a/magenta/models/latent_transfer/configs/fashion_mnist_0_nlatent100.py
+++ b/magenta/models/latent_transfer/configs/fashion_mnist_0_nlatent100.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Config for Fashion-MNIST with nlatent=64.
 """
 

--- a/magenta/models/latent_transfer/configs/fashion_mnist_0_nlatent64.py
+++ b/magenta/models/latent_transfer/configs/fashion_mnist_0_nlatent64.py
@@ -1,0 +1,27 @@
+"""Config for Fashion-MNIST with nlatent=64.
+"""
+
+# pylint:disable=invalid-name
+
+from functools import partial
+
+import nn
+
+n_latent = 64
+
+Encoder = partial(nn.EncoderMNIST, n_latent=n_latent)
+Decoder = nn.DecoderMNIST
+Classifier = nn.DFull
+
+config = {
+    'Encoder': Encoder,
+    'Decoder': Decoder,
+    'Classifier': Classifier,
+    'n_latent': n_latent,
+    'dataset': 'FASHION-MNIST',
+    'img_width': 28,
+    'crop_width': 108,
+    'batch_size': 512,
+    'beta': 1.0,
+    'x_sigma': 0.1,
+}

--- a/magenta/models/latent_transfer/configs/fashion_mnist_0_nlatent64.py
+++ b/magenta/models/latent_transfer/configs/fashion_mnist_0_nlatent64.py
@@ -5,7 +5,7 @@
 
 from functools import partial
 
-import nn
+from magenta.models.latent_transfer import nn
 
 n_latent = 64
 

--- a/magenta/models/latent_transfer/configs/fashion_mnist_0_nlatent64.py
+++ b/magenta/models/latent_transfer/configs/fashion_mnist_0_nlatent64.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Config for Fashion-MNIST with nlatent=64.
 """
 

--- a/magenta/models/latent_transfer/configs/fashion_mnist_classifier_0.py
+++ b/magenta/models/latent_transfer/configs/fashion_mnist_classifier_0.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Config for Fasion-MNIST classifier.
 """
 

--- a/magenta/models/latent_transfer/configs/fashion_mnist_classifier_0.py
+++ b/magenta/models/latent_transfer/configs/fashion_mnist_classifier_0.py
@@ -1,0 +1,14 @@
+"""Config for Fasion-MNIST classifier.
+"""
+
+# pylint:disable=invalid-name
+
+import nn
+from configs import fashion_mnist_0_nlatent64
+
+config = fashion_mnist_0_nlatent64.config
+
+Classifier = nn.DFull
+
+config['batch_size'] = 256
+config['Classifier'] = Classifier

--- a/magenta/models/latent_transfer/configs/fashion_mnist_classifier_0.py
+++ b/magenta/models/latent_transfer/configs/fashion_mnist_classifier_0.py
@@ -3,8 +3,8 @@
 
 # pylint:disable=invalid-name
 
-import nn
-from configs import fashion_mnist_0_nlatent64
+from magenta.models.latent_transfer import nn
+from magenta.models.latent_transfer.configs import fashion_mnist_0_nlatent64
 
 config = fashion_mnist_0_nlatent64.config
 

--- a/magenta/models/latent_transfer/configs/joint_exp_2fashion_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_2fashion_parameterized.py
@@ -4,11 +4,12 @@
 # pylint:disable=invalid-name
 
 from functools import partial
-from tensorflow import flags
+
+import temsorflow as tf
 
 from magenta.models.latent_transfer import model_joint
 
-FLAGS = flags.FLAGS
+FLAGS = tf.flags.FLAGS
 
 n_latent = FLAGS.n_latent
 n_latent_shared = FLAGS.n_latent_shared

--- a/magenta/models/latent_transfer/configs/joint_exp_2fashion_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_2fashion_parameterized.py
@@ -1,0 +1,68 @@
+"""Config for Fashion-MNIST <> Fashion-MNIST transfer.
+"""
+
+# pylint:disable=invalid-name
+
+from functools import partial
+from tensorflow import flags
+
+import model_joint
+
+FLAGS = flags.FLAGS
+
+n_latent = 64
+n_latent_shared = FLAGS.n_latent_shared
+layers = (128,) * 4
+batch_size = 128
+
+Encoder = partial(
+    model_joint.EncoderLatentFull,
+    input_size=n_latent,
+    output_size=n_latent_shared,
+    layers=layers)
+
+Decoder = partial(
+    model_joint.DecoderLatentFull,
+    input_size=n_latent_shared,
+    output_size=n_latent,
+    layers=layers)
+
+vae_config_A = {
+    'Encoder': Encoder,
+    'Decoder': Decoder,
+    'prior_loss_beta': FLAGS.prior_loss_beta_A,
+    'prior_loss': 'KL',
+    'batch_size': batch_size,
+    'n_latent': n_latent,
+    'n_latent_shared': n_latent_shared,
+}
+
+vae_config_B = {
+    'Encoder': Encoder,
+    'Decoder': Decoder,
+    'prior_loss_beta': FLAGS.prior_loss_beta_B,
+    'prior_loss': 'KL',
+    'batch_size': batch_size,
+    'n_latent': n_latent,
+    'n_latent_shared': n_latent_shared,
+}
+
+config = {
+    'vae_A': vae_config_A,
+    'vae_B': vae_config_B,
+    'config_A': 'fashion_mnist_0_nlatent64',
+    'config_B': 'fashion_mnist_0_nlatent64',
+    'config_classifier_A': 'fashion_mnist_classifier_0',
+    'config_classifier_B': 'fashion_mnist_classifier_0',
+    # model
+    'prior_loss_align_beta': FLAGS.prior_loss_align_beta,
+    'mean_recons_A_align_beta': FLAGS.mean_recons_A_align_beta,
+    'mean_recons_B_align_beta': FLAGS.mean_recons_B_align_beta,
+    'mean_recons_A_to_B_align_beta': FLAGS.mean_recons_A_to_B_align_beta,
+    'mean_recons_B_to_A_align_beta': FLAGS.mean_recons_B_to_A_align_beta,
+    'pairing_number': FLAGS.pairing_number,
+    # training dynamics
+    'batch_size': batch_size,
+    'n_latent': n_latent,
+    'n_latent_shared': n_latent_shared,
+}

--- a/magenta/models/latent_transfer/configs/joint_exp_2fashion_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_2fashion_parameterized.py
@@ -6,7 +6,7 @@
 from functools import partial
 from tensorflow import flags
 
-import model_joint
+from magenta.models.latent_transfer import model_joint
 
 FLAGS = flags.FLAGS
 

--- a/magenta/models/latent_transfer/configs/joint_exp_2fashion_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_2fashion_parameterized.py
@@ -10,7 +10,7 @@ import model_joint
 
 FLAGS = flags.FLAGS
 
-n_latent = 64
+n_latent = FLAGS.n_latent
 n_latent_shared = FLAGS.n_latent_shared
 layers = (128,) * 4
 batch_size = 128

--- a/magenta/models/latent_transfer/configs/joint_exp_2fashion_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_2fashion_parameterized.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Config for Fashion-MNIST <> Fashion-MNIST transfer.
 """
 

--- a/magenta/models/latent_transfer/configs/joint_exp_2mnist_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_2mnist_parameterized.py
@@ -1,0 +1,68 @@
+"""Config for MNIST <> MNIST transfer.
+"""
+
+# pylint:disable=invalid-name
+
+from functools import partial
+from tensorflow import flags
+
+import model_joint
+
+FLAGS = flags.FLAGS
+
+n_latent = 64
+n_latent_shared = FLAGS.n_latent_shared
+layers = (128,) * 4
+batch_size = 128
+
+Encoder = partial(
+    model_joint.EncoderLatentFull,
+    input_size=n_latent,
+    output_size=n_latent_shared,
+    layers=layers)
+
+Decoder = partial(
+    model_joint.DecoderLatentFull,
+    input_size=n_latent_shared,
+    output_size=n_latent,
+    layers=layers)
+
+vae_config_A = {
+    'Encoder': Encoder,
+    'Decoder': Decoder,
+    'prior_loss_beta': FLAGS.prior_loss_beta_A,
+    'prior_loss': 'KL',
+    'batch_size': batch_size,
+    'n_latent': n_latent,
+    'n_latent_shared': n_latent_shared,
+}
+
+vae_config_B = {
+    'Encoder': Encoder,
+    'Decoder': Decoder,
+    'prior_loss_beta': FLAGS.prior_loss_beta_B,
+    'prior_loss': 'KL',
+    'batch_size': batch_size,
+    'n_latent': n_latent,
+    'n_latent_shared': n_latent_shared,
+}
+
+config = {
+    'vae_A': vae_config_A,
+    'vae_B': vae_config_B,
+    'config_A': 'mnist_0_nlatent64',
+    'config_B': 'mnist_0_nlatent64',
+    'config_classifier_A': 'mnist_classifier_0',
+    'config_classifier_B': 'mnist_classifier_0',
+    # model
+    'prior_loss_align_beta': FLAGS.prior_loss_align_beta,
+    'mean_recons_A_align_beta': FLAGS.mean_recons_A_align_beta,
+    'mean_recons_B_align_beta': FLAGS.mean_recons_B_align_beta,
+    'mean_recons_A_to_B_align_beta': FLAGS.mean_recons_A_to_B_align_beta,
+    'mean_recons_B_to_A_align_beta': FLAGS.mean_recons_B_to_A_align_beta,
+    'pairing_number': FLAGS.pairing_number,
+    # training dynamics
+    'batch_size': batch_size,
+    'n_latent': n_latent,
+    'n_latent_shared': n_latent_shared,
+}

--- a/magenta/models/latent_transfer/configs/joint_exp_2mnist_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_2mnist_parameterized.py
@@ -4,11 +4,12 @@
 # pylint:disable=invalid-name
 
 from functools import partial
-from tensorflow import flags
+
+import temsorflow as tf
 
 from magenta.models.latent_transfer import model_joint
 
-FLAGS = flags.FLAGS
+FLAGS = tf.flags.FLAGS
 
 n_latent = FLAGS.n_latent
 n_latent_shared = FLAGS.n_latent_shared

--- a/magenta/models/latent_transfer/configs/joint_exp_2mnist_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_2mnist_parameterized.py
@@ -6,7 +6,7 @@
 from functools import partial
 from tensorflow import flags
 
-import model_joint
+from magenta.models.latent_transfer import model_joint
 
 FLAGS = flags.FLAGS
 

--- a/magenta/models/latent_transfer/configs/joint_exp_2mnist_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_2mnist_parameterized.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Config for MNIST <> MNIST transfer.
 """
 

--- a/magenta/models/latent_transfer/configs/joint_exp_mnist100_2wavegan_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_mnist100_2wavegan_parameterized.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Config for MNIST <> WaveGAN transfer.
 """
 

--- a/magenta/models/latent_transfer/configs/joint_exp_mnist100_2wavegan_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_mnist100_2wavegan_parameterized.py
@@ -1,4 +1,4 @@
-"""Config for MNIST <> MNIST transfer.
+"""Config for MNIST <> WaveGAN transfer.
 """
 
 # pylint:disable=invalid-name
@@ -10,21 +10,23 @@ import model_joint
 
 FLAGS = flags.FLAGS
 
-n_latent = FLAGS.n_latent
+n_latent_A = 100
+n_latent_B = 100
 n_latent_shared = FLAGS.n_latent_shared
 layers = (128,) * 4
+layers_B = (2048,) * 8
 batch_size = 128
 
 Encoder = partial(
     model_joint.EncoderLatentFull,
-    input_size=n_latent,
+    input_size=n_latent_A,
     output_size=n_latent_shared,
     layers=layers)
 
 Decoder = partial(
     model_joint.DecoderLatentFull,
     input_size=n_latent_shared,
-    output_size=n_latent,
+    output_size=n_latent_A,
     layers=layers)
 
 vae_config_A = {
@@ -33,27 +35,46 @@ vae_config_A = {
     'prior_loss_beta': FLAGS.prior_loss_beta_A,
     'prior_loss': 'KL',
     'batch_size': batch_size,
-    'n_latent': n_latent,
+    'n_latent': n_latent_A,
     'n_latent_shared': n_latent_shared,
 }
 
-vae_config_B = {
-    'Encoder': Encoder,
-    'Decoder': Decoder,
+
+def make_Encoder_B(n_latent):
+  return partial(
+      model_joint.EncoderLatentFull,
+      input_size=n_latent,
+      output_size=n_latent_shared,
+      layers=layers_B,
+  )
+
+
+def make_Decoder_B(n_latent):
+  return partial(
+      model_joint.DecoderLatentFull,
+      input_size=n_latent_shared,
+      output_size=n_latent,
+      layers=layers_B,
+  )
+
+
+wavegan_config_B = {
+    'Encoder': make_Encoder_B(n_latent_B),
+    'Decoder': make_Decoder_B(n_latent_B),
     'prior_loss_beta': FLAGS.prior_loss_beta_B,
     'prior_loss': 'KL',
     'batch_size': batch_size,
-    'n_latent': n_latent,
+    'n_latent': n_latent_B,
     'n_latent_shared': n_latent_shared,
 }
 
 config = {
     'vae_A': vae_config_A,
-    'vae_B': vae_config_B,
-    'config_A': 'mnist_0_nlatent64',
-    'config_B': 'mnist_0_nlatent64',
+    'vae_B': wavegan_config_B,
+    'config_A': 'mnist_0_nlatent100',
+    'config_B': 'wavegan',
     'config_classifier_A': 'mnist_classifier_0',
-    'config_classifier_B': 'mnist_classifier_0',
+    'config_classifier_B': '<unused>',
     # model
     'prior_loss_align_beta': FLAGS.prior_loss_align_beta,
     'mean_recons_A_align_beta': FLAGS.mean_recons_A_align_beta,
@@ -63,6 +84,5 @@ config = {
     'pairing_number': FLAGS.pairing_number,
     # training dynamics
     'batch_size': batch_size,
-    'n_latent': n_latent,
     'n_latent_shared': n_latent_shared,
 }

--- a/magenta/models/latent_transfer/configs/joint_exp_mnist100_2wavegan_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_mnist100_2wavegan_parameterized.py
@@ -4,11 +4,12 @@
 # pylint:disable=invalid-name
 
 from functools import partial
-from tensorflow import flags
+
+import temsorflow as tf
 
 from magenta.models.latent_transfer import model_joint
 
-FLAGS = flags.FLAGS
+FLAGS = tf.flags.FLAGS
 
 n_latent_A = 100
 n_latent_B = 100

--- a/magenta/models/latent_transfer/configs/joint_exp_mnist100_2wavegan_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_mnist100_2wavegan_parameterized.py
@@ -6,7 +6,7 @@
 from functools import partial
 from tensorflow import flags
 
-import model_joint
+from magenta.models.latent_transfer import model_joint
 
 FLAGS = flags.FLAGS
 

--- a/magenta/models/latent_transfer/configs/joint_exp_mnist2fashion_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_mnist2fashion_parameterized.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Config for MNIST <> Fashion-MNIST transfer.
 """
 

--- a/magenta/models/latent_transfer/configs/joint_exp_mnist2fashion_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_mnist2fashion_parameterized.py
@@ -4,11 +4,12 @@
 # pylint:disable=invalid-name
 
 from functools import partial
-from tensorflow import flags
+
+import temsorflow as tf
 
 from magenta.models.latent_transfer import model_joint
 
-FLAGS = flags.FLAGS
+FLAGS = tf.flags.FLAGS
 
 n_latent = FLAGS.n_latent
 n_latent_shared = FLAGS.n_latent_shared

--- a/magenta/models/latent_transfer/configs/joint_exp_mnist2fashion_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_mnist2fashion_parameterized.py
@@ -6,7 +6,7 @@
 from functools import partial
 from tensorflow import flags
 
-import model_joint
+from magenta.models.latent_transfer import model_joint
 
 FLAGS = flags.FLAGS
 

--- a/magenta/models/latent_transfer/configs/joint_exp_mnist2fashion_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_mnist2fashion_parameterized.py
@@ -10,7 +10,7 @@ import model_joint
 
 FLAGS = flags.FLAGS
 
-n_latent = 64
+n_latent = FLAGS.n_latent
 n_latent_shared = FLAGS.n_latent_shared
 layers = (128,) * 4
 batch_size = 128

--- a/magenta/models/latent_transfer/configs/joint_exp_mnist2fashion_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_mnist2fashion_parameterized.py
@@ -1,0 +1,68 @@
+"""Config for MNIST <> Fashion-MNIST transfer.
+"""
+
+# pylint:disable=invalid-name
+
+from functools import partial
+from tensorflow import flags
+
+import model_joint
+
+FLAGS = flags.FLAGS
+
+n_latent = 64
+n_latent_shared = FLAGS.n_latent_shared
+layers = (128,) * 4
+batch_size = 128
+
+Encoder = partial(
+    model_joint.EncoderLatentFull,
+    input_size=n_latent,
+    output_size=n_latent_shared,
+    layers=layers)
+
+Decoder = partial(
+    model_joint.DecoderLatentFull,
+    input_size=n_latent_shared,
+    output_size=n_latent,
+    layers=layers)
+
+vae_config_A = {
+    'Encoder': Encoder,
+    'Decoder': Decoder,
+    'prior_loss_beta': FLAGS.prior_loss_beta_A,
+    'prior_loss': 'KL',
+    'batch_size': batch_size,
+    'n_latent': n_latent,
+    'n_latent_shared': n_latent_shared,
+}
+
+vae_config_B = {
+    'Encoder': Encoder,
+    'Decoder': Decoder,
+    'prior_loss_beta': FLAGS.prior_loss_beta_B,
+    'prior_loss': 'KL',
+    'batch_size': batch_size,
+    'n_latent': n_latent,
+    'n_latent_shared': n_latent_shared,
+}
+
+config = {
+    'vae_A': vae_config_A,
+    'vae_B': vae_config_B,
+    'config_A': 'mnist_0_nlatent64',
+    'config_B': 'fashion_mnist_0_nlatent64',
+    'config_classifier_A': 'mnist_classifier_0',
+    'config_classifier_B': 'fashion_mnist_classifier_0',
+    # model
+    'prior_loss_align_beta': FLAGS.prior_loss_align_beta,
+    'mean_recons_A_align_beta': FLAGS.mean_recons_A_align_beta,
+    'mean_recons_B_align_beta': FLAGS.mean_recons_B_align_beta,
+    'mean_recons_A_to_B_align_beta': FLAGS.mean_recons_A_to_B_align_beta,
+    'mean_recons_B_to_A_align_beta': FLAGS.mean_recons_B_to_A_align_beta,
+    'pairing_number': FLAGS.pairing_number,
+    # training dynamics
+    'batch_size': batch_size,
+    'n_latent': n_latent,
+    'n_latent_shared': n_latent_shared,
+}

--- a/magenta/models/latent_transfer/configs/joint_exp_mnist2wavegan_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_mnist2wavegan_parameterized.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Config for MNIST <> WaveGAN transfer.
 """
 

--- a/magenta/models/latent_transfer/configs/joint_exp_mnist2wavegan_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_mnist2wavegan_parameterized.py
@@ -1,0 +1,88 @@
+"""Config for MNIST <> WaveGAN transfer.
+"""
+
+# pylint:disable=invalid-name
+
+from functools import partial
+from tensorflow import flags
+
+import model_joint
+
+FLAGS = flags.FLAGS
+
+n_latent_A = 64
+n_latent_B = 100
+n_latent_shared = FLAGS.n_latent_shared
+layers = (128,) * 4
+layers_B = (2048,) * 8
+batch_size = 128
+
+Encoder = partial(
+    model_joint.EncoderLatentFull,
+    input_size=n_latent_A,
+    output_size=n_latent_shared,
+    layers=layers)
+
+Decoder = partial(
+    model_joint.DecoderLatentFull,
+    input_size=n_latent_shared,
+    output_size=n_latent_A,
+    layers=layers)
+
+vae_config_A = {
+    'Encoder': Encoder,
+    'Decoder': Decoder,
+    'prior_loss_beta': FLAGS.prior_loss_beta_A,
+    'prior_loss': 'KL',
+    'batch_size': batch_size,
+    'n_latent': n_latent_A,
+    'n_latent_shared': n_latent_shared,
+}
+
+
+def make_Encoder_B(n_latent):
+  return partial(
+      model_joint.EncoderLatentFull,
+      input_size=n_latent,
+      output_size=n_latent_shared,
+      layers=layers_B,
+  )
+
+
+def make_Decoder_B(n_latent):
+  return partial(
+      model_joint.DecoderLatentFull,
+      input_size=n_latent_shared,
+      output_size=n_latent,
+      layers=layers_B,
+  )
+
+
+wavegan_config_B = {
+    'Encoder': make_Encoder_B(n_latent_B),
+    'Decoder': make_Decoder_B(n_latent_B),
+    'prior_loss_beta': FLAGS.prior_loss_beta_B,
+    'prior_loss': 'KL',
+    'batch_size': batch_size,
+    'n_latent': n_latent_B,
+    'n_latent_shared': n_latent_shared,
+}
+
+config = {
+    'vae_A': vae_config_A,
+    'vae_B': wavegan_config_B,
+    'config_A': 'mnist_0_nlatent64',
+    'config_B': 'wavegan',
+    'config_classifier_A': 'mnist_classifier_0',
+    'config_classifier_B': '<unsued>',
+    # model
+    'prior_loss_align_beta': FLAGS.prior_loss_align_beta,
+    'mean_recons_A_align_beta': FLAGS.mean_recons_A_align_beta,
+    'mean_recons_B_align_beta': FLAGS.mean_recons_B_align_beta,
+    'mean_recons_A_to_B_align_beta': FLAGS.mean_recons_A_to_B_align_beta,
+    'mean_recons_B_to_A_align_beta': FLAGS.mean_recons_B_to_A_align_beta,
+    'pairing_number': FLAGS.pairing_number,
+    # training dynamics
+    'batch_size': batch_size,
+    'n_latent_shared': n_latent_shared,
+}

--- a/magenta/models/latent_transfer/configs/joint_exp_mnist2wavegan_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_mnist2wavegan_parameterized.py
@@ -4,11 +4,12 @@
 # pylint:disable=invalid-name
 
 from functools import partial
-from tensorflow import flags
+
+import temsorflow as tf
 
 from magenta.models.latent_transfer import model_joint
 
-FLAGS = flags.FLAGS
+FLAGS = tf.flags.FLAGS
 
 n_latent_A = FLAGS.n_latent
 n_latent_B = 100

--- a/magenta/models/latent_transfer/configs/joint_exp_mnist2wavegan_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_mnist2wavegan_parameterized.py
@@ -6,7 +6,7 @@
 from functools import partial
 from tensorflow import flags
 
-import model_joint
+from magenta.models.latent_transfer import model_joint
 
 FLAGS = flags.FLAGS
 

--- a/magenta/models/latent_transfer/configs/joint_exp_mnist2wavegan_parameterized.py
+++ b/magenta/models/latent_transfer/configs/joint_exp_mnist2wavegan_parameterized.py
@@ -10,7 +10,7 @@ import model_joint
 
 FLAGS = flags.FLAGS
 
-n_latent_A = 64
+n_latent_A = FLAGS.n_latent
 n_latent_B = 100
 n_latent_shared = FLAGS.n_latent_shared
 layers = (128,) * 4

--- a/magenta/models/latent_transfer/configs/mnist_0_nlatent100.py
+++ b/magenta/models/latent_transfer/configs/mnist_0_nlatent100.py
@@ -5,7 +5,7 @@
 
 from functools import partial
 
-import nn
+from magenta.models.latent_transfer import nn
 
 n_latent = 100
 

--- a/magenta/models/latent_transfer/configs/mnist_0_nlatent100.py
+++ b/magenta/models/latent_transfer/configs/mnist_0_nlatent100.py
@@ -1,0 +1,27 @@
+"""Config for MNIST with nlatent=64.
+"""
+
+# pylint:disable=invalid-name
+
+from functools import partial
+
+import nn
+
+n_latent = 100
+
+Encoder = partial(nn.EncoderMNIST, n_latent=n_latent)
+Decoder = nn.DecoderMNIST
+Classifier = nn.DFull
+
+config = {
+    'Encoder': Encoder,
+    'Decoder': Decoder,
+    'Classifier': Classifier,
+    'n_latent': n_latent,
+    'dataset': 'MNIST',
+    'img_width': 28,
+    'crop_width': 108,
+    'batch_size': 512,
+    'beta': 1.0,
+    'x_sigma': 0.1,
+}

--- a/magenta/models/latent_transfer/configs/mnist_0_nlatent64.py
+++ b/magenta/models/latent_transfer/configs/mnist_0_nlatent64.py
@@ -1,0 +1,27 @@
+"""Config for MNIST with nlatent=64.
+"""
+
+# pylint:disable=invalid-name
+
+from functools import partial
+
+import nn
+
+n_latent = 64
+
+Encoder = partial(nn.EncoderMNIST, n_latent=n_latent)
+Decoder = nn.DecoderMNIST
+Classifier = nn.DFull
+
+config = {
+    'Encoder': Encoder,
+    'Decoder': Decoder,
+    'Classifier': Classifier,
+    'n_latent': n_latent,
+    'dataset': 'MNIST',
+    'img_width': 28,
+    'crop_width': 108,
+    'batch_size': 512,
+    'beta': 1.0,
+    'x_sigma': 0.1,
+}

--- a/magenta/models/latent_transfer/configs/mnist_0_nlatent64.py
+++ b/magenta/models/latent_transfer/configs/mnist_0_nlatent64.py
@@ -5,7 +5,7 @@
 
 from functools import partial
 
-import nn
+from magenta.models.latent_transfer import nn
 
 n_latent = 64
 

--- a/magenta/models/latent_transfer/configs/mnist_classifier_0.py
+++ b/magenta/models/latent_transfer/configs/mnist_classifier_0.py
@@ -1,0 +1,14 @@
+"""Config for MNIST classifier.
+"""
+
+# pylint:disable=invalid-name
+
+import nn
+from configs import mnist_0_nlatent64
+
+config = mnist_0_nlatent64.config
+
+Classifier = nn.DFull
+
+config['batch_size'] = 256
+config['Classifier'] = Classifier

--- a/magenta/models/latent_transfer/configs/mnist_classifier_0.py
+++ b/magenta/models/latent_transfer/configs/mnist_classifier_0.py
@@ -3,8 +3,8 @@
 
 # pylint:disable=invalid-name
 
-import nn
-from configs import mnist_0_nlatent64
+from magenta.models.latent_transfer import nn
+from magenta.models.latent_transfer.configs import mnist_0_nlatent64
 
 config = mnist_0_nlatent64.config
 

--- a/magenta/models/latent_transfer/configs/wavegan.py
+++ b/magenta/models/latent_transfer/configs/wavegan.py
@@ -1,5 +1,5 @@
 """A simple place holder for pre-trained WaveGAN model."""
 
 config = {
-    'dataset': 'WaveGAN',  # the case doesn't matter.
+    'dataset': 'WaveGAN',  # It's case-insensitive.
 }

--- a/magenta/models/latent_transfer/configs/wavegan.py
+++ b/magenta/models/latent_transfer/configs/wavegan.py
@@ -1,0 +1,5 @@
+"""A simple place holder for pre-trained WaveGAN model."""
+
+config = {
+    'dataset': 'WaveGAN',  # the case doesn't matter.
+}

--- a/magenta/models/latent_transfer/encode_dataspace.py
+++ b/magenta/models/latent_transfer/encode_dataspace.py
@@ -14,17 +14,16 @@ import os
 
 import numpy as np
 import tensorflow as tf
-from tensorflow import app
-from tensorflow import flags
 
 from magenta.models.latent_transfer import common
 from magenta.models.latent_transfer import model_dataspace
 
-FLAGS = flags.FLAGS
+FLAGS = tf.flags.FLAGS
 
-flags.DEFINE_string('config', 'mnist_0', 'The name of the model config to use.')
-flags.DEFINE_string('exp_uid', '_exp_0',
-                    'String to append to config for filenames/directories.')
+tf.flags.DEFINE_string('config', 'mnist_0',
+                       'The name of the model config to use.')
+tf.flags.DEFINE_string('exp_uid', '_exp_0',
+                       'String to append to config for filenames/directories.')
 
 
 def main(unused_argv):
@@ -126,4 +125,4 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
-  app.run(main)
+  tf.app.run(main)

--- a/magenta/models/latent_transfer/encode_dataspace.py
+++ b/magenta/models/latent_transfer/encode_dataspace.py
@@ -17,8 +17,8 @@ import tensorflow as tf
 from tensorflow import app
 from tensorflow import flags
 
-import common
-import model_dataspace
+from magenta.models.latent_transfer import common
+from magenta.models.latent_transfer import model_dataspace
 
 FLAGS = flags.FLAGS
 

--- a/magenta/models/latent_transfer/encode_dataspace.py
+++ b/magenta/models/latent_transfer/encode_dataspace.py
@@ -109,15 +109,15 @@ def main(unused_argv):
   # Save encoded as npz file
   encoded_save_path = os.path.join(basepath, 'encoded', model_uid)
   tf.gfile.MakeDirs(encoded_save_path)
-  tf.logging.info('encoded train_data saved to %s' % os.path.join(
-      encoded_save_path, 'encoded_train_data.npz'))
+  tf.logging.info('encoded train_data saved to %s',
+                  os.path.join(encoded_save_path, 'encoded_train_data.npz'))
   np.savez(
       os.path.join(encoded_save_path, 'encoded_train_data.npz'),
       mu=encoded_train_data.mu,
       sigma=encoded_train_data.sigma,
   )
-  tf.logging.info('encoded eval_data saved to %s' % os.path.join(
-      encoded_save_path, 'encoded_eval_data.npz'))
+  tf.logging.info('encoded eval_data saved to %s',
+                  os.path.join(encoded_save_path, 'encoded_eval_data.npz'))
   np.savez(
       os.path.join(encoded_save_path, 'encoded_eval_data.npz'),
       mu=encoded_eval_data.mu,

--- a/magenta/models/latent_transfer/encode_dataspace.py
+++ b/magenta/models/latent_transfer/encode_dataspace.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Encode the data using pre-trained VAE on dataspace.
 
 This script encodes the instances in dataspace (x) from the training set into

--- a/magenta/models/latent_transfer/encode_dataspace.py
+++ b/magenta/models/latent_transfer/encode_dataspace.py
@@ -1,0 +1,129 @@
+"""Encode the data using pre-trained VAE on dataspace.
+
+This script encodes the instances in dataspace (x) from the training set into
+distributions in the latent space (z) using the pre-trained the models from
+`train_dataspace.py`
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import importlib
+import os
+
+import numpy as np
+import tensorflow as tf
+from tensorflow import app
+from tensorflow import flags
+
+import common
+import model_dataspace
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string('config', 'mnist_0', 'The name of the model config to use.')
+flags.DEFINE_string('exp_uid', '_exp_0',
+                    'String to append to config for filenames/directories.')
+
+
+def main(unused_argv):
+  del unused_argv
+
+  # Load Config
+  config_name = FLAGS.config
+  config_module = importlib.import_module('configs.%s' % config_name)
+  config = config_module.config
+  model_uid = common.get_model_uid(config_name, FLAGS.exp_uid)
+  batch_size = config['batch_size']
+
+  # Load dataset
+  dataset = common.load_dataset(config)
+  basepath = dataset.basepath
+  save_path = dataset.save_path
+  train_data = dataset.train_data
+  eval_data = dataset.eval_data
+
+  # Make the directory
+  save_dir = os.path.join(save_path, model_uid)
+  best_dir = os.path.join(save_dir, 'best')
+  tf.gfile.MakeDirs(save_dir)
+  tf.gfile.MakeDirs(best_dir)
+  tf.logging.info('Save Dir: %s', save_dir)
+
+  # Load Model
+  tf.reset_default_graph()
+  sess = tf.Session()
+  m = model_dataspace.Model(config, name=model_uid)
+  _ = m()  # noqa
+
+  # Initialize
+  sess.run(tf.global_variables_initializer())
+
+  # Load
+  m.vae_saver.restore(sess,
+                      os.path.join(best_dir, 'vae_best_%s.ckpt' % model_uid))
+
+  # Encode
+  def encode(data):
+    """Encode the data in dataspace to latent spaceself.
+
+    This script runs the encoding in batched mode to limit GPU memory usage.
+
+    Args:
+      data: A numpy array of data to be encoded.
+
+    Returns:
+      A object with instances `mu` and `sigma`, the parameters of encoded
+      distributions in the latent space.
+    """
+    mu_list, sigma_list = [], []
+
+    for i in range(0, len(data), batch_size):
+      start, end = i, min(i + batch_size, len(data))
+      batch = data[start:end]
+
+      mu, sigma = sess.run([m.mu, m.sigma], {m.x: batch})
+      mu_list.append(mu)
+      sigma_list.append(sigma)
+
+    mu = np.concatenate(mu_list)
+    sigma = np.concatenate(sigma_list)
+
+    return common.ObjectBlob(mu=mu, sigma=sigma)
+
+  encoded_train_data = encode(train_data)
+  tf.logging.info(
+      'encode train_data: mu.shape = %s sigma.shape = %s',
+      encoded_train_data.mu.shape,
+      encoded_train_data.sigma.shape,
+  )
+
+  encoded_eval_data = encode(eval_data)
+  tf.logging.info(
+      'encode eval_data: mu.shape = %s sigma.shape = %s',
+      encoded_eval_data.mu.shape,
+      encoded_eval_data.sigma.shape,
+  )
+
+  # Save encoded as npz file
+  encoded_save_path = os.path.join(basepath, 'encoded', model_uid)
+  tf.gfile.MakeDirs(encoded_save_path)
+  tf.logging.info('encoded train_data saved to %s' % os.path.join(
+      encoded_save_path, 'encoded_train_data.npz'))
+  np.savez(
+      os.path.join(encoded_save_path, 'encoded_train_data.npz'),
+      mu=encoded_train_data.mu,
+      sigma=encoded_train_data.sigma,
+  )
+  tf.logging.info('encoded eval_data saved to %s' % os.path.join(
+      encoded_save_path, 'encoded_eval_data.npz'))
+  np.savez(
+      os.path.join(encoded_save_path, 'encoded_eval_data.npz'),
+      mu=encoded_eval_data.mu,
+      sigma=encoded_eval_data.sigma,
+  )
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/magenta/models/latent_transfer/interpolate_joint.py
+++ b/magenta/models/latent_transfer/interpolate_joint.py
@@ -17,9 +17,9 @@ import tensorflow as tf
 from tensorflow import app
 from tensorflow import flags
 
-import common
-import common_joint
-import model_joint
+from magenta.models.latent_transfer import common
+from magenta.models.latent_transfer import common_joint
+from magenta.models.latent_transfer import model_joint
 
 FLAGS = flags.FLAGS
 

--- a/magenta/models/latent_transfer/interpolate_joint.py
+++ b/magenta/models/latent_transfer/interpolate_joint.py
@@ -14,44 +14,43 @@ from os.path import join
 
 import numpy as np
 import tensorflow as tf
-from tensorflow import app
-from tensorflow import flags
 
 from magenta.models.latent_transfer import common
 from magenta.models.latent_transfer import common_joint
 from magenta.models.latent_transfer import model_joint
 
-FLAGS = flags.FLAGS
+FLAGS = tf.flags.FLAGS
 
-flags.DEFINE_string('config', 'transfer_A_unconditional_mnist_to_mnist',
-                    'The name of the model config to use.')
-flags.DEFINE_string('exp_uid_A', '_exp_0', 'exp_uid for data_A')
-flags.DEFINE_string('exp_uid_B', '_exp_1', 'exp_uid for data_B')
-flags.DEFINE_string('exp_uid', '_exp_0',
-                    'String to append to config for filenames/directories.')
-flags.DEFINE_integer('n_iters', 100000, 'Number of iterations.')
-flags.DEFINE_integer('n_iters_per_save', 5000, 'Iterations per a save.')
-flags.DEFINE_integer('n_iters_per_eval', 5000, 'Iterations per a evaluation.')
-flags.DEFINE_integer('random_seed', 19260817, 'Random seed')
-flags.DEFINE_string('exp_uid_classifier', '_exp_0', 'exp_uid for classifier')
+tf.flags.DEFINE_string('config', 'transfer_A_unconditional_mnist_to_mnist',
+                       'The name of the model config to use.')
+tf.flags.DEFINE_string('exp_uid_A', '_exp_0', 'exp_uid for data_A')
+tf.flags.DEFINE_string('exp_uid_B', '_exp_1', 'exp_uid for data_B')
+tf.flags.DEFINE_string('exp_uid', '_exp_0',
+                       'String to append to config for filenames/directories.')
+tf.flags.DEFINE_integer('n_iters', 100000, 'Number of iterations.')
+tf.flags.DEFINE_integer('n_iters_per_save', 5000, 'Iterations per a save.')
+tf.flags.DEFINE_integer('n_iters_per_eval', 5000,
+                        'Iterations per a evaluation.')
+tf.flags.DEFINE_integer('random_seed', 19260817, 'Random seed')
+tf.flags.DEFINE_string('exp_uid_classifier', '_exp_0', 'exp_uid for classifier')
 
 # For Overriding configs
-flags.DEFINE_integer('n_latent', 64, '')
-flags.DEFINE_integer('n_latent_shared', 2, '')
-flags.DEFINE_float('prior_loss_beta_A', 0.01, '')
-flags.DEFINE_float('prior_loss_beta_B', 0.01, '')
-flags.DEFINE_float('prior_loss_align_beta', 0.0, '')
-flags.DEFINE_float('mean_recons_A_align_beta', 0.0, '')
-flags.DEFINE_float('mean_recons_B_align_beta', 0.0, '')
-flags.DEFINE_float('mean_recons_A_to_B_align_beta', 0.0, '')
-flags.DEFINE_float('mean_recons_B_to_A_align_beta', 0.0, '')
-flags.DEFINE_integer('pairing_number', 1024, '')
+tf.flags.DEFINE_integer('n_latent', 64, '')
+tf.flags.DEFINE_integer('n_latent_shared', 2, '')
+tf.flags.DEFINE_float('prior_loss_beta_A', 0.01, '')
+tf.flags.DEFINE_float('prior_loss_beta_B', 0.01, '')
+tf.flags.DEFINE_float('prior_loss_align_beta', 0.0, '')
+tf.flags.DEFINE_float('mean_recons_A_align_beta', 0.0, '')
+tf.flags.DEFINE_float('mean_recons_B_align_beta', 0.0, '')
+tf.flags.DEFINE_float('mean_recons_A_to_B_align_beta', 0.0, '')
+tf.flags.DEFINE_float('mean_recons_B_to_A_align_beta', 0.0, '')
+tf.flags.DEFINE_integer('pairing_number', 1024, '')
 
 # For controling interpolation
-flags.DEFINE_integer('load_ckpt_iter', 0, '')
-flags.DEFINE_string('interpolate_labels', '',
-                    'a `,` separated list of 0-indexed labels.')
-flags.DEFINE_integer('nb_images_between_labels', 1, '')
+tf.flags.DEFINE_integer('load_ckpt_iter', 0, '')
+tf.flags.DEFINE_string('interpolate_labels', '',
+                       'a `,` separated list of 0-indexed labels.')
+tf.flags.DEFINE_integer('nb_images_between_labels', 1, '')
 
 
 def load_config(config_name):
@@ -202,4 +201,4 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
-  app.run(main)
+  tf.app.run(main)

--- a/magenta/models/latent_transfer/interpolate_joint.py
+++ b/magenta/models/latent_transfer/interpolate_joint.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Produce interpolation in the joint model trained by `train_joint.py`.
 
 This script produces interpolation on one side of the joint model as a series of

--- a/magenta/models/latent_transfer/interpolate_joint.py
+++ b/magenta/models/latent_transfer/interpolate_joint.py
@@ -1,0 +1,205 @@
+"""Produce interpolation in the joint model trained by `train_joint.py`.
+
+This script produces interpolation on one side of the joint model as a series of
+images, as well as in other side of the model through paralleling,
+image-by-image transformation.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import importlib
+from os.path import join
+
+import numpy as np
+import tensorflow as tf
+from tensorflow import app
+from tensorflow import flags
+
+import common
+import common_joint
+import model_joint
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string('config', 'transfer_A_unconditional_mnist_to_mnist',
+                    'The name of the model config to use.')
+flags.DEFINE_string('exp_uid_A', '_exp_0', 'exp_uid for data_A')
+flags.DEFINE_string('exp_uid_B', '_exp_1', 'exp_uid for data_B')
+flags.DEFINE_string('exp_uid', '_exp_0',
+                    'String to append to config for filenames/directories.')
+flags.DEFINE_integer('n_iters', 100000, 'Number of iterations.')
+flags.DEFINE_integer('n_iters_per_save', 5000, 'Iterations per a save.')
+flags.DEFINE_integer('n_iters_per_eval', 5000, 'Iterations per a evaluation.')
+flags.DEFINE_integer('random_seed', 19260817, 'Random seed')
+flags.DEFINE_string('exp_uid_classifier', '_exp_0', 'exp_uid for classifier')
+
+# For Overriding configs
+flags.DEFINE_integer('n_latent', 64, '')
+flags.DEFINE_integer('n_latent_shared', 2, '')
+flags.DEFINE_float('prior_loss_beta_A', 0.01, '')
+flags.DEFINE_float('prior_loss_beta_B', 0.01, '')
+flags.DEFINE_float('prior_loss_align_beta', 0.0, '')
+flags.DEFINE_float('mean_recons_A_align_beta', 0.0, '')
+flags.DEFINE_float('mean_recons_B_align_beta', 0.0, '')
+flags.DEFINE_float('mean_recons_A_to_B_align_beta', 0.0, '')
+flags.DEFINE_float('mean_recons_B_to_A_align_beta', 0.0, '')
+flags.DEFINE_integer('pairing_number', 1024, '')
+
+# For controling interpolation
+flags.DEFINE_integer('load_ckpt_iter', 0, '')
+flags.DEFINE_string('interpolate_labels', '',
+                    'a `,` separated list of 0-indexed labels.')
+flags.DEFINE_integer('nb_images_between_labels', 1, '')
+
+
+def load_config(config_name):
+  return importlib.import_module('configs.%s' % config_name).config
+
+
+def main(unused_argv):
+  # pylint:disable=unused-variable
+  # Reason:
+  #   This training script relys on many programmatical call to function and
+  #   access to variables. Pylint cannot infer this case so it emits false alarm
+  #   of unused-variable if we do not disable this warning.
+
+  # pylint:disable=invalid-name
+  # Reason:
+  #   Following variables have their name consider to be invalid by pylint so
+  #   we disable the warning.
+  #   - Variable that in its name has A or B indictating their belonging of
+  #     one side of data.
+  del unused_argv
+
+  # Load main config
+  config_name = FLAGS.config
+  config = load_config(config_name)
+
+  config_name_A = config['config_A']
+  config_name_B = config['config_B']
+  config_name_classifier_A = config['config_classifier_A']
+  config_name_classifier_B = config['config_classifier_B']
+
+  # Load dataset
+  dataset_A = common_joint.load_dataset(config_name_A, FLAGS.exp_uid_A)
+  (dataset_blob_A, train_data_A, train_label_A, train_mu_A, train_sigma_A,
+   index_grouped_by_label_A) = dataset_A
+  dataset_B = common_joint.load_dataset(config_name_B, FLAGS.exp_uid_B)
+  (dataset_blob_B, train_data_B, train_label_B, train_mu_B, train_sigma_B,
+   index_grouped_by_label_B) = dataset_B
+
+  # Prepare directories
+  dirs = common_joint.prepare_dirs('joint', config_name, FLAGS.exp_uid)
+  save_dir, sample_dir = dirs
+
+  # Set random seed
+  np.random.seed(FLAGS.random_seed)
+  tf.set_random_seed(FLAGS.random_seed)
+
+  # Real Training.
+  tf.reset_default_graph()
+  sess = tf.Session()
+
+  # Load model's architecture (= build)
+  one_side_helper_A = common_joint.OneSideHelper(config_name_A, FLAGS.exp_uid_A,
+                                                 config_name_classifier_A,
+                                                 FLAGS.exp_uid_classifier)
+  one_side_helper_B = common_joint.OneSideHelper(config_name_B, FLAGS.exp_uid_B,
+                                                 config_name_classifier_B,
+                                                 FLAGS.exp_uid_classifier)
+  m = common_joint.load_model(model_joint.Model, config_name, FLAGS.exp_uid)
+
+  # Initialize and restore
+  sess.run(tf.global_variables_initializer())
+
+  one_side_helper_A.restore(dataset_blob_A)
+  one_side_helper_B.restore(dataset_blob_B)
+
+  # Restore from ckpt
+  config_name = FLAGS.config
+  model_uid = common.get_model_uid(config_name, FLAGS.exp_uid)
+  save_name = join(save_dir,
+                   'transfer_%s_%d.ckpt' % (model_uid, FLAGS.load_ckpt_iter))
+  m.vae_saver.restore(sess, save_name)
+
+  # prepare intepolate dir
+  intepolate_dir = join(sample_dir, 'interpolate_sample',
+                        '%010d' % FLAGS.load_ckpt_iter)
+  tf.gfile.MakeDirs(intepolate_dir)
+
+  # things
+  interpolate_labels = [int(_) for _ in FLAGS.interpolate_labels.split(',')]
+  nb_images_between_labels = FLAGS.nb_images_between_labels
+
+  index_list_A = []
+  last_pos = [0] * 10
+  for label in interpolate_labels:
+    index_list_A.append(index_grouped_by_label_A[label][last_pos[label]])
+    last_pos[label] += 1
+
+  index_list_B = []
+  last_pos = [-1] * 10
+  for label in interpolate_labels:
+    index_list_B.append(index_grouped_by_label_B[label][last_pos[label]])
+    last_pos[label] -= 1
+
+  z_A = []
+  z_A.append(train_mu_A[index_list_A[0]])
+  for i_label in range(1, len(interpolate_labels)):
+    last_z_A = z_A[-1]
+    this_z_A = train_mu_A[index_list_A[i_label]]
+    for j in range(1, nb_images_between_labels + 1):
+      z_A.append(last_z_A +
+                 (this_z_A - last_z_A) * (float(j) / nb_images_between_labels))
+  z_B = []
+  z_B.append(train_mu_B[index_list_B[0]])
+  for i_label in range(1, len(interpolate_labels)):
+    last_z_B = z_B[-1]
+    this_z_B = train_mu_B[index_list_B[i_label]]
+    for j in range(1, nb_images_between_labels + 1):
+      z_B.append(last_z_B +
+                 (this_z_B - last_z_B) * (float(j) / nb_images_between_labels))
+  z_B_tr = []
+  for this_z_A in z_A:
+    this_z_B_tr = sess.run(m.x_A_to_B_direct, {m.x_A: np.array([this_z_A])})
+    z_B_tr.append(this_z_B_tr[0])
+
+  # Generate data domain instances and save.
+  z_A = np.array(z_A)
+  x_A = one_side_helper_A.m_helper.decode(z_A)
+  x_A = common.post_proc(x_A, one_side_helper_A.m_helper.config)
+  batched_x_A = common.batch_image(
+      x_A,
+      max_images=len(x_A),
+      rows=len(x_A),
+      cols=1,
+  )
+  common.save_image(batched_x_A, join(intepolate_dir, 'x_A.png'))
+
+  z_B = np.array(z_B)
+  x_B = one_side_helper_B.m_helper.decode(z_B)
+  x_B = common.post_proc(x_B, one_side_helper_B.m_helper.config)
+  batched_x_B = common.batch_image(
+      x_B,
+      max_images=len(x_B),
+      rows=len(x_B),
+      cols=1,
+  )
+  common.save_image(batched_x_B, join(intepolate_dir, 'x_B.png'))
+
+  z_B_tr = np.array(z_B_tr)
+  x_B_tr = one_side_helper_B.m_helper.decode(z_B_tr)
+  x_B_tr = common.post_proc(x_B_tr, one_side_helper_B.m_helper.config)
+  batched_x_B_tr = common.batch_image(
+      x_B_tr,
+      max_images=len(x_B_tr),
+      rows=len(x_B_tr),
+      cols=1,
+  )
+  common.save_image(batched_x_B_tr, join(intepolate_dir, 'x_B_tr.png'))
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/magenta/models/latent_transfer/local_mnist.py
+++ b/magenta/models/latent_transfer/local_mnist.py
@@ -1,5 +1,10 @@
 """Reading MNIST dataset locally.
 
+This library contains functions used to read MNIST-family data such as vanilla
+MNIST or Fashion-MNIST. Typical usage is:
+
+  data_dir = ...
+  train, validation, test = read_data_sets(data_dir)
 """
 from __future__ import absolute_import
 from __future__ import division

--- a/magenta/models/latent_transfer/local_mnist.py
+++ b/magenta/models/latent_transfer/local_mnist.py
@@ -1,0 +1,240 @@
+"""Reading MNIST dataset locally.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import gzip
+import os
+
+import numpy as np
+import tensorflow as tf
+
+gfile = tf.gfile
+
+
+def _read32(bytestream):
+  dt = np.dtype(np.uint32).newbyteorder('>')
+  return np.frombuffer(bytestream.read(4), dtype=dt)[0]
+
+
+def extract_images(f):
+  """Extract the images into a 4D uint8 np array [index, y, x, depth].
+
+  Args:
+    f: A file object that can be passed into a gzip reader.
+
+  Returns:
+    data: A 4D uint8 np array [index, y, x, depth].
+
+  Raises:
+    ValueError: If the bytestream does not start with 2051.
+  """
+  tf.logging.info('Extracting', f.name)
+  with gzip.GzipFile(fileobj=f) as bytestream:
+    magic = _read32(bytestream)
+    if magic != 2051:
+      raise ValueError(
+          'Invalid magic number %d in MNIST image file: %s' % (magic, f.name))
+    num_images = _read32(bytestream)
+    rows = _read32(bytestream)
+    cols = _read32(bytestream)
+    buf = bytestream.read(rows * cols * num_images)
+    data = np.frombuffer(buf, dtype=np.uint8)
+    data = data.reshape(num_images, rows, cols, 1)
+    return data
+
+
+def dense_to_one_hot(labels_dense, num_classes):
+  """Convert class labels from scalars to one-hot vectors."""
+  num_labels = labels_dense.shape[0]
+  index_offset = np.arange(num_labels) * num_classes
+  labels_one_hot = np.zeros((num_labels, num_classes))
+  labels_one_hot.flat[index_offset + labels_dense.ravel()] = 1
+  return labels_one_hot
+
+
+def extract_labels(f, one_hot=False, num_classes=10):
+  """Extract the labels into a 1D uint8 np array [index].
+
+  Args:
+    f: A file object that can be passed into a gzip reader.
+    one_hot: Does one hot encoding for the result.
+    num_classes: Number of classes for the one hot encoding.
+
+  Returns:
+    labels: a 1D uint8 np array.
+
+  Raises:
+    ValueError: If the bystream doesn't start with 2049.
+  """
+  tf.logging.info('Extracting', f.name)
+  with gzip.GzipFile(fileobj=f) as bytestream:
+    magic = _read32(bytestream)
+    if magic != 2049:
+      raise ValueError(
+          'Invalid magic number %d in MNIST label file: %s' % (magic, f.name))
+    num_items = _read32(bytestream)
+    buf = bytestream.read(num_items)
+    labels = np.frombuffer(buf, dtype=np.uint8)
+    if one_hot:
+      return dense_to_one_hot(labels, num_classes)
+    return labels
+
+
+class DataSet(object):
+  """A dataset for MNIST."""
+
+  def __init__(
+      self,
+      images,
+      labels,
+      fake_data=False,  # pylint:disable=unused-argument
+      one_hot=False,  # pylint:disable=unused-argument
+      dtype=np.float32,
+      reshape=True,
+      seed=None,  # pylint:disable=unused-argument
+  ):  # pylint:disable=g-doc-args
+    """Construct a DataSet.
+
+    one_hot arg is used only if fake_data is true.  `dtype` can be either
+    `uint8` to leave the input as `[0, 255]`, or `float32` to rescale into
+    `[0, 1]`.  Seed arg provides for convenient deterministic testing.
+    """
+    # If op level seed is not set, use whatever graph level seed is
+    # returned.
+    np.random.seed()
+    assert images.shape[0] == labels.shape[0], (
+        'images.shape: %s labels.shape: %s' % (images.shape, labels.shape))
+    self._num_examples = images.shape[0]
+
+    # Convert shape from [num examples, rows, columns, depth]
+    # to [num examples, rows*columns] (assuming depth == 1)
+    if reshape:
+      assert images.shape[3] == 1
+      images = images.reshape(images.shape[0],
+                              images.shape[1] * images.shape[2])
+    if dtype == np.float32:  # Convert from [0, 255] -> [0.0, 1.0].
+      images = images.astype(np.float32)
+      images = np.multiply(images, 1.0 / 255.0)
+    self._images = images
+    self._labels = labels
+    self._epochs_completed = 0
+    self._index_in_epoch = 0
+
+  @property
+  def images(self):
+    return self._images
+
+  @property
+  def labels(self):
+    return self._labels
+
+  @property
+  def num_examples(self):
+    return self._num_examples
+
+  @property
+  def epochs_completed(self):
+    return self._epochs_completed
+
+  def next_batch(self, batch_size, fake_data=False, shuffle=True):
+    """Return the next `batch_size` examples from this data set."""
+    if fake_data:
+      fake_image = [1] * 784
+      if self.one_hot:
+        fake_label = [1] + [0] * 9
+      else:
+        fake_label = 0
+      return [fake_image for _ in
+              range(batch_size)], [fake_label for _ in range(batch_size)]
+    start = self._index_in_epoch
+    # Shuffle for the first epoch
+    if self._epochs_completed == 0 and start == 0 and shuffle:
+      perm0 = np.arange(self._num_examples)
+      np.random.shuffle(perm0)
+      self._images = self.images[perm0]
+      self._labels = self.labels[perm0]
+    # Go to the next epoch
+    if start + batch_size > self._num_examples:
+      # Finished epoch
+      self._epochs_completed += 1
+      # Get the rest examples in this epoch
+      rest_num_examples = self._num_examples - start
+      images_rest_part = self._images[start:self._num_examples]
+      labels_rest_part = self._labels[start:self._num_examples]
+      # Shuffle the data
+      if shuffle:
+        perm = np.arange(self._num_examples)
+        np.random.shuffle(perm)
+        self._images = self.images[perm]
+        self._labels = self.labels[perm]
+      # Start next epoch
+      start = 0
+      self._index_in_epoch = batch_size - rest_num_examples
+      end = self._index_in_epoch
+      images_new_part = self._images[start:end]
+      labels_new_part = self._labels[start:end]
+      return np.concatenate(
+          (images_rest_part, images_new_part), axis=0), np.concatenate(
+              (labels_rest_part, labels_new_part), axis=0)
+    else:
+      self._index_in_epoch += batch_size
+      end = self._index_in_epoch
+      return self._images[start:end], self._labels[start:end]
+
+
+def read_data_sets(
+    train_dir,
+    fake_data=False,  # pylint:disable=unused-argument
+    one_hot=False,
+    dtype=np.float32,
+    reshape=True,
+    validation_size=5000,
+    seed=None,
+):
+  """Read multiple datasets."""
+  # pylint:disable=invalid-name
+  TRAIN_IMAGES = 'train-images-idx3-ubyte.gz'
+  TRAIN_LABELS = 'train-labels-idx1-ubyte.gz'
+  TEST_IMAGES = 't10k-images-idx3-ubyte.gz'
+  TEST_LABELS = 't10k-labels-idx1-ubyte.gz'
+
+  local_file = os.path.join(train_dir, TRAIN_IMAGES)
+  with gfile.Open(local_file, 'rb') as f:
+    train_images = extract_images(f)
+
+  local_file = os.path.join(train_dir, TRAIN_LABELS)
+  with gfile.Open(local_file, 'rb') as f:
+    train_labels = extract_labels(f, one_hot=one_hot)
+
+  local_file = os.path.join(train_dir, TEST_IMAGES)
+  with gfile.Open(local_file, 'rb') as f:
+    test_images = extract_images(f)
+
+  local_file = os.path.join(train_dir, TEST_LABELS)
+  with gfile.Open(local_file, 'rb') as f:
+    test_labels = extract_labels(f, one_hot=one_hot)
+
+  if not 0 <= validation_size <= len(train_images):
+    raise ValueError(
+        'Validation size should be between 0 and {}. Received: {}.'.format(
+            len(train_images), validation_size))
+
+  validation_images = train_images[:validation_size]
+  validation_labels = train_labels[:validation_size]
+  train_images = train_images[validation_size:]
+  train_labels = train_labels[validation_size:]
+
+  options = dict(dtype=dtype, reshape=reshape, seed=seed)
+
+  train = DataSet(train_images, train_labels, **options)
+  validation = DataSet(validation_images, validation_labels, **options)
+  test = DataSet(test_images, test_labels, **options)
+
+  return train, validation, test
+
+
+def load_mnist(train_dir='MNIST-data'):
+  return read_data_sets(train_dir)

--- a/magenta/models/latent_transfer/local_mnist.py
+++ b/magenta/models/latent_transfer/local_mnist.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Reading MNIST dataset locally.
 
 This library contains functions used to read MNIST-family data such as vanilla

--- a/magenta/models/latent_transfer/model_dataspace.py
+++ b/magenta/models/latent_transfer/model_dataspace.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Model in the dapaspace (e.g. pre-trained VAE).
 
 The whole experiment handles transfer between latent space

--- a/magenta/models/latent_transfer/model_dataspace.py
+++ b/magenta/models/latent_transfer/model_dataspace.py
@@ -15,7 +15,7 @@ from six import iteritems
 import sonnet as snt
 import tensorflow as tf
 
-from common import dataset_is_mnist_family
+from magenta.models.latent_transfer.common import dataset_is_mnist_family
 
 ds = tf.contrib.distributions
 

--- a/magenta/models/latent_transfer/model_dataspace.py
+++ b/magenta/models/latent_transfer/model_dataspace.py
@@ -1,0 +1,171 @@
+"""Model in the dapaspace (e.g. pre-trained VAE).
+
+The whole experiment handles transfer between latent space
+of generative models that model the data. This file defines models
+that explicitly model the data (x) in the latent space (z) and provide
+mechanism of encoding (x->z) and decoding (z->x).
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+from six import iteritems
+import sonnet as snt
+import tensorflow as tf
+
+from common import dataset_is_mnist_family
+
+ds = tf.contrib.distributions
+
+
+class Model(snt.AbstractModule):
+  """VAE for MNIST or CelebA dataset."""
+
+  def __init__(self, config, name=''):
+    super(Model, self).__init__(name=name)
+    self.config = config
+
+  def _build(self, unused_input=None):
+    # pylint:disable=unused-variable
+    # Reason:
+    #   All endpoints are stored as attribute at the end of `_build`.
+    #   Pylint cannot infer this case so it emits false alarm of
+    #   unused-variable if we do not disable this warning.
+
+    config = self.config
+
+    # Constants
+    batch_size = config['batch_size']
+    n_latent = config['n_latent']
+    img_width = config['img_width']
+
+    # ---------------------------------------------------------------------
+    # ## Placeholders
+    # ---------------------------------------------------------------------
+    # Image data
+    if dataset_is_mnist_family(config['dataset']):
+      n_labels = 10
+      x = tf.placeholder(
+          tf.float32, shape=(None, img_width * img_width), name='x')
+      attr_loss_fn = tf.losses.softmax_cross_entropy
+      attr_pred_fn = tf.nn.softmax
+      attr_weights = tf.constant(np.ones([1]).astype(np.float32))
+      # p_x_fn = lambda logits: ds.Bernoulli(logits=logits)
+      x_sigma = tf.constant(config['x_sigma'])
+      p_x_fn = (lambda logs: ds.Normal(loc=tf.nn.sigmoid(logs), scale=x_sigma)
+               )  # noqa
+
+    elif config['dataset'] == 'CELEBA':
+      n_labels = 10
+      x = tf.placeholder(
+          tf.float32, shape=(None, img_width, img_width, 3), name='x')
+      attr_loss_fn = tf.losses.sigmoid_cross_entropy
+      attr_pred_fn = tf.nn.sigmoid
+      attr_weights = tf.constant(np.ones([1, n_labels]).astype(np.float32))
+      x_sigma = tf.constant(config['x_sigma'])
+      p_x_fn = (lambda logs: ds.Normal(loc=tf.nn.sigmoid(logs), scale=x_sigma)
+               )  # noqa
+
+    # Attributes
+    labels = tf.placeholder(tf.int32, shape=(None, n_labels), name='labels')
+    # Real / fake label reward
+    r = tf.placeholder(tf.float32, shape=(None, 1), name='D_label')
+    # Transform through optimization
+    z0 = tf.placeholder(tf.float32, shape=(None, n_latent), name='z0')
+
+    # ---------------------------------------------------------------------
+    # ## Modules with parameters
+    # ---------------------------------------------------------------------
+    # Abstract Modules.
+    # Variable that is class has name consider to be invalid by pylint so we
+    # disable the warning.
+    # pylint:disable=invalid-name
+    Encoder = config['Encoder']
+    Decoder = config['Decoder']
+    Classifier = config['Classifier']
+    # pylint:enable=invalid-name
+
+    encoder = Encoder(name='encoder')
+    decoder = Decoder(name='decoder')
+    classifier = Classifier(output_size=n_labels, name='classifier')
+
+    # ---------------------------------------------------------------------
+    # ## Classify Attributes from pixels
+    # ---------------------------------------------------------------------
+    logits_classifier = classifier(x)
+    pred_classifier = attr_pred_fn(logits_classifier)
+    classifier_loss = attr_loss_fn(labels, logits=logits_classifier)
+
+    # ---------------------------------------------------------------------
+    # ## VAE
+    # ---------------------------------------------------------------------
+    # Encode
+    mu, sigma = encoder(x)
+    q_z = ds.Normal(loc=mu, scale=sigma)
+
+    # Optimize / Amortize or feedthrough
+    q_z_sample = q_z.sample()
+
+    z = q_z_sample
+
+    # Decode
+    logits = decoder(z)
+    p_x = p_x_fn(logits)
+    x_mean = p_x.mean()
+
+    # Reconstruction Loss
+    if config['dataset'] == 'CELEBA':
+      recons = tf.reduce_sum(p_x.log_prob(x), axis=[1, 2, 3])
+    else:
+      recons = tf.reduce_sum(p_x.log_prob(x), axis=[-1])
+
+    mean_recons = tf.reduce_mean(recons)
+
+    # Prior
+    p_z = ds.Normal(loc=0., scale=1.)
+    prior_sample = p_z.sample(sample_shape=[batch_size, n_latent])
+
+    # KL Loss.
+    # We use `KL` in variable name for naming consistency with math.
+    # pylint:disable=invalid-name
+    if config['beta'] == 0:
+      mean_KL = tf.constant(0.0)
+    else:
+      KL_qp = ds.kl_divergence(q_z, p_z)
+      KL = tf.reduce_sum(KL_qp, axis=-1)
+      mean_KL = tf.reduce_mean(KL)
+    # pylint:enable=invalid-name
+
+    # VAE Loss
+    beta = tf.constant(config['beta'])
+    vae_loss = -mean_recons + mean_KL * beta
+
+    # ---------------------------------------------------------------------
+    # ## Training
+    # ---------------------------------------------------------------------
+    # Learning rates
+    vae_lr = tf.constant(3e-4)
+    classifier_lr = tf.constant(3e-4)
+
+    # Training Ops
+    vae_vars = list(encoder.get_variables())
+    vae_vars.extend(decoder.get_variables())
+    train_vae = tf.train.AdamOptimizer(learning_rate=vae_lr).minimize(
+        vae_loss, var_list=vae_vars)
+
+    classifier_vars = classifier.get_variables()
+    train_classifier = tf.train.AdamOptimizer(
+        learning_rate=classifier_lr).minimize(
+            classifier_loss, var_list=classifier_vars)
+
+    # Savers
+    vae_saver = tf.train.Saver(vae_vars, max_to_keep=100)
+    classifier_saver = tf.train.Saver(classifier_vars, max_to_keep=1000)
+
+    # Add all endpoints as object attributes
+    for k, v in iteritems(locals()):
+      self.__dict__[k] = v
+
+    # pylint:enable=unused-variable

--- a/magenta/models/latent_transfer/model_joint.py
+++ b/magenta/models/latent_transfer/model_joint.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """The joint transfer model that bridges latent spaces of dataspace models.
 
 The whole experiment handles transfer between latent space

--- a/magenta/models/latent_transfer/model_joint.py
+++ b/magenta/models/latent_transfer/model_joint.py
@@ -282,6 +282,8 @@ class Model(snt.AbstractModule):
     x_from_prior_B = vae_B.x_from_prior
     x_A_to_B = vae_B.decoder(q_z_sample_A)
     x_B_to_A = vae_A.decoder(q_z_sample_B)
+    x_A_to_B_direct = vae_B.decoder(mu_A)
+    x_B_to_A_direct = vae_A.decoder(mu_B)
     z_hat = tf.placeholder(tf.float32, shape=(None, n_latent_shared))
     x_joint_A = vae_A.decoder(z_hat)
     x_joint_B = vae_B.decoder(z_hat)

--- a/magenta/models/latent_transfer/model_joint.py
+++ b/magenta/models/latent_transfer/model_joint.py
@@ -1,0 +1,421 @@
+"""The joint transfer model that bridges latent spaces of dataspace models.
+
+The whole experiment handles transfer between latent space
+of generative models that model the data. This file defines the joint model
+that models the transfer between latent spaces (z1, z2) of models on dataspace.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from six import iteritems
+
+import sonnet as snt
+import tensorflow as tf
+
+import nn
+
+ds = tf.contrib.distributions
+
+
+def affine(x, output_size, z=None, residual=False, softplus=False):
+  """Make an affine layer with optional residual link and softplus activation.
+
+  Args:
+    x: An TF tensor which is the input.
+    output_size: The size of output, e.g. the dimension of this affine layer.
+    z: An TF tensor which is added when residual link is enabled.
+    residual: A boolean indicating whether to enable residual link.
+    softplus: Whether to apply softplus activation at the end.
+
+  Returns:
+    The output tensor.
+  """
+  if residual:
+    x = snt.Linear(2 * output_size)(x)
+    z = snt.Linear(output_size)(z)
+    dz = x[:, :output_size]
+    gates = tf.nn.sigmoid(x[:, output_size:])
+    output = (1 - gates) * z + gates * dz
+  else:
+    output = snt.Linear(output_size)(x)
+
+  if softplus:
+    output = tf.nn.softplus(output)
+
+  return output
+
+
+class EncoderLatentFull(snt.AbstractModule):
+  """An MLP (Full layers) encoder for modeling latent space."""
+
+  def __init__(self,
+               input_size,
+               output_size,
+               layers=(2048,) * 4,
+               name='EncoderLatentFull',
+               residual=True):
+    super(EncoderLatentFull, self).__init__(name=name)
+    self.layers = layers
+    self.input_size = input_size
+    self.output_size = output_size
+    self.residual = residual
+
+  def _build(self, z):
+    x = z
+    for l in self.layers:
+      x = tf.nn.relu(snt.Linear(l)(x))
+
+    mu = affine(x, self.output_size, z, residual=self.residual, softplus=False)
+    sigma = affine(
+        x, self.output_size, z, residual=self.residual, softplus=True)
+    return mu, sigma
+
+
+class DecoderLatentFull(snt.AbstractModule):
+  """An MLP (Full layers) decoder for modeling latent space."""
+
+  def __init__(self,
+               input_size,
+               output_size,
+               layers=(2048,) * 4,
+               name='DecoderLatentFull',
+               residual=True):
+    super(DecoderLatentFull, self).__init__(name=name)
+    self.layers = layers
+    self.input_size = input_size
+    self.output_size = output_size
+    self.residual = residual
+
+  def _build(self, z):
+    x = z
+    for l in self.layers:
+      x = tf.nn.relu(snt.Linear(l)(x))
+
+    mu = affine(x, self.output_size, z, residual=self.residual, softplus=False)
+    return mu
+
+
+class VAE(snt.AbstractModule):
+  """VAE for modling latant space."""
+
+  def __init__(self, config, name=''):
+    super(VAE, self).__init__(name=name)
+    self.config = config
+
+  def _build(self, unused_input=None):
+    # pylint:disable=unused-variable
+    # Reason:
+    #   All endpoints are stored as attribute at the end of `_build`.
+    #   Pylint cannot infer this case so it emits false alarm of
+    #   unused-variable if we do not disable this warning.
+
+    config = self.config
+
+    # Constants
+    batch_size = config['batch_size']
+    n_latent = config['n_latent']
+    n_latent_shared = config['n_latent_shared']
+
+    # ---------------------------------------------------------------------
+    # ## Placeholders
+    # ---------------------------------------------------------------------
+
+    x = tf.placeholder(tf.float32, shape=(None, n_latent))
+
+    # ---------------------------------------------------------------------
+    # ## Modules with parameters
+    # ---------------------------------------------------------------------
+    # Variable that is class has name consider to be invalid by pylint so we
+    # disable the warning.
+    # pylint:disable=invalid-name
+    Encoder = config['Encoder']
+    Decoder = config['Decoder']
+    encoder = Encoder(name='encoder')
+    decoder = Decoder(name='decoder')
+    # pylint:enable=invalid-name
+
+    # ---------------------------------------------------------------------
+    # ## Placeholders
+    # ---------------------------------------------------------------------
+    mu, sigma = encoder(x)
+    mean_abs_mu, mean_abs_sigma = tf.reduce_mean(tf.abs(mu)), tf.reduce_mean(
+        tf.abs(sigma))  # for summary only
+    q_z = ds.Normal(loc=mu, scale=sigma)
+    q_z_sample = q_z.sample()
+
+    # Decode
+    x_prime = decoder(q_z_sample)
+
+    # Reconstruction Loss
+    # Don't use log_prob from tf.ds (larger = better)
+    # Instead, we use L2 norm (smaller = better)
+    # # recons = tf.reduce_sum(p_x.log_prob(x), axis=[-1])
+    recons = tf.reduce_mean(tf.square(x_prime - x))
+    mean_recons = tf.reduce_mean(recons)
+
+    # Prior
+    p_z = ds.Normal(loc=0., scale=1.)
+    p_z_sample = p_z.sample(sample_shape=[batch_size, n_latent_shared])
+    x_from_prior = decoder(p_z_sample)
+
+    # Space filling
+
+    # We use `KL` in variable name for naming consistency with math.
+    # pylint:disable=invalid-name
+    beta = config['prior_loss_beta']
+    if beta == 0:
+      prior_loss = tf.constant(0.0)
+    else:
+      if config['prior_loss'].lower() == 'KL'.lower():
+        KL_qp = ds.kl_divergence(ds.Normal(loc=mu, scale=sigma), p_z)
+        KL = tf.reduce_sum(KL_qp, axis=-1)
+        mean_KL = tf.reduce_mean(KL)
+        prior_loss = mean_KL
+      else:
+        raise NotImplementedError()
+    # pylint:enable=invalid-name
+
+    # VAE Loss
+    beta = tf.constant(config['prior_loss_beta'])
+    scaled_prior_loss = prior_loss * beta
+    vae_loss = mean_recons + scaled_prior_loss
+
+    # ---------------------------------------------------------------------
+    # ## Training
+    # ---------------------------------------------------------------------
+    # Learning rates
+    vae_lr = tf.constant(3e-4)
+    # Training Ops
+    vae_vars = list(encoder.get_variables())
+    vae_vars.extend(decoder.get_variables())
+
+    if vae_vars:
+      # Here, if we use identity transferm, there is no var to optimize,
+      # so in this case we shall avoid building optimizer and saver,
+      # otherwise there would be
+      # "No variables to optimize." / "No variables to save" error.
+
+      # Optimizer
+      train_vae = tf.train.AdamOptimizer(learning_rate=vae_lr).minimize(
+          vae_loss, var_list=vae_vars)
+
+      # Savers
+      vae_saver = tf.train.Saver(vae_vars, max_to_keep=100)
+
+    # Add all endpoints as object attributes
+    for k, v in iteritems(locals()):
+      self.__dict__[k] = v
+
+    # pylint:enable=unused-variable
+
+
+class Model(snt.AbstractModule):
+  """A joint model with two VAEs for latent spaces and ops for transfer.
+
+  This model containts two VAEs to model two latant spaces individually,
+  as well as extra Baysian Inference in training to enable transfer.
+  """
+
+  def __init__(self, config, name=''):
+    super(Model, self).__init__(name=name)
+    self.config = config
+
+  def _build(self, unused_input=None):
+    # pylint:disable=unused-variable
+    # Reason:
+    #   All endpoints are stored as attribute at the end of `_build`.
+    #   Pylint cannot infer this case so it emits false alarm of
+    #   unused-variable if we do not disable this warning.
+
+    # pylint:disable=invalid-name
+    # Reason:
+    #   Following variables have their name consider to be invalid by pylint so
+    #   we disable the warning.
+    #   - Variable that is class
+    #   - Variable that in its name has A or B indictating their belonging of
+    #     one side of data.
+
+    # ---------------------------------------------------------------------
+    # ## Extract parameters from config
+    # ---------------------------------------------------------------------
+
+    config = self.config
+    lr = config.get('lr', 3e-4)
+    n_latent_shared = config['n_latent_shared']
+
+    if 'n_latent' in config:
+      n_latent_A = n_latent_B = config['n_latent']
+    else:
+      n_latent_A = config['vae_A']['n_latent']
+      n_latent_B = config['vae_B']['n_latent']
+
+    # ---------------------------------------------------------------------
+    # ## VAE containing Modules with parameters
+    # ---------------------------------------------------------------------
+    vae_A = VAE(config['vae_A'], name='vae_A')
+    vae_A()
+    vae_B = VAE(config['vae_B'], name='vae_B')
+    vae_B()
+
+    vae_lr = tf.constant(lr)
+    vae_vars = vae_A.vae_vars + vae_B.vae_vars
+    vae_loss = vae_A.vae_loss + vae_B.vae_loss
+    train_vae = tf.train.AdamOptimizer(learning_rate=vae_lr).minimize(
+        vae_loss, var_list=vae_vars)
+    vae_saver = tf.train.Saver(vae_vars, max_to_keep=100)
+
+    # ---------------------------------------------------------------------
+    # ## Computation Flow
+    # ---------------------------------------------------------------------
+
+    # Tensor Endpoints
+    x_A = vae_A.x
+    x_B = vae_B.x
+    q_z_sample_A = vae_A.q_z_sample
+    q_z_sample_B = vae_B.q_z_sample
+    mu_A, sigma_A = vae_A.mu, vae_A.sigma
+    mu_B, sigma_B = vae_B.mu, vae_B.sigma
+    x_prime_A = vae_A.x_prime
+    x_prime_B = vae_B.x_prime
+    x_from_prior_A = vae_A.x_from_prior
+    x_from_prior_B = vae_B.x_from_prior
+    x_A_to_B = vae_B.decoder(q_z_sample_A)
+    x_B_to_A = vae_A.decoder(q_z_sample_B)
+    z_hat = tf.placeholder(tf.float32, shape=(None, n_latent_shared))
+    x_joint_A = vae_A.decoder(z_hat)
+    x_joint_B = vae_B.decoder(z_hat)
+
+    vae_loss_A = vae_A.vae_loss
+    vae_loss_B = vae_B.vae_loss
+
+    x_align_A = tf.placeholder(tf.float32, shape=(None, n_latent_A))
+    x_align_B = tf.placeholder(tf.float32, shape=(None, n_latent_B))
+    mu_align_A, sigma_align_A = vae_A.encoder(x_align_A)
+    mu_align_B, sigma_align_B = vae_B.encoder(x_align_B)
+    q_z_align_A = ds.Normal(loc=mu_align_A, scale=sigma_align_A)
+    q_z_align_B = ds.Normal(loc=mu_align_B, scale=sigma_align_B)
+
+    # VI in joint space
+
+    mu_align, sigma_align = nn.product_two_guassian_pdfs(
+        mu_align_A, sigma_align_A, mu_align_B, sigma_align_B)
+    q_z_align = ds.Normal(loc=mu_align, scale=sigma_align)
+    p_z_align = ds.Normal(loc=0., scale=1.)
+
+    # - KL
+    KL_qp_align = ds.kl_divergence(q_z_align, p_z_align)
+    KL_align = tf.reduce_sum(KL_qp_align, axis=-1)
+    mean_KL_align = tf.reduce_mean(KL_align)
+    prior_loss_align = mean_KL_align
+    prior_loss_align_beta = config.get('prior_loss_align_beta', 0.0)
+    scaled_prior_loss_align = prior_loss_align * prior_loss_align_beta
+
+    # - Reconstruction (from joint Gussian)
+    q_z_sample_align = q_z_align.sample()
+    x_prime_A_align = vae_A.decoder(q_z_sample_align)
+    x_prime_B_align = vae_B.decoder(q_z_sample_align)
+
+    mean_recons_A_align = tf.reduce_mean(tf.square(x_prime_A_align - x_align_A))
+    mean_recons_B_align = tf.reduce_mean(tf.square(x_prime_B_align - x_align_B))
+    mean_recons_A_align_beta = config.get('mean_recons_A_align_beta', 0.0)
+    scaled_mean_recons_A_align = mean_recons_A_align * mean_recons_A_align_beta
+    mean_recons_B_align_beta = config.get('mean_recons_B_align_beta', 0.0)
+    scaled_mean_recons_B_align = mean_recons_B_align * mean_recons_B_align_beta
+    scaled_mean_recons_align = (
+        scaled_mean_recons_A_align + scaled_mean_recons_B_align)
+
+    # - Reconstruction (from transfer)
+    q_z_align_A_sample = q_z_align_A.sample()
+    q_z_align_B_sample = q_z_align_B.sample()
+    x_A_to_B_align = vae_B.decoder(q_z_align_A_sample)
+    x_B_to_A_align = vae_A.decoder(q_z_align_B_sample)
+    mean_recons_A_to_B_align = tf.reduce_mean(
+        tf.square(x_A_to_B_align - x_align_B))
+    mean_recons_B_to_A_align = tf.reduce_mean(
+        tf.square(x_B_to_A_align - x_align_A))
+    mean_recons_A_to_B_align_beta = config.get('mean_recons_A_to_B_align_beta',
+                                               0.0)
+    scaled_mean_recons_A_to_B_align = (
+        mean_recons_A_to_B_align * mean_recons_A_to_B_align_beta)
+    mean_recons_B_to_A_align_beta = config.get('mean_recons_B_to_A_align_beta',
+                                               0.0)
+    scaled_mean_recons_B_to_A_align = (
+        mean_recons_B_to_A_align * mean_recons_B_to_A_align_beta)
+    scaled_mean_recons_cross_A_B_align = (
+        scaled_mean_recons_A_to_B_align + scaled_mean_recons_B_to_A_align)
+
+    # Full loss
+    full_loss = (vae_loss_A + vae_loss_B + scaled_mean_recons_align +
+                 scaled_mean_recons_cross_A_B_align)
+
+    # train op
+    full_lr = tf.constant(lr)
+    train_full = tf.train.AdamOptimizer(learning_rate=full_lr).minimize(
+        full_loss, var_list=vae_vars)
+
+    # Add all endpoints as object attributes
+    for k, v in iteritems(locals()):
+      self.__dict__[k] = v
+
+    # pylint:enable=unused-variable
+    # pylint:enable=invalid-name
+
+  def get_summary_kv_dict(self):
+    m = self
+    return {
+        'm.vae_A.mean_recons':
+        m.vae_A.mean_recons,
+        'm.vae_A.prior_loss':
+        m.vae_A.prior_loss,
+        'm.vae_A.scaled_prior_loss':
+        m.vae_A.scaled_prior_loss,
+        'm.vae_A.vae_loss':
+        m.vae_A.vae_loss,
+        'm.vae_B.mean_recons':
+        m.vae_B.mean_recons,
+        'm.vae_A.mean_abs_mu':
+        m.vae_A.mean_abs_mu,
+        'm.vae_A.mean_abs_sigma':
+        m.vae_A.mean_abs_sigma,
+        'm.vae_B.prior_loss':
+        m.vae_B.prior_loss,
+        'm.vae_B.scaled_prior_loss':
+        m.vae_B.scaled_prior_loss,
+        'm.vae_B.vae_loss':
+        m.vae_B.vae_loss,
+        'm.vae_B.mean_abs_mu':
+        m.vae_B.mean_abs_mu,
+        'm.vae_B.mean_abs_sigma':
+        m.vae_B.mean_abs_sigma,
+        'm.vae_loss_A':
+        m.vae_loss_A,
+        'm.vae_loss_B':
+        m.vae_loss_B,
+        'm.prior_loss_align':
+        m.prior_loss_align,
+        'm.scaled_prior_loss_align':
+        m.scaled_prior_loss_align,
+        'm.mean_recons_A_align':
+        m.mean_recons_A_align,
+        'm.mean_recons_B_align':
+        m.mean_recons_B_align,
+        'm.scaled_mean_recons_A_align':
+        m.scaled_mean_recons_A_align,
+        'm.scaled_mean_recons_B_align':
+        m.scaled_mean_recons_B_align,
+        'm.scaled_mean_recons_align':
+        m.scaled_mean_recons_align,
+        'm.mean_recons_A_to_B_align':
+        m.mean_recons_A_to_B_align,
+        'm.mean_recons_B_to_A_align':
+        m.mean_recons_B_to_A_align,
+        'm.scaled_mean_recons_A_to_B_align':
+        m.scaled_mean_recons_A_to_B_align,
+        'm.scaled_mean_recons_B_to_A_align':
+        m.scaled_mean_recons_B_to_A_align,
+        'm.scaled_mean_recons_cross_A_B_align':
+        m.scaled_mean_recons_cross_A_B_align,
+        'm.full_loss':
+        m.full_loss
+    }

--- a/magenta/models/latent_transfer/model_joint.py
+++ b/magenta/models/latent_transfer/model_joint.py
@@ -13,7 +13,7 @@ from six import iteritems
 import sonnet as snt
 import tensorflow as tf
 
-import nn
+from magenta.models.latent_transfer import nn
 
 ds = tf.contrib.distributions
 

--- a/magenta/models/latent_transfer/nn.py
+++ b/magenta/models/latent_transfer/nn.py
@@ -1,4 +1,8 @@
-"""Nerual network components."""
+"""Nerual network components.
+
+This library containts nerual network components in either raw TF or sonnet
+Module.
+"""
 
 import numpy as np
 import sonnet as snt

--- a/magenta/models/latent_transfer/nn.py
+++ b/magenta/models/latent_transfer/nn.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Nerual network components.
 
 This library containts nerual network components in either raw TF or sonnet

--- a/magenta/models/latent_transfer/nn.py
+++ b/magenta/models/latent_transfer/nn.py
@@ -1,0 +1,175 @@
+"""Nerual network components."""
+
+import numpy as np
+import sonnet as snt
+import tensorflow as tf
+
+
+def product_two_guassian_pdfs(mu_1, sigma_1, mu_2, sigma_2):
+  """Product of two Guasssian PDF."""
+  # https://ccrma.stanford.edu/~jos/sasp/Product_Two_Gaussian_PDFs.html
+  sigma_1_square = tf.square(sigma_1)
+  sigma_2_square = tf.square(sigma_2)
+  mu = (mu_1 * sigma_2_square + mu_2 * sigma_1_square) / (
+      sigma_1_square + sigma_2_square)
+  sigma_square = (sigma_1_square * sigma_2_square) / (
+      sigma_1_square + sigma_2_square)
+  sigma = tf.sqrt(sigma_square)
+  return mu, sigma
+
+
+def tf_batch_image(b, mb=36):
+  """Turn a batch of images into a single image mosaic."""
+  b_shape = b.get_shape().as_list()
+  rows = int(np.ceil(np.sqrt(mb)))
+  cols = rows
+  diff = rows * cols - mb
+  b = tf.concat(
+      [b[:mb], tf.zeros([diff, b_shape[1], b_shape[2], b_shape[3]])], axis=0)
+  tmp = tf.reshape(b, [-1, cols * b_shape[1], b_shape[2], b_shape[3]])
+  img = tf.concat([tmp[i:i + 1] for i in range(rows)], axis=2)
+  return img
+
+
+class EncoderMNIST(snt.AbstractModule):
+  """MLP encoder for MNIST."""
+
+  def __init__(self, n_latent=64, layers=(1024,) * 3, name='encoder'):
+    super(EncoderMNIST, self).__init__(name=name)
+    self.n_latent = n_latent
+    self.layers = layers
+
+  def _build(self, x):
+    for size in self.layers:
+      x = tf.nn.relu(snt.Linear(size)(x))
+    pre_z = snt.Linear(2 * self.n_latent)(x)
+    mu = pre_z[:, :self.n_latent]
+    sigma = tf.nn.softplus(pre_z[:, self.n_latent:])
+    return mu, sigma
+
+
+class DecoderMNIST(snt.AbstractModule):
+  """MLP decoder for MNIST."""
+
+  def __init__(self, layers=(1024,) * 3, n_out=784, name='decoder'):
+    super(DecoderMNIST, self).__init__(name=name)
+    self.layers = layers
+    self.n_out = n_out
+
+  def _build(self, x):
+    for size in self.layers:
+      x = tf.nn.relu(snt.Linear(size)(x))
+    logits = snt.Linear(self.n_out)(x)
+    return logits
+
+
+class EncoderConv(snt.AbstractModule):
+  """ConvNet encoder for CelebA."""
+
+  def __init__(self,
+               n_latent,
+               layers=((256, 5, 2), (512, 5, 2), (1024, 3, 2), (2048, 3, 2)),
+               padding_linear_layers=None,
+               name='encoder'):
+    super(EncoderConv, self).__init__(name=name)
+    self.n_latent = n_latent
+    self.layers = layers
+    self.padding_linear_layers = padding_linear_layers or []
+
+  def _build(self, x):
+    h = x
+    for unused_i, l in enumerate(self.layers):
+      h = tf.nn.relu(snt.Conv2D(l[0], l[1], l[2])(h))
+
+    h_shape = h.get_shape().as_list()
+    h = tf.reshape(h, [-1, h_shape[1] * h_shape[2] * h_shape[3]])
+    for _, l in enumerate(self.padding_linear_layers):
+      h = snt.Linear(l)(h)
+    pre_z = snt.Linear(2 * self.n_latent)(h)
+    mu = pre_z[:, :self.n_latent]
+    sigma = tf.nn.softplus(pre_z[:, self.n_latent:])
+    return mu, sigma
+
+
+class DecoderConv(snt.AbstractModule):
+  """ConvNet decoder for CelebA."""
+
+  def __init__(self,
+               layers=((2048, 4, 4), (1024, 3, 2), (512, 3, 2), (256, 5, 2),
+                       (3, 5, 2)),
+               padding_linear_layers=None,
+               name='decoder'):
+    super(DecoderConv, self).__init__(name=name)
+    self.layers = layers
+    self.padding_linear_layers = padding_linear_layers or []
+
+  def _build(self, x):
+    for i, l in enumerate(self.padding_linear_layers):
+      x = snt.Linear(l)(x)
+    for i, l in enumerate(self.layers):
+      if i == 0:
+        h = snt.Linear(l[1] * l[2] * l[0])(x)
+        h = tf.reshape(h, [-1, l[1], l[2], l[0]])
+      elif i == len(self.layers) - 1:
+        h = snt.Conv2DTranspose(l[0], None, l[1], l[2])(h)
+      else:
+        h = tf.nn.relu(snt.Conv2DTranspose(l[0], None, l[1], l[2])(h))
+    logits = h
+    return logits
+
+
+class ClassifierConv(snt.AbstractModule):
+  """ConvNet classifier."""
+
+  def __init__(self,
+               output_size,
+               layers=((256, 5, 2), (256, 3, 1), (512, 5, 2), (512, 3, 1),
+                       (1024, 3, 2), (2048, 3, 2)),
+               name='encoder'):
+    super(ClassifierConv, self).__init__(name=name)
+    self.output_size = output_size
+    self.layers = layers
+
+  def _build(self, x):
+    h = x
+    for unused_i, l in enumerate(self.layers):
+      h = tf.nn.relu(snt.Conv2D(l[0], l[1], l[2])(h))
+
+    h_shape = h.get_shape().as_list()
+    h = tf.reshape(h, [-1, h_shape[1] * h_shape[2] * h_shape[3]])
+    logits = snt.Linear(self.output_size)(h)
+    return logits
+
+
+class GFull(snt.AbstractModule):
+  """MLP (Full layers) generator."""
+
+  def __init__(self, n_latent, layers=(2048,) * 4, name='generator'):
+    super(GFull, self).__init__(name=name)
+    self.layers = layers
+    self.n_latent = n_latent
+
+  def _build(self, z):
+    x = z
+    for l in self.layers:
+      x = tf.nn.relu(snt.Linear(l)(x))
+    x = snt.Linear(2 * self.n_latent)(x)
+    dz = x[:, :self.n_latent]
+    gates = tf.nn.sigmoid(x[:, self.n_latent:])
+    z_prime = (1 - gates) * z + gates * dz
+    return z_prime
+
+
+class DFull(snt.AbstractModule):
+  """MLP (Full layers) discriminator/classifier."""
+
+  def __init__(self, output_size=1, layers=(2048,) * 4, name='D'):
+    super(DFull, self).__init__(name=name)
+    self.layers = layers
+    self.output_size = output_size
+
+  def _build(self, x):
+    for l in self.layers:
+      x = tf.nn.relu(snt.Linear(l)(x))
+    logits = snt.Linear(self.output_size)(x)
+    return logits

--- a/magenta/models/latent_transfer/sample_dataspace.py
+++ b/magenta/models/latent_transfer/sample_dataspace.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Sample from pre-trained VAE on dataspace.
 
 This script provides sampling from VAE on dataspace trained using

--- a/magenta/models/latent_transfer/sample_dataspace.py
+++ b/magenta/models/latent_transfer/sample_dataspace.py
@@ -14,18 +14,17 @@ import os
 
 import numpy as np
 import tensorflow as tf
-from tensorflow import app
-from tensorflow import flags
 
 from magenta.models.latent_transfer import common
 from magenta.models.latent_transfer import model_dataspace
 
-FLAGS = flags.FLAGS
+FLAGS = tf.flags.FLAGS
 
-flags.DEFINE_string('config', 'mnist_0', 'The name of the model config to use.')
-flags.DEFINE_string('exp_uid', '_exp_0',
-                    'String to append to config for filenames/directories.')
-flags.DEFINE_integer('random_seed', 19260817, 'Random seed.')
+tf.flags.DEFINE_string('config', 'mnist_0',
+                       'The name of the model config to use.')
+tf.flags.DEFINE_string('exp_uid', '_exp_0',
+                       'String to append to config for filenames/directories.')
+tf.flags.DEFINE_integer('random_seed', 19260817, 'Random seed.')
 
 
 def main(unused_argv):
@@ -109,4 +108,4 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
-  app.run(main)
+  tf.app.run(main)

--- a/magenta/models/latent_transfer/sample_dataspace.py
+++ b/magenta/models/latent_transfer/sample_dataspace.py
@@ -17,8 +17,8 @@ import tensorflow as tf
 from tensorflow import app
 from tensorflow import flags
 
-import common
-import model_dataspace
+from magenta.models.latent_transfer import common
+from magenta.models.latent_transfer import model_dataspace
 
 FLAGS = flags.FLAGS
 

--- a/magenta/models/latent_transfer/sample_dataspace.py
+++ b/magenta/models/latent_transfer/sample_dataspace.py
@@ -1,0 +1,112 @@
+"""Sample from pre-trained VAE on dataspace.
+
+This script provides sampling from VAE on dataspace trained using
+`train_dataspace.py`. The main purpose is to help manually check the quality
+of model on dataspace.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import importlib
+import os
+
+import numpy as np
+import tensorflow as tf
+from tensorflow import app
+from tensorflow import flags
+
+import common
+import model_dataspace
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string('config', 'mnist_0', 'The name of the model config to use.')
+flags.DEFINE_string('exp_uid', '_exp_0',
+                    'String to append to config for filenames/directories.')
+flags.DEFINE_integer('random_seed', 19260817, 'Random seed.')
+
+
+def main(unused_argv):
+  del unused_argv
+
+  # Load Config
+  config_name = FLAGS.config
+  config_module = importlib.import_module('configs.%s' % config_name)
+  config = config_module.config
+  model_uid = common.get_model_uid(config_name, FLAGS.exp_uid)
+  n_latent = config['n_latent']
+
+  # Load dataset
+  dataset = common.load_dataset(config)
+  basepath = dataset.basepath
+  save_path = dataset.save_path
+  train_data = dataset.train_data
+
+  # Make the directory
+  save_dir = os.path.join(save_path, model_uid)
+  best_dir = os.path.join(save_dir, 'best')
+  tf.gfile.MakeDirs(save_dir)
+  tf.gfile.MakeDirs(best_dir)
+  tf.logging.info('Save Dir: %s', save_dir)
+
+  # Set random seed
+  np.random.seed(FLAGS.random_seed)
+  tf.set_random_seed(FLAGS.random_seed)
+
+  # Load Model
+  tf.reset_default_graph()
+  sess = tf.Session()
+  with tf.device(tf.train.replica_device_setter(ps_tasks=0)):
+    m = model_dataspace.Model(config, name=model_uid)
+    _ = m()  # noqa
+
+    # Initialize
+    sess.run(tf.global_variables_initializer())
+
+    # Load
+    m.vae_saver.restore(sess,
+                        os.path.join(best_dir, 'vae_best_%s.ckpt' % model_uid))
+
+    # Sample from prior
+    sample_count = 64
+
+    image_path = os.path.join(basepath, 'sample', model_uid)
+    tf.gfile.MakeDirs(image_path)
+
+    # from prior
+    z_p = np.random.randn(sample_count, m.n_latent)
+    x_p = sess.run(m.x_mean, {m.z: z_p})
+    x_p = common.post_proc(x_p, config)
+    common.save_image(
+        common.batch_image(x_p), os.path.join(image_path, 'sample_prior.png'))
+
+    # Sample from priro, as Grid
+    boundary = 2.0
+    number_grid = 50
+    blob = common.make_grid(
+        boundary=boundary, number_grid=number_grid, dim_latent=n_latent)
+    z_grid, dim_grid = blob.z_grid, blob.dim_grid
+    x_grid = sess.run(m.x_mean, {m.z: z_grid})
+    x_grid = common.post_proc(x_grid, config)
+    batch_image_grid = common.make_batch_image_grid(dim_grid, number_grid)
+    common.save_image(
+        batch_image_grid(x_grid), os.path.join(image_path, 'sample_grid.png'))
+
+    # Reconstruction
+    sample_count = 64
+    x_real = train_data[:sample_count]
+    mu, sigma = sess.run([m.mu, m.sigma], {m.x: x_real})
+    x_rec = sess.run(m.x_mean, {m.mu: mu, m.sigma: sigma})
+    x_rec = common.post_proc(x_rec, config)
+
+    x_real = common.post_proc(x_real, config)
+    common.save_image(
+        common.batch_image(x_real), os.path.join(image_path, 'image_real.png'))
+    common.save_image(
+        common.batch_image(x_rec), os.path.join(image_path, 'image_rec.png'))
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/magenta/models/latent_transfer/sample_wavegan.py
+++ b/magenta/models/latent_transfer/sample_wavegan.py
@@ -14,20 +14,20 @@ from os.path import join
 import numpy as np
 from scipy.io import wavfile
 import tensorflow as tf
-from tensorflow import app
-from tensorflow import flags
 from tqdm import tqdm
 
-FLAGS = flags.FLAGS
+FLAGS = tf.flags.FLAGS
 
-flags.DEFINE_integer('total_per_label', '7000', 'Minimal # samples per label')
-flags.DEFINE_integer('top_per_label', '1700', '# of top samples per label')
-flags.DEFINE_string('gen_ckpt_dir', '',
-                    'The directory to WaveGAN generator\'s ckpt.')
-flags.DEFINE_string('inception_ckpt_dir', '',
-                    'The directory to WaveGAN inception (classifier)\'s ckpt.')
-flags.DEFINE_string('latent_dir', '',
-                    'The directory to WaveGAN\'s latent space.')
+tf.flags.DEFINE_integer('total_per_label', '7000',
+                        'Minimal # samples per label')
+tf.flags.DEFINE_integer('top_per_label', '1700', '# of top samples per label')
+tf.flags.DEFINE_string('gen_ckpt_dir', '',
+                       'The directory to WaveGAN generator\'s ckpt.')
+tf.flags.DEFINE_string(
+    'inception_ckpt_dir', '',
+    'The directory to WaveGAN inception (classifier)\'s ckpt.')
+tf.flags.DEFINE_string('latent_dir', '',
+                       'The directory to WaveGAN\'s latent space.')
 
 
 def main(unused_argv):
@@ -164,4 +164,4 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
-  app.run(main)
+  tf.app.run(main)

--- a/magenta/models/latent_transfer/sample_wavegan.py
+++ b/magenta/models/latent_transfer/sample_wavegan.py
@@ -1,0 +1,167 @@
+"""Sample from pre-trained WaveGAN model.
+
+This script provides sampling from pre-trained WaveGAN model that is done
+through the original author's code (https://github.com/chrisdonahue/wavegan).
+The main purpose is to help manually check the quality of WaveGAN model.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from operator import itemgetter
+from os.path import join
+
+import numpy as np
+from scipy.io import wavfile
+import tensorflow as tf
+from tensorflow import app
+from tensorflow import flags
+from tqdm import tqdm
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_integer('total_per_label', '7000', 'Minimal # samples per label')
+flags.DEFINE_integer('top_per_label', '1700', '# of top samples per label')
+flags.DEFINE_string('gen_ckpt_dir', '',
+                    'The directory to WaveGAN generator\'s ckpt.')
+flags.DEFINE_string('inception_ckpt_dir', '',
+                    'The directory to WaveGAN inception (classifier)\'s ckpt.')
+flags.DEFINE_string('latent_dir', '',
+                    'The directory to WaveGAN\'s latent space.')
+
+
+def main(unused_argv):
+
+  # pylint:disable=invalid-name
+  # Reason:
+  #   Following variables have their name consider to be invalid by pylint so
+  #   we disable the warning.
+  #   - Variable that is class
+
+  del unused_argv
+
+  use_gaussian_pretrained_model = FLAGS.use_gaussian_pretrained_model
+
+  gen_ckpt_dir = FLAGS.gen_ckpt_dir
+  inception_ckpt_dir = FLAGS.inception_ckpt_dir
+
+  # TF init
+  tf.reset_default_graph()
+  # - generative model
+  graph_gan = tf.Graph()
+  with graph_gan.as_default():
+    sess_gan = tf.Session(graph=graph_gan)
+    if use_gaussian_pretrained_model:
+      saver_gan = tf.train.import_meta_graph(
+          join(gen_ckpt_dir, '..', 'infer', 'infer.meta'))
+      saver_gan.restore(sess_gan, join(gen_ckpt_dir, 'model.ckpt'))
+    else:
+      saver_gan = tf.train.import_meta_graph(join(gen_ckpt_dir, 'infer.meta'))
+      saver_gan.restore(sess_gan, join(gen_ckpt_dir, 'model.ckpt'))
+  # - classifier (inception)
+  graph_class = tf.Graph()
+  with graph_class.as_default():
+    sess_class = tf.Session(graph=graph_class)
+    saver_class = tf.train.import_meta_graph(
+        join(inception_ckpt_dir, 'infer.meta'))
+    saver_class.restore(sess_class, join(inception_ckpt_dir, 'best_acc-103005'))
+
+  # Generate: Tensor symbols
+  z = graph_gan.get_tensor_by_name('z:0')
+  G_z = graph_gan.get_tensor_by_name('G_z:0')[:, :, 0]
+  # G_z_spec = graph_gan.get_tensor_by_name('G_z_spec:0')
+  # Classification: Tensor symbols
+  x = graph_class.get_tensor_by_name('x:0')
+  scores = graph_class.get_tensor_by_name('scores:0')
+
+  # Sample something AND classify them
+
+  output_dir = FLAGS.latent_dir
+
+  tf.gfile.MakeDirs(output_dir)
+
+  np.random.seed(19260817)
+  total_per_label = FLAGS.total_per_label
+  top_per_label = FLAGS.top_per_label
+  group_by_label = [[] for _ in range(10)]
+  batch_size = 200
+  hidden_dim = 100
+
+  with tqdm(desc='min label count', unit=' #', total=total_per_label) as pbar:
+    label_count = [0] * 10
+    last_min_label_count = 0
+    while True:
+      min_label_count = min(label_count)
+      pbar.update(min_label_count - last_min_label_count)
+      last_min_label_count = min_label_count
+
+      if use_gaussian_pretrained_model:
+        _z = np.random.randn(batch_size, hidden_dim)
+      else:
+        _z = (np.random.rand(batch_size, hidden_dim) * 2.) - 1.
+      # _G_z, _G_z_spec = sess_gan.run([G_z, G_z_spec], {z: _z})
+      _G_z = sess_gan.run(G_z, {z: _z})
+      _x = _G_z
+      _scores = sess_class.run(scores, {x: _x})
+      _max_scores = np.max(_scores, axis=1)
+      _labels = np.argmax(_scores, axis=1)
+      for i in range(batch_size):
+        label = _labels[i]
+
+        group_by_label[label].append((_max_scores[i], (_z[i], _G_z[i])))
+        label_count[label] += 1
+
+        if len(group_by_label[label]) >= top_per_label * 2:
+          # remove unneeded tails
+          group_by_label[label].sort(key=itemgetter(0), reverse=True)
+          group_by_label[label] = group_by_label[label][:top_per_label]
+
+      if last_min_label_count >= total_per_label:
+        break
+
+  for label in range(10):
+    group_by_label[label].sort(key=itemgetter(0), reverse=True)
+    group_by_label[label] = group_by_label[label][:top_per_label]
+
+  # output a few samples as image
+  image_output_dir = join(output_dir, 'sample_iamge')
+  tf.gfile.MakeDirs(image_output_dir)
+
+  for label in range(10):
+    group_by_label[label].sort(key=itemgetter(0), reverse=True)
+    index = 0
+    for confidence, (
+        _,
+        this_G_z,
+    ) in group_by_label[label][:10]:
+      output_basename = 'predlabel=%d_index=%02d_confidence=%.6f' % (
+          label, index, confidence)
+      wavfile.write(
+          filename=join(image_output_dir, output_basename + '_sound.wav'),
+          rate=16000,
+          data=this_G_z)
+
+  # Make Numpy arrays and save everything as an npz file
+  array_label, array_z, array_G_z = [], [], []
+  for label in range(10):
+    for _, blob in group_by_label[label]:
+      this_z, this_G_z = blob[:2]
+      array_label.append(label)
+      array_z.append(this_z)
+      array_G_z.append(this_G_z)
+  array_label = np.array(array_label, dtype='i')
+  array_z = np.array(array_z)
+  array_G_z = np.array(array_G_z)
+
+  np.savez(
+      join(output_dir, 'data_train.npz'),
+      label=array_label,
+      z=array_z,
+      G_z=array_G_z,
+  )
+
+  # pylint:enable=invalid-name
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/magenta/models/latent_transfer/sample_wavegan.py
+++ b/magenta/models/latent_transfer/sample_wavegan.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Sample from pre-trained WaveGAN model.
 
 This script provides sampling from pre-trained WaveGAN model that is done

--- a/magenta/models/latent_transfer/train_dataspace.py
+++ b/magenta/models/latent_transfer/train_dataspace.py
@@ -1,0 +1,181 @@
+"""Train VAE on dataspace.
+
+This script trains the models that model the data space as defined in
+`model_dataspace.py`. The best checkpoint (as evaluated on valid set)
+would be used to encode and decode the latent space (z) to and from data
+space (x).
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import importlib
+import os
+
+import numpy as np
+import tensorflow as tf
+from tensorflow import app
+from tensorflow import flags
+from tensorflow import logging
+
+import common
+import model_dataspace
+import nn
+configs_module_prefix = 'configs'
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string('config', 'mnist_0', 'The name of the model config to use.')
+flags.DEFINE_integer('n_iters', 200000, 'Number of iterations.')
+flags.DEFINE_integer('n_iters_per_save', 1000, 'Iterations per saving.')
+flags.DEFINE_integer('n_iters_per_eval', 50, 'Iterations per evaluate.')
+flags.DEFINE_float('lr', 3e-4, 'learning_rate.')
+flags.DEFINE_string('exp_uid', '_exp_0',
+                    'String to append to config for filenames/directories.')
+flags.DEFINE_integer('random_seed', 10003, 'Random seed.')
+
+MNIST_SIZE = 28
+
+
+def main(unused_argv):
+  del unused_argv
+
+  # Load Config
+  config_name = FLAGS.config
+  config_module = importlib.import_module(configs_module_prefix +
+                                          '.%s' % config_name)
+  config = config_module.config
+  model_uid = common.get_model_uid(config_name, FLAGS.exp_uid)
+  batch_size = config['batch_size']
+
+  # Load dataset
+  dataset = common.load_dataset(config)
+  save_path = dataset.save_path
+  train_data = dataset.train_data
+  attr_train = dataset.attr_train
+  eval_data = dataset.eval_data
+  attr_eval = dataset.attr_eval
+
+  # Make the directory
+  save_dir = os.path.join(save_path, model_uid)
+  best_dir = os.path.join(save_dir, 'best')
+  tf.gfile.MakeDirs(save_dir)
+  tf.gfile.MakeDirs(best_dir)
+  logging.info('Save Dir: %s', save_dir)
+
+  np.random.seed(FLAGS.random_seed)
+  # We use `N` in variable name to emphasis its being the Number of something.
+  N_train = train_data.shape[0]  # pylint:disable=invalid-name
+  N_eval = eval_data.shape[0]  # pylint:disable=invalid-name
+
+  # Load Model
+  tf.reset_default_graph()
+  sess = tf.Session()
+
+  m = model_dataspace.Model(config, name=model_uid)
+  _ = m()  # noqa
+
+  # Create summaries
+  tf.summary.scalar('Train_Loss', m.vae_loss)
+  tf.summary.scalar('Mean_Recon_LL', m.mean_recons)
+  tf.summary.scalar('Mean_KL', m.mean_KL)
+  scalar_summaries = tf.summary.merge_all()
+
+  x_mean_, x_ = m.x_mean, m.x
+  if common.dataset_is_mnist_family(config['dataset']):
+    x_mean_ = tf.reshape(x_mean_, [-1, MNIST_SIZE, MNIST_SIZE, 1])
+    x_ = tf.reshape(x_, [-1, MNIST_SIZE, MNIST_SIZE, 1])
+
+  x_mean_summary = tf.summary.image(
+      'Reconstruction', nn.tf_batch_image(x_mean_), max_outputs=1)
+  x_summary = tf.summary.image('Original', nn.tf_batch_image(x_), max_outputs=1)
+  sample_summary = tf.summary.image(
+      'Sample', nn.tf_batch_image(x_mean_), max_outputs=1)
+  # Summary writers
+  train_writer = tf.summary.FileWriter(save_dir + '/vae_train', sess.graph)
+  eval_writer = tf.summary.FileWriter(save_dir + '/vae_eval', sess.graph)
+
+  # Initialize
+  sess.run(tf.global_variables_initializer())
+
+  i_start = 0
+  running_N_eval = 30  # pylint:disable=invalid-name
+  traces = {
+      'i': [],
+      'i_pred': [],
+      'loss': [],
+      'loss_eval': [],
+  }
+
+  best_eval_loss = np.inf
+  vae_lr_ = np.logspace(np.log10(FLAGS.lr), np.log10(1e-6), FLAGS.n_iters)
+
+  # Train the VAE
+  for i in range(i_start, FLAGS.n_iters):
+    start = (i * batch_size) % N_train
+    end = start + batch_size
+    batch = train_data[start:end]
+    labels = attr_train[start:end]
+
+    # train op
+    res = sess.run(
+        [m.train_vae, m.vae_loss, m.mean_recons, m.mean_KL, scalar_summaries], {
+            m.x: batch,
+            m.vae_lr: vae_lr_[i],
+            m.labels: labels,
+        })
+    logging.info('Iter: %d, Loss: %d', i, res[1])
+    train_writer.add_summary(res[-1], i)
+
+    if i % FLAGS.n_iters_per_eval == 0:
+      # write training reconstructions
+      if batch.shape[0] == batch_size:
+        res = sess.run([x_summary, x_mean_summary], {
+            m.x: batch,
+            m.labels: labels,
+        })
+        train_writer.add_summary(res[0], i)
+        train_writer.add_summary(res[1], i)
+
+      # write sample reconstructions
+      prior_sample = sess.run(m.prior_sample)
+      res = sess.run([sample_summary], {
+          m.q_z_sample: prior_sample,
+          m.labels: labels,
+      })
+      train_writer.add_summary(res[0], i)
+
+      # write eval summaries
+      start = (i * batch_size) % N_eval
+      end = start + batch_size
+      batch = eval_data[start:end]
+      labels = attr_eval[start:end]
+      if batch.shape[0] == batch_size:
+        res_eval = sess.run([
+            m.vae_loss, m.mean_recons, m.mean_KL, scalar_summaries, x_summary,
+            x_mean_summary
+        ], {
+            m.x: batch,
+            m.labels: labels,
+        })
+        traces['loss_eval'].append(res_eval[0])
+        eval_writer.add_summary(res_eval[-3], i)
+        eval_writer.add_summary(res_eval[-2], i)
+        eval_writer.add_summary(res_eval[-1], i)
+
+    if i % FLAGS.n_iters_per_save == 0:
+      smoothed_eval_loss = np.mean(traces['loss_eval'][-running_N_eval:])
+      if smoothed_eval_loss < best_eval_loss:
+        # Save the best model
+        best_eval_loss = smoothed_eval_loss
+        save_name = os.path.join(best_dir, 'vae_best_%s.ckpt' % model_uid)
+        logging.info('SAVING BEST! %s Iter: %d', save_name, i)
+        m.vae_saver.save(sess, save_name)
+        with tf.gfile.Open(os.path.join(best_dir, 'best_ckpt_iters.txt'),
+                           'w') as f:
+          f.write('%d' % i)
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/magenta/models/latent_transfer/train_dataspace.py
+++ b/magenta/models/latent_transfer/train_dataspace.py
@@ -15,25 +15,23 @@ import os
 
 import numpy as np
 import tensorflow as tf
-from tensorflow import app
-from tensorflow import flags
-from tensorflow import logging
 
 from magenta.models.latent_transfer import common
 from magenta.models.latent_transfer import model_dataspace
 from magenta.models.latent_transfer import nn
 configs_module_prefix = 'magenta.models.latent_transfer.configs'
 
-FLAGS = flags.FLAGS
+FLAGS = tf.flags.FLAGS
 
-flags.DEFINE_string('config', 'mnist_0', 'The name of the model config to use.')
-flags.DEFINE_integer('n_iters', 200000, 'Number of iterations.')
-flags.DEFINE_integer('n_iters_per_save', 1000, 'Iterations per saving.')
-flags.DEFINE_integer('n_iters_per_eval', 50, 'Iterations per evaluate.')
-flags.DEFINE_float('lr', 3e-4, 'learning_rate.')
-flags.DEFINE_string('exp_uid', '_exp_0',
-                    'String to append to config for filenames/directories.')
-flags.DEFINE_integer('random_seed', 10003, 'Random seed.')
+tf.flags.DEFINE_string('config', 'mnist_0',
+                       'The name of the model config to use.')
+tf.flags.DEFINE_integer('n_iters', 200000, 'Number of iterations.')
+tf.flags.DEFINE_integer('n_iters_per_save', 1000, 'Iterations per saving.')
+tf.flags.DEFINE_integer('n_iters_per_eval', 50, 'Iterations per evaluate.')
+tf.flags.DEFINE_float('lr', 3e-4, 'learning_rate.')
+tf.flags.DEFINE_string('exp_uid', '_exp_0',
+                       'String to append to config for filenames/directories.')
+tf.flags.DEFINE_integer('random_seed', 10003, 'Random seed.')
 
 MNIST_SIZE = 28
 
@@ -62,7 +60,7 @@ def main(unused_argv):
   best_dir = os.path.join(save_dir, 'best')
   tf.gfile.MakeDirs(save_dir)
   tf.gfile.MakeDirs(best_dir)
-  logging.info('Save Dir: %s', save_dir)
+  tf.logging.info('Save Dir: %s', save_dir)
 
   np.random.seed(FLAGS.random_seed)
   # We use `N` in variable name to emphasis its being the Number of something.
@@ -125,7 +123,7 @@ def main(unused_argv):
             m.vae_lr: vae_lr_[i],
             m.labels: labels,
         })
-    logging.info('Iter: %d, Loss: %d', i, res[1])
+    tf.logging.info('Iter: %d, Loss: %d', i, res[1])
     train_writer.add_summary(res[-1], i)
 
     if i % FLAGS.n_iters_per_eval == 0:
@@ -170,7 +168,7 @@ def main(unused_argv):
         # Save the best model
         best_eval_loss = smoothed_eval_loss
         save_name = os.path.join(best_dir, 'vae_best_%s.ckpt' % model_uid)
-        logging.info('SAVING BEST! %s Iter: %d', save_name, i)
+        tf.logging.info('SAVING BEST! %s Iter: %d', save_name, i)
         m.vae_saver.save(sess, save_name)
         with tf.gfile.Open(os.path.join(best_dir, 'best_ckpt_iters.txt'),
                            'w') as f:
@@ -178,4 +176,4 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
-  app.run(main)
+  tf.app.run(main)

--- a/magenta/models/latent_transfer/train_dataspace.py
+++ b/magenta/models/latent_transfer/train_dataspace.py
@@ -19,10 +19,10 @@ from tensorflow import app
 from tensorflow import flags
 from tensorflow import logging
 
-import common
-import model_dataspace
-import nn
-configs_module_prefix = 'configs'
+from magenta.models.latent_transfer import common
+from magenta.models.latent_transfer import model_dataspace
+from magenta.models.latent_transfer import nn
+configs_module_prefix = 'magenta.models.latent_transfer.configs'
 
 FLAGS = flags.FLAGS
 

--- a/magenta/models/latent_transfer/train_dataspace.py
+++ b/magenta/models/latent_transfer/train_dataspace.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Train VAE on dataspace.
 
 This script trains the models that model the data space as defined in

--- a/magenta/models/latent_transfer/train_dataspace_classifier.py
+++ b/magenta/models/latent_transfer/train_dataspace_classifier.py
@@ -16,21 +16,20 @@ import os
 
 import numpy as np
 import tensorflow as tf
-from tensorflow import app
-from tensorflow import flags
 
 from magenta.models.latent_transfer import common
 from magenta.models.latent_transfer import model_dataspace
 configs_module_prefix = 'magenta.models.latent_transfer.configs'
 
-FLAGS = flags.FLAGS
-flags.DEFINE_string('config', 'mnist_0', 'The name of the model config to use.')
-flags.DEFINE_bool('local', False, 'Run job locally.')
-flags.DEFINE_integer('n_iters', 200000, 'Number of iterations.')
-flags.DEFINE_integer('n_iters_per_save', 10000, 'Iterations per a save.')
-flags.DEFINE_float('lr', 3e-4, 'learning_rate.')
-flags.DEFINE_string('exp_uid', '_exp_0',
-                    'String to append to config for filenames/directories.')
+FLAGS = tf.flags.FLAGS
+tf.flags.DEFINE_string('config', 'mnist_0',
+                       'The name of the model config to use.')
+tf.flags.DEFINE_bool('local', False, 'Run job locally.')
+tf.flags.DEFINE_integer('n_iters', 200000, 'Number of iterations.')
+tf.flags.DEFINE_integer('n_iters_per_save', 10000, 'Iterations per a save.')
+tf.flags.DEFINE_float('lr', 3e-4, 'learning_rate.')
+tf.flags.DEFINE_string('exp_uid', '_exp_0',
+                       'String to append to config for filenames/directories.')
 
 
 def main(unused_argv):
@@ -147,4 +146,4 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
-  app.run(main)
+  tf.app.run(main)

--- a/magenta/models/latent_transfer/train_dataspace_classifier.py
+++ b/magenta/models/latent_transfer/train_dataspace_classifier.py
@@ -19,9 +19,9 @@ import tensorflow as tf
 from tensorflow import app
 from tensorflow import flags
 
-import common
-import model_dataspace
-configs_module_prefix = 'configs'
+from magenta.models.latent_transfer import common
+from magenta.models.latent_transfer import model_dataspace
+configs_module_prefix = 'magenta.models.latent_transfer.configs'
 
 FLAGS = flags.FLAGS
 flags.DEFINE_string('config', 'mnist_0', 'The name of the model config to use.')

--- a/magenta/models/latent_transfer/train_dataspace_classifier.py
+++ b/magenta/models/latent_transfer/train_dataspace_classifier.py
@@ -1,4 +1,8 @@
 """Train classifier on dataspace.
+
+This script trains the data space classifier as defined in
+`model_dataspace.py`. The best checkpoint (as evaluated on valid set)
+would be used to classifier instances in the data space (x).
 """
 
 # pylint:disable=invalid-name

--- a/magenta/models/latent_transfer/train_dataspace_classifier.py
+++ b/magenta/models/latent_transfer/train_dataspace_classifier.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Train classifier on dataspace.
 
 This script trains the data space classifier as defined in

--- a/magenta/models/latent_transfer/train_dataspace_classifier.py
+++ b/magenta/models/latent_transfer/train_dataspace_classifier.py
@@ -1,0 +1,146 @@
+"""Train classifier on dataspace.
+"""
+
+# pylint:disable=invalid-name
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import importlib
+import os
+
+import numpy as np
+import tensorflow as tf
+from tensorflow import app
+from tensorflow import flags
+
+import common
+import model_dataspace
+configs_module_prefix = 'configs'
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string('config', 'mnist_0', 'The name of the model config to use.')
+flags.DEFINE_bool('local', False, 'Run job locally.')
+flags.DEFINE_integer('n_iters', 200000, 'Number of iterations.')
+flags.DEFINE_integer('n_iters_per_save', 10000, 'Iterations per a save.')
+flags.DEFINE_float('lr', 3e-4, 'learning_rate.')
+flags.DEFINE_string('exp_uid', '_exp_0',
+                    'String to append to config for filenames/directories.')
+
+
+def main(unused_argv):
+  del unused_argv
+
+  # Load Config
+  config_name = FLAGS.config
+  config_module = importlib.import_module(configs_module_prefix +
+                                          '.%s' % config_name)
+  config = config_module.config
+  model_uid = common.get_model_uid(config_name, FLAGS.exp_uid)
+  batch_size = config['batch_size']
+
+  # Load dataset
+  dataset = common.load_dataset(config)
+  save_path = dataset.save_path
+  train_data = dataset.train_data
+  attr_train = dataset.attr_train
+  eval_data = dataset.eval_data
+  attr_eval = dataset.attr_eval
+
+  # Make the directory
+  save_dir = os.path.join(save_path, model_uid)
+  best_dir = os.path.join(save_dir, 'best')
+  tf.gfile.MakeDirs(save_dir)
+  tf.gfile.MakeDirs(best_dir)
+  tf.logging.info('Save Dir: %s', save_dir)
+
+  np.random.seed(10003)
+  N_train = train_data.shape[0]
+  N_eval = eval_data.shape[0]
+
+  # Load Model
+  tf.reset_default_graph()
+  sess = tf.Session()
+  m = model_dataspace.Model(config, name=model_uid)
+  _ = m()  # noqa
+
+  # Create summaries
+  y_true = m.labels
+  y_pred = tf.cast(tf.greater(m.pred_classifier, 0.5), tf.int32)
+  accuracy = tf.reduce_mean(tf.cast(tf.equal(y_true, y_pred), tf.float32))
+
+  tf.summary.scalar('Loss', m.classifier_loss)
+  tf.summary.scalar('Accuracy', accuracy)
+  scalar_summaries = tf.summary.merge_all()
+
+  # Summary writers
+  train_writer = tf.summary.FileWriter(save_dir + '/train', sess.graph)
+  eval_writer = tf.summary.FileWriter(save_dir + '/eval', sess.graph)
+
+  # Initialize
+  sess.run(tf.global_variables_initializer())
+
+  i_start = 0
+  running_N_eval = 30
+  traces = {
+      'i': [],
+      'i_pred': [],
+      'loss': [],
+      'loss_eval': [],
+  }
+
+  best_eval_loss = np.inf
+  classifier_lr_ = np.logspace(
+      np.log10(FLAGS.lr), np.log10(1e-6), FLAGS.n_iters)
+
+  # Train the Classifier
+  for i in range(i_start, FLAGS.n_iters):
+    start = (i * batch_size) % N_train
+    end = start + batch_size
+    batch = train_data[start:end]
+    labels = attr_train[start:end]
+
+    # train op
+    res = sess.run([m.train_classifier, m.classifier_loss, scalar_summaries], {
+        m.x: batch,
+        m.labels: labels,
+        m.classifier_lr: classifier_lr_[i]
+    })
+    tf.logging.info('Iter: %d, Loss: %.2e', i, res[1])
+    train_writer.add_summary(res[-1], i)
+
+    if i % 10 == 0:
+      # write training reconstructions
+      if batch.shape[0] == batch_size:
+        # write eval summaries
+        start = (i * batch_size) % N_eval
+        end = start + batch_size
+        batch = eval_data[start:end]
+        labels = attr_eval[start:end]
+
+        if batch.shape[0] == batch_size:
+          res_eval = sess.run([m.classifier_loss, scalar_summaries], {
+              m.x: batch,
+              m.labels: labels,
+          })
+          traces['loss_eval'].append(res_eval[0])
+          eval_writer.add_summary(res_eval[-1], i)
+
+    if i % FLAGS.n_iters_per_save == 0:
+      smoothed_eval_loss = np.mean(traces['loss_eval'][-running_N_eval:])
+      if smoothed_eval_loss < best_eval_loss:
+
+        # Save the best model
+        best_eval_loss = smoothed_eval_loss
+        save_name = os.path.join(best_dir,
+                                 'classifier_best_%s.ckpt' % model_uid)
+        tf.logging.info('SAVING BEST! %s Iter: %d', save_name, i)
+        m.classifier_saver.save(sess, save_name)
+        with tf.gfile.Open(os.path.join(best_dir, 'best_ckpt_iters.txt'),
+                           'w') as f:
+          f.write('%d' % i)
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/magenta/models/latent_transfer/train_joint.py
+++ b/magenta/models/latent_transfer/train_joint.py
@@ -18,9 +18,9 @@ from tensorflow import app
 from tensorflow import flags
 from tqdm import tqdm
 
-import common
-import common_joint
-import model_joint
+from magenta.models.latent_transfer import common
+from magenta.models.latent_transfer import common_joint
+from magenta.models.latent_transfer import model_joint
 
 FLAGS = flags.FLAGS
 

--- a/magenta/models/latent_transfer/train_joint.py
+++ b/magenta/models/latent_transfer/train_joint.py
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Train joint model on two latent spaces.
 
 This script train the joint model defined in `model_joint.py` that transfers

--- a/magenta/models/latent_transfer/train_joint.py
+++ b/magenta/models/latent_transfer/train_joint.py
@@ -37,6 +37,7 @@ flags.DEFINE_integer('random_seed', 19260817, 'Random seed')
 flags.DEFINE_string('exp_uid_classifier', '_exp_0', 'exp_uid for classifier')
 
 # For Overriding configs
+flags.DEFINE_integer('n_latent', 64, '')
 flags.DEFINE_integer('n_latent_shared', 2, '')
 flags.DEFINE_float('prior_loss_beta_A', 0.01, '')
 flags.DEFINE_float('prior_loss_beta_B', 0.01, '')

--- a/magenta/models/latent_transfer/train_joint.py
+++ b/magenta/models/latent_transfer/train_joint.py
@@ -1,0 +1,317 @@
+"""Train joint model on two latent spaces.
+
+This script train the joint model defined in `model_joint.py` that transfers
+between latent space of generative models that model the data.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from functools import partial
+import importlib
+from os.path import join
+
+import numpy as np
+import tensorflow as tf
+from tensorflow import app
+from tensorflow import flags
+from tqdm import tqdm
+
+import common
+import common_joint
+import model_joint
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string('config', 'transfer_A_unconditional_mnist_to_mnist',
+                    'The name of the model config to use.')
+flags.DEFINE_string('exp_uid_A', '_exp_0', 'exp_uid for data_A')
+flags.DEFINE_string('exp_uid_B', '_exp_1', 'exp_uid for data_B')
+flags.DEFINE_string('exp_uid', '_exp_0',
+                    'String to append to config for filenames/directories.')
+flags.DEFINE_integer('n_iters', 100000, 'Number of iterations.')
+flags.DEFINE_integer('n_iters_per_save', 5000, 'Iterations per a save.')
+flags.DEFINE_integer('n_iters_per_eval', 5000, 'Iterations per a evaluation.')
+flags.DEFINE_integer('random_seed', 19260817, 'Random seed')
+flags.DEFINE_string('exp_uid_classifier', '_exp_0', 'exp_uid for classifier')
+
+# For Overriding configs
+flags.DEFINE_integer('n_latent_shared', 2, '')
+flags.DEFINE_float('prior_loss_beta_A', 0.01, '')
+flags.DEFINE_float('prior_loss_beta_B', 0.01, '')
+flags.DEFINE_float('prior_loss_align_beta', 0.0, '')
+flags.DEFINE_float('mean_recons_A_align_beta', 0.0, '')
+flags.DEFINE_float('mean_recons_B_align_beta', 0.0, '')
+flags.DEFINE_float('mean_recons_A_to_B_align_beta', 0.0, '')
+flags.DEFINE_float('mean_recons_B_to_A_align_beta', 0.0, '')
+flags.DEFINE_integer('pairing_number', 1024, '')
+
+
+def load_config(config_name):
+  return importlib.import_module('configs.%s' % config_name).config
+
+
+def main(unused_argv):
+  # pylint:disable=unused-variable
+  # Reason:
+  #   This training script relys on many programmatical call to function and
+  #   access to variables. Pylint cannot infer this case so it emits false alarm
+  #   of unused-variable if we do not disable this warning.
+
+  # pylint:disable=invalid-name
+  # Reason:
+  #   Following variables have their name consider to be invalid by pylint so
+  #   we disable the warning.
+  #   - Variable that in its name has A or B indictating their belonging of
+  #     one side of data.
+  del unused_argv
+
+  # Load main config
+  config_name = FLAGS.config
+  config = load_config(config_name)
+
+  config_name_A = config['config_A']
+  config_name_B = config['config_B']
+  config_name_classifier_A = config['config_classifier_A']
+  config_name_classifier_B = config['config_classifier_B']
+
+  # Load dataset
+  dataset_A = common_joint.load_dataset(config_name_A, FLAGS.exp_uid_A)
+  (dataset_blob_A, train_data_A, train_label_A, train_mu_A, train_sigma_A,
+   index_grouped_by_label_A) = dataset_A
+  dataset_B = common_joint.load_dataset(config_name_B, FLAGS.exp_uid_B)
+  (dataset_blob_B, train_data_B, train_label_B, train_mu_B, train_sigma_B,
+   index_grouped_by_label_B) = dataset_B
+
+  # Prepare directories
+  dirs = common_joint.prepare_dirs('joint', config_name, FLAGS.exp_uid)
+  save_dir, sample_dir = dirs
+
+  # Set random seed
+  np.random.seed(FLAGS.random_seed)
+  tf.set_random_seed(FLAGS.random_seed)
+
+  # Real Training.
+  tf.reset_default_graph()
+  sess = tf.Session()
+
+  # Load model's architecture (= build)
+  one_side_helper_A = common_joint.OneSideHelper(config_name_A, FLAGS.exp_uid_A,
+                                                 config_name_classifier_A,
+                                                 FLAGS.exp_uid_classifier)
+  one_side_helper_B = common_joint.OneSideHelper(config_name_B, FLAGS.exp_uid_B,
+                                                 config_name_classifier_B,
+                                                 FLAGS.exp_uid_classifier)
+  m = common_joint.load_model(model_joint.Model, config_name, FLAGS.exp_uid)
+
+  # Prepare summary
+  train_writer = tf.summary.FileWriter(save_dir + '/transfer_train', sess.graph)
+  scalar_summaries = tf.summary.merge([
+      tf.summary.scalar(key, value)
+      for key, value in m.get_summary_kv_dict().items()
+  ])
+  manual_summary_helper = common_joint.ManualSummaryHelper()
+
+  # Initialize and restore
+  sess.run(tf.global_variables_initializer())
+
+  one_side_helper_A.restore(dataset_blob_A)
+  one_side_helper_B.restore(dataset_blob_B)
+
+  # Miscs from config
+  batch_size = config['batch_size']
+  n_latent_shared = config['n_latent_shared']
+  pairing_number = config['pairing_number']
+  n_latent_A = config['vae_A']['n_latent']
+  n_latent_B = config['vae_B']['n_latent']
+  i_start = 0
+  # Data iterators
+
+  single_data_iterator_A = common_joint.SingleDataIterator(
+      train_mu_A, train_sigma_A, batch_size)
+  single_data_iterator_B = common_joint.SingleDataIterator(
+      train_mu_B, train_sigma_B, batch_size)
+  paired_data_iterator = common_joint.PairedDataIterator(
+      train_mu_A, train_sigma_A, train_data_A, train_label_A,
+      index_grouped_by_label_A, train_mu_B, train_sigma_B, train_data_B,
+      train_label_B, index_grouped_by_label_B, pairing_number, batch_size)
+  single_data_iterator_A_for_evaluation = common_joint.SingleDataIterator(
+      train_mu_A, train_sigma_A, batch_size)
+  single_data_iterator_B_for_evaluation = common_joint.SingleDataIterator(
+      train_mu_B, train_sigma_B, batch_size)
+
+  # Training loop
+  n_iters = FLAGS.n_iters
+  for i in tqdm(range(i_start, n_iters), desc='training', unit=' batch'):
+    # Prepare data for this batch
+    # - Unsupervised (A)
+    x_A, _ = next(single_data_iterator_A)
+    x_B, _ = next(single_data_iterator_B)
+    # - Supervised (aligning)
+    x_align_A, x_align_B, align_debug_info = next(paired_data_iterator)
+    real_x_align_A, real_x_align_B = align_debug_info
+
+    # Run training op and write summary
+    res = sess.run([m.train_full, scalar_summaries], {
+        m.x_A: x_A,
+        m.x_B: x_B,
+        m.x_align_A: x_align_A,
+        m.x_align_B: x_align_B,
+    })
+    train_writer.add_summary(res[-1], i)
+
+    if i % FLAGS.n_iters_per_save == 0:
+      # Save the model if instructed
+      config_name = FLAGS.config
+      model_uid = common.get_model_uid(config_name, FLAGS.exp_uid)
+
+      save_name = join(save_dir, 'transfer_%s_%d.ckpt' % (model_uid, i))
+      m.vae_saver.save(sess, save_name)
+      with tf.gfile.Open(join(save_dir, 'ckpt_iters.txt'), 'w') as f:
+        f.write('%d' % i)
+
+    # Evaluate if instructed
+    if i % FLAGS.n_iters_per_eval == 0:
+      # Helper functions
+      def joint_sample(sample_size):
+        z_hat = np.random.randn(sample_size, n_latent_shared)
+        return sess.run([m.x_joint_A, m.x_joint_B], {
+            m.z_hat: z_hat,
+        })
+
+      def get_x_from_prior_A():
+        return sess.run(m.x_from_prior_A)
+
+      def get_x_from_prior_B():
+        return sess.run(m.x_from_prior_B)
+
+      def get_x_from_posterior_A():
+        return next(single_data_iterator_A_for_evaluation)[0]
+
+      def get_x_from_posterior_B():
+        return next(single_data_iterator_B_for_evaluation)[0]
+
+      def get_x_prime_A(x_A):
+        return sess.run(m.x_prime_A, {m.x_A: x_A})
+
+      def get_x_prime_B(x_B):
+        return sess.run(m.x_prime_B, {m.x_B: x_B})
+
+      def transfer_A_to_B(x_A):
+        return sess.run(m.x_A_to_B, {m.x_A: x_A})
+
+      def transfer_B_to_A(x_B):
+        return sess.run(m.x_B_to_A, {m.x_B: x_B})
+
+      def manual_summary(key, value):
+        summary = manual_summary_helper.get_summary(sess, key, value)
+        # This [cell-var-from-loop] is intented
+        train_writer.add_summary(summary, i)  # pylint: disable=cell-var-from-loop
+
+      # Classifier based evaluation
+      sample_total_size = 10000
+      sample_batch_size = 100
+
+      def pred(one_side_helper, x):
+        real_x = one_side_helper.m_helper.decode(x)
+        return one_side_helper.m_classifier_helper.classify(real_x, batch_size)
+
+      def accuarcy(x_1, x_2, type_1, type_2):
+        assert type_1 in ('A', 'B') and type_2 in ('A', 'B')
+        func_A = partial(pred, one_side_helper=one_side_helper_A)
+        func_B = partial(pred, one_side_helper=one_side_helper_B)
+        func_1 = func_A if type_1 == 'A' else func_B
+        func_2 = func_A if type_2 == 'A' else func_B
+        pred_1, pred_2 = func_1(x=x_1), func_2(x=x_2)
+        return np.mean(np.equal(pred_1, pred_2).astype('f'))
+
+      def joint_sample_accuarcy():
+        x_A, x_B = joint_sample(sample_size=sample_total_size)  # pylint: disable=cell-var-from-loop
+        return accuarcy(x_A, x_B, 'A', 'B')
+
+      def transfer_sample_accuarcy_A_B():
+        x_A = get_x_from_prior_A()
+        x_B = transfer_A_to_B(x_A)
+        return accuarcy(x_A, x_B, 'A', 'B')
+
+      def transfer_sample_accuarcy_B_A():
+        x_B = get_x_from_prior_B()
+        x_A = transfer_B_to_A(x_B)
+        return accuarcy(x_A, x_B, 'A', 'B')
+
+      def transfer_accuarcy_A_B():
+        x_A = get_x_from_posterior_A()
+        x_B = transfer_A_to_B(x_A)
+        return accuarcy(x_A, x_B, 'A', 'B')
+
+      def transfer_accuarcy_B_A():
+        x_B = get_x_from_posterior_B()
+        x_A = transfer_B_to_A(x_B)
+        return accuarcy(x_A, x_B, 'A', 'B')
+
+      def recons_accuarcy_A():
+        # Use x_A in outer scope
+        # These [cell-var-from-loop]s are intended
+        x_A_prime = get_x_prime_A(x_A)  # pylint: disable=cell-var-from-loop
+        return accuarcy(x_A, x_A_prime, 'A', 'A')  # pylint: disable=cell-var-from-loop
+
+      def recons_accuarcy_B():
+        # use x_B in outer scope
+        # These [cell-var-from-loop]s are intended
+        x_B_prime = get_x_prime_B(x_B)  # pylint: disable=cell-var-from-loop
+        return accuarcy(x_B, x_B_prime, 'B', 'B')  # pylint: disable=cell-var-from-loop
+
+      # Do all manual summary
+      for func_name in (
+          'joint_sample_accuarcy',
+          'transfer_sample_accuarcy_A_B',
+          'transfer_sample_accuarcy_B_A',
+          'transfer_accuarcy_A_B',
+          'transfer_accuarcy_B_A',
+          'recons_accuarcy_A',
+          'recons_accuarcy_B',
+      ):
+        func = locals()[func_name]
+        manual_summary(func_name, func())
+
+      # Sampling based evaluation / sampling
+      x_prime_A = get_x_prime_A(x_A)
+      x_prime_B = get_x_prime_B(x_B)
+      x_from_prior_A = get_x_from_prior_A()
+      x_from_prior_B = get_x_from_prior_B()
+      x_A_to_B = transfer_A_to_B(x_A)
+      x_B_to_A = transfer_B_to_A(x_B)
+      x_align_A_to_B = transfer_A_to_B(x_align_A)
+      x_align_B_to_A = transfer_B_to_A(x_align_B)
+      x_joint_A, x_joint_B = joint_sample(sample_size=batch_size)
+
+      this_iter_sample_dir = join(sample_dir, 'transfer_train_sample',
+                                  '%010d' % i)
+      tf.gfile.MakeDirs(this_iter_sample_dir)
+
+      for helper, var_names, x_is_real_x in [
+          (one_side_helper_A.m_helper,
+           ('x_A', 'x_prime_A', 'x_from_prior_A', 'x_B_to_A', 'x_align_A',
+            'x_align_B_to_A', 'x_joint_A'), False),
+          (one_side_helper_A.m_helper, ('real_x_align_A',), True),
+          (one_side_helper_B.m_helper,
+           ('x_B', 'x_prime_B', 'x_from_prior_B', 'x_A_to_B', 'x_align_B',
+            'x_align_A_to_B', 'x_joint_B'), False),
+          (one_side_helper_B.m_helper, ('real_x_align_B',), True),
+      ]:
+        for var_name in var_names:
+          # Here `var` would be None if
+          #   - there is no such variable in `locals()`, or
+          #   - such variable exists but the value is None
+          # In both case, we would skip saving data from it.
+          var = locals().get(var_name, None)
+          if var is not None:
+            helper.save_data(var, var_name, this_iter_sample_dir, x_is_real_x)
+
+  # pylint:enable=invalid-name
+  # pylint:enable=unused-variable
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/magenta/models/latent_transfer/train_joint.py
+++ b/magenta/models/latent_transfer/train_joint.py
@@ -14,39 +14,38 @@ from os.path import join
 
 import numpy as np
 import tensorflow as tf
-from tensorflow import app
-from tensorflow import flags
 from tqdm import tqdm
 
 from magenta.models.latent_transfer import common
 from magenta.models.latent_transfer import common_joint
 from magenta.models.latent_transfer import model_joint
 
-FLAGS = flags.FLAGS
+FLAGS = tf.flags.FLAGS
 
-flags.DEFINE_string('config', 'transfer_A_unconditional_mnist_to_mnist',
-                    'The name of the model config to use.')
-flags.DEFINE_string('exp_uid_A', '_exp_0', 'exp_uid for data_A')
-flags.DEFINE_string('exp_uid_B', '_exp_1', 'exp_uid for data_B')
-flags.DEFINE_string('exp_uid', '_exp_0',
-                    'String to append to config for filenames/directories.')
-flags.DEFINE_integer('n_iters', 100000, 'Number of iterations.')
-flags.DEFINE_integer('n_iters_per_save', 5000, 'Iterations per a save.')
-flags.DEFINE_integer('n_iters_per_eval', 5000, 'Iterations per a evaluation.')
-flags.DEFINE_integer('random_seed', 19260817, 'Random seed')
-flags.DEFINE_string('exp_uid_classifier', '_exp_0', 'exp_uid for classifier')
+tf.flags.DEFINE_string('config', 'transfer_A_unconditional_mnist_to_mnist',
+                       'The name of the model config to use.')
+tf.flags.DEFINE_string('exp_uid_A', '_exp_0', 'exp_uid for data_A')
+tf.flags.DEFINE_string('exp_uid_B', '_exp_1', 'exp_uid for data_B')
+tf.flags.DEFINE_string('exp_uid', '_exp_0',
+                       'String to append to config for filenames/directories.')
+tf.flags.DEFINE_integer('n_iters', 100000, 'Number of iterations.')
+tf.flags.DEFINE_integer('n_iters_per_save', 5000, 'Iterations per a save.')
+tf.flags.DEFINE_integer('n_iters_per_eval', 5000,
+                        'Iterations per a evaluation.')
+tf.flags.DEFINE_integer('random_seed', 19260817, 'Random seed')
+tf.flags.DEFINE_string('exp_uid_classifier', '_exp_0', 'exp_uid for classifier')
 
 # For Overriding configs
-flags.DEFINE_integer('n_latent', 64, '')
-flags.DEFINE_integer('n_latent_shared', 2, '')
-flags.DEFINE_float('prior_loss_beta_A', 0.01, '')
-flags.DEFINE_float('prior_loss_beta_B', 0.01, '')
-flags.DEFINE_float('prior_loss_align_beta', 0.0, '')
-flags.DEFINE_float('mean_recons_A_align_beta', 0.0, '')
-flags.DEFINE_float('mean_recons_B_align_beta', 0.0, '')
-flags.DEFINE_float('mean_recons_A_to_B_align_beta', 0.0, '')
-flags.DEFINE_float('mean_recons_B_to_A_align_beta', 0.0, '')
-flags.DEFINE_integer('pairing_number', 1024, '')
+tf.flags.DEFINE_integer('n_latent', 64, '')
+tf.flags.DEFINE_integer('n_latent_shared', 2, '')
+tf.flags.DEFINE_float('prior_loss_beta_A', 0.01, '')
+tf.flags.DEFINE_float('prior_loss_beta_B', 0.01, '')
+tf.flags.DEFINE_float('prior_loss_align_beta', 0.0, '')
+tf.flags.DEFINE_float('mean_recons_A_align_beta', 0.0, '')
+tf.flags.DEFINE_float('mean_recons_B_align_beta', 0.0, '')
+tf.flags.DEFINE_float('mean_recons_A_to_B_align_beta', 0.0, '')
+tf.flags.DEFINE_float('mean_recons_B_to_A_align_beta', 0.0, '')
+tf.flags.DEFINE_integer('pairing_number', 1024, '')
 
 
 def load_config(config_name):
@@ -315,4 +314,4 @@ def main(unused_argv):
 
 
 if __name__ == '__main__':
-  app.run(main)
+  tf.app.run(main)


### PR DESCRIPTION
Check-in of Latent Transfer model and training scripts.

This check-in contains the core parts of Latent Transfer model including:

- The transfer model using Variational Inference that bridges latents spaces of data space models.
- The scripts for training such model.
- Related configs which also allow parameterization from command line.
- Training of VAE and classifier of data space (MNIST and CelebA)
- The utility for associated data space model on more data (Fashion MNIST, WaveGAN) and on more functionality (sampling, encoding).