### PR TITLE
Update loader.py to use non-deprecated tf.data API

### DIFF
--- a/magenta/models/piano_genie/loader.py
+++ b/magenta/models/piano_genie/loader.py
@@ -148,7 +148,7 @@ def load_noteseqs(fp,
     dataset = dataset.shuffle(buffer_size=buffer_size)
 
   # Make batches
-  dataset = dataset.apply(tf.contrib.data.batch_and_drop_remainder(batch_size))
+  dataset = dataset.batch(batch_size, drop_remainder=True)
 
   # Repeat
   if repeat:


### PR DESCRIPTION
`tf.contrib.data.batch_and_drop_remainder(n)` has been deprecated and replaced with `Dataset.batch(n, drop_remainder=True)`.