### PR TITLE
Update uses of tf.contrib.distributions to use TensorFlow Probability.

### DIFF
--- a/magenta/models/latent_transfer/BUILD
+++ b/magenta/models/latent_transfer/BUILD
@@ -103,6 +103,7 @@ py_library(
         # numpy dep
         # sonnet dep
         # tensorflow dep
+        # tensorflow_probability dep
     ],
 )
 
@@ -115,6 +116,7 @@ py_library(
         # numpy dep
         # sonnet dep
         # tensorflow dep
+        # tensorflow_probability dep
     ],
 )
 

--- a/magenta/models/latent_transfer/model_dataspace.py
+++ b/magenta/models/latent_transfer/model_dataspace.py
@@ -27,10 +27,11 @@ import numpy as np
 from six import iteritems
 import sonnet as snt
 import tensorflow as tf
+import tensorflow_probability as tfp
 
 from magenta.models.latent_transfer.common import dataset_is_mnist_family
 
-ds = tf.contrib.distributions
+ds = tfp.distributions
 
 
 class Model(snt.AbstractModule):

--- a/magenta/models/latent_transfer/model_joint.py
+++ b/magenta/models/latent_transfer/model_joint.py
@@ -25,10 +25,11 @@ from six import iteritems
 
 import sonnet as snt
 import tensorflow as tf
+import tensorflow_probability as tfp
 
 from magenta.models.latent_transfer import nn
 
-ds = tf.contrib.distributions
+ds = tfp.distributions
 
 
 def affine(x, output_size, z=None, residual=False, softplus=False):

--- a/magenta/models/music_vae/BUILD
+++ b/magenta/models/music_vae/BUILD
@@ -77,6 +77,7 @@ py_test(
         # tensorflow dep
     ],
 )
+
 py_library(
     name = "configs",
     srcs = ["configs.py"],
@@ -96,6 +97,7 @@ py_library(
     srcs_version = "PY2AND3",
     deps = [
         # tensorflow dep
+        # tensorflow_probability dep
     ],
 )
 

--- a/magenta/models/music_vae/base_model.py
+++ b/magenta/models/music_vae/base_model.py
@@ -21,8 +21,9 @@ import abc
 
 # internal imports
 import tensorflow as tf
+import tensorflow_probability as tfp
 
-ds = tf.contrib.distributions
+ds = tfp.distributions
 
 
 class BaseEncoder(object):
@@ -347,7 +348,7 @@ class MusicVAE(object):
       tf.logging.warning(
           'Sampling from conditional model without `z`. Using random `z`.')
       normal_shape = [n, self.hparams.z_size]
-      normal_dist = tf.contrib.distributions.Normal(
+      normal_dist = tfp.distributions.Normal(
           loc=tf.zeros(normal_shape), scale=tf.ones(normal_shape))
       z = normal_dist.sample()
 

--- a/magenta/models/music_vae/lstm_models.py
+++ b/magenta/models/music_vae/lstm_models.py
@@ -557,7 +557,7 @@ class CategoricalLstmDecoder(BaseLstmDecoder):
     return r_loss, metric_map
 
   def _sample(self, rnn_output, temperature=1.0):
-    sampler = tf.contrib.distributions.OneHotCategorical(
+    sampler = tfp.distributions.OneHotCategorical(
         logits=rnn_output / temperature, dtype=tf.float32)
     return sampler.sample()
 
@@ -714,7 +714,7 @@ class MultiOutCategoricalLstmDecoder(CategoricalLstmDecoder):
     split_logits = tf.split(rnn_output, self._output_depths, axis=-1)
     samples = []
     for logits, output_depth in zip(split_logits, self._output_depths):
-      sampler = tf.contrib.distributions.Categorical(
+      sampler = tfp.distributions.Categorical(
           logits=logits / temperature)
       sample_label = sampler.sample()
       samples.append(tf.one_hot(sample_label, output_depth, dtype=tf.float32))

--- a/magenta/tools/pip/setup.py
+++ b/magenta/tools/pip/setup.py
@@ -52,8 +52,10 @@ REQUIRED_PACKAGES = [
 
 if gpu_mode:
   REQUIRED_PACKAGES.append('tensorflow-gpu >= 1.8.0')
+  REQUIRED_PACKAGES.append('tensorflow-probability-gpu >= 0.3.0')
 else:
   REQUIRED_PACKAGES.append('tensorflow >= 1.8.0')
+  REQUIRED_PACKAGES.append('tensorflow-probability >= 0.3.0')
 
 # pylint:disable=line-too-long
 CONSOLE_SCRIPTS = [


### PR DESCRIPTION
Given that tf.contrib.distributions is being deprecated/removed, update all uses of tf.contrib.distributions to use tfp.distributions (TensorFlow Probability: https://www.tensorflow.org/probability/).