### PR TITLE
python 3 compatibility for music vae

### DIFF
--- a/magenta/models/music_vae/base_model.py
+++ b/magenta/models/music_vae/base_model.py
@@ -303,7 +303,7 @@ class MusicVAE(object):
     optimizer = tf.train.AdamOptimizer(lr)
 
     tf.summary.scalar('learning_rate', lr)
-    for n, t in scalars_to_summarize.iteritems():
+    for n, t in scalars_to_summarize.items():
       tf.summary.scalar(n, tf.reduce_mean(t))
 
     return optimizer

--- a/magenta/models/music_vae/lstm_models.py
+++ b/magenta/models/music_vae/lstm_models.py
@@ -1077,7 +1077,7 @@ class HierarchicalLstmDecoder(base_model.BaseDecoder):
     hier_t = tf.reshape(t, hier_shape)
     # Move the batch dimension to after the hierarchical dimensions.
     num_levels = len(level_lengths)
-    perm = range(len(hier_shape))
+    perm = list(range(len(hier_shape)))
     perm.insert(num_levels, perm.pop(0))
     return tf.transpose(hier_t, perm)
 


### PR DESCRIPTION
Converted an instance of range() to list(range()) because insert was subsequently called on the output, which is a list in python 2, but a generator in python 3, and thus an error is raised. By converting it to a list, the error will not be raised in either version. 

Converted an instance of dict.iteritems() to dict.items() for compatibility with both python 2 and 3. There are other instances of dict.iteritems() that did not cause problems in my code that may cause problems for others, but since iteritems() returns an iterator and items() returns a list, testing will be required before changing these instances.