### PR TITLE
Fixing tensorflow-probability-gpu version

### DIFF
--- a/magenta/tools/pip/setup.py
+++ b/magenta/tools/pip/setup.py
@@ -55,7 +55,7 @@ if gpu_mode:
   REQUIRED_PACKAGES.append('tensorflow-probability-gpu >= 0.4.0')
 else:
   REQUIRED_PACKAGES.append('tensorflow >= 1.12.0')
-  REQUIRED_PACKAGES.append('tensorflow-probability >= 0.4.0')
+  REQUIRED_PACKAGES.append('tensorflow-probability >= 0.5.0')
 
 # pylint:disable=line-too-long
 CONSOLE_SCRIPTS = [

--- a/magenta/tools/pip/setup.py
+++ b/magenta/tools/pip/setup.py
@@ -52,10 +52,10 @@ REQUIRED_PACKAGES = [
 
 if gpu_mode:
   REQUIRED_PACKAGES.append('tensorflow-gpu >= 1.12.0')
-  REQUIRED_PACKAGES.append('tensorflow-probability-gpu >= 0.5.0')
+  REQUIRED_PACKAGES.append('tensorflow-probability-gpu >= 0.4.0')
 else:
   REQUIRED_PACKAGES.append('tensorflow >= 1.12.0')
-  REQUIRED_PACKAGES.append('tensorflow-probability >= 0.5.0')
+  REQUIRED_PACKAGES.append('tensorflow-probability >= 0.4.0')
 
 # pylint:disable=line-too-long
 CONSOLE_SCRIPTS = [


### PR DESCRIPTION
0.4.0 is the latest stable release for tensorflow-probability-gpu, 0.5.0 is still in pre-release stage. Using a later version here causes errors during installation with pip.