### PR TITLE
Specify file type as 'rb' when reading MIDI files as 'rb' for python3.

### DIFF
--- a/magenta/models/music_vae/music_vae_generate.py
+++ b/magenta/models/music_vae/music_vae_generate.py
@@ -116,10 +116,8 @@ def run(config_map):
       raise ValueError('Input MIDI 1 not found: %s' % FLAGS.input_midi_1)
     if not os.path.exists(input_midi_2):
       raise ValueError('Input MIDI 2 not found: %s' % FLAGS.input_midi_2)
-    input_1 = mm.midi_to_sequence_proto(
-        tf.gfile.GFile(input_midi_1, 'rb').read())
-    input_2 = mm.midi_to_sequence_proto(
-        tf.gfile.GFile(input_midi_2, 'rb').read())
+    input_1 = mm.midi_file_to_note_sequence(input_midi_1)
+    input_2 = mm.midi_file_to_note_sequence(input_midi_2)
 
     def _check_extract_examples(input_ns, path, input_number):
       """Make sure each input returns exactly one example from the converter."""

--- a/magenta/models/music_vae/music_vae_generate.py
+++ b/magenta/models/music_vae/music_vae_generate.py
@@ -116,8 +116,10 @@ def run(config_map):
       raise ValueError('Input MIDI 1 not found: %s' % FLAGS.input_midi_1)
     if not os.path.exists(input_midi_2):
       raise ValueError('Input MIDI 2 not found: %s' % FLAGS.input_midi_2)
-    input_1 = mm.midi_to_sequence_proto(tf.gfile.GFile(input_midi_1).read())
-    input_2 = mm.midi_to_sequence_proto(tf.gfile.GFile(input_midi_2).read())
+    input_1 = mm.midi_to_sequence_proto(
+        tf.gfile.GFile(input_midi_1, 'rb').read())
+    input_2 = mm.midi_to_sequence_proto(
+        tf.gfile.GFile(input_midi_2, 'rb').read())
 
     def _check_extract_examples(input_ns, path, input_number):
       """Make sure each input returns exactly one example from the converter."""

--- a/magenta/models/onsets_frames_transcription/onsets_frames_transcription_create_dataset.py
+++ b/magenta/models/onsets_frames_transcription/onsets_frames_transcription_create_dataset.py
@@ -250,13 +250,12 @@ def generate_train_set(exclude_ids):
     for pair in train_file_pairs:
       print(pair)
       # load the wav data
-      wav_data = tf.gfile.Open(pair[0]).read()
+      wav_data = tf.gfile.Open(pair[0], 'rb').read()
       samples = audio_io.wav_data_to_samples(wav_data, FLAGS.sample_rate)
       samples = librosa.util.normalize(samples, norm=np.inf)
 
       # load the midi data and convert to a notesequence
-      midi_data = tf.gfile.Open(pair[1]).read()
-      ns = midi_io.midi_to_sequence_proto(midi_data)
+      ns = midi_io.midi_file_to_note_sequence(pair[1])
 
       splits = find_split_points(ns, samples, FLAGS.sample_rate,
                                  FLAGS.min_length, FLAGS.max_length)
@@ -319,8 +318,7 @@ def generate_test_set():
       wav_data = audio_io.samples_to_wav_data(samples, FLAGS.sample_rate)
 
       # load the midi data and convert to a notesequence
-      midi_data = tf.gfile.Open(pair[1]).read()
-      ns = midi_io.midi_to_sequence_proto(midi_data)
+      ns = midi_io.midi_file_to_note_sequence(pair[1])
 
       velocities = [note.velocity for note in ns.notes]
       velocity_max = np.max(velocities)


### PR DESCRIPTION
Fixes #1330.