### PR TITLE
Fix onsets and frames import of pianoroll_to_note_sequence

### DIFF
--- a/magenta/models/onsets_frames_transcription/train_util.py
+++ b/magenta/models/onsets_frames_transcription/train_util.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 
 from . import data
 from . import model
-from .infer_util import pianoroll_to_note_sequence
+from magenta.music.sequences_lib import pianoroll_to_note_sequence
 from .infer_util import sequence_to_valued_intervals
 
 from mir_eval.transcription import precision_recall_f1_overlap


### PR DESCRIPTION
Hi, I'm working on an extension of the onsets and frames paper for my senior research work and I think I found a bug in this import statement.

Also in this same file, I found that lines 89, 92, 312, 328, and 336 are incompatible with python 3:
`File "/private/var/tmp/_bazel_faraaz/243fc692f61ecdfea95cd86ad338ee1d/execroot/__main__/bazel-out/darwin-fastbuild/bin/amt/models/onsets_frames/train.runfiles/__main__/amt/models/onsets_frames/train_util.py", line 89, in train
    for label, loss_collection in losses.iteritems():
AttributeError: 'dict' object has no attribute 'iteritems'`

Changing `iteritems` to `items` fixed this error for me, but I think this has slightly different functionality in python 2. Just wanted to point it out!
