### PR TITLE
Fixes for onsets and frames testing

### DIFF
--- a/magenta/models/onsets_frames_transcription/train_util.py
+++ b/magenta/models/onsets_frames_transcription/train_util.py
@@ -152,7 +152,7 @@ def evaluate(train_dir,
         tf.contrib.training.SummaryAtEndHook(eval_dir)]
     tf.contrib.training.evaluate_repeatedly(
         train_dir,
-        eval_ops=metrics_to_updates.values(),
+        eval_ops=list(metrics_to_updates.values()),
         hooks=hooks,
         eval_interval_secs=60,
         timeout=None)
@@ -178,10 +178,10 @@ def test(checkpoint_path, test_dir, examples_path, hparams,
         checkpoint_path=checkpoint_path,
         logdir=test_dir,
         num_evals=num_batches or transcription_data.num_batches,
-        eval_op=metrics_to_updates.values(),
-        final_op=metrics_to_values.values())
+        eval_op=list(metrics_to_updates.values()),
+        final_op=list(metrics_to_values.values()))
 
-    metrics_to_values = dict(zip(metrics_to_values.keys(), metric_values))
+    metrics_to_values = dict(zip(list(metrics_to_values.keys()), metric_values))
     for metric in metrics_to_values:
       value = metrics_to_values[metric]
       if np.isscalar(value):

--- a/magenta/models/onsets_frames_transcription/train_util.py
+++ b/magenta/models/onsets_frames_transcription/train_util.py
@@ -24,6 +24,7 @@ from .infer_util import sequence_to_valued_intervals
 
 from mir_eval.transcription import precision_recall_f1_overlap
 
+import numpy as np
 import pretty_midi
 import tensorflow as tf
 import tensorflow.contrib.slim as slim
@@ -173,6 +174,7 @@ def test(checkpoint_path, test_dir, examples_path, hparams,
         losses, labels, predictions, images, hparams)
 
     metric_values = slim.evaluation.evaluate_once(
+        master='',
         checkpoint_path=checkpoint_path,
         logdir=test_dir,
         num_evals=num_batches or transcription_data.num_batches,
@@ -181,7 +183,9 @@ def test(checkpoint_path, test_dir, examples_path, hparams,
 
     metrics_to_values = dict(zip(metrics_to_values.keys(), metric_values))
     for metric in metrics_to_values:
-      print('%s: %f' % (metric, metrics_to_values[metric]))
+      value = metrics_to_values[metric]
+      if np.isscalar(value):
+        print('%s: %f' % (metric, value))
 
 
 def _note_metrics_op(labels, predictions, hparams, offset_ratio=None):


### PR DESCRIPTION
Hi again! I was running the code for onsets and frames testing and ran into a couple bugs.

First, the call to `evaluate_once` was missing the `master` argument (see this [link](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/slim/python/slim/evaluation.py)). It's a little confusing because the comments for `evaluate_once` in this file differ from the actual implementation.

Second, when printing out the metrics I found that not all of the metrics were scalars, and this caused errors while printing them out. I added a check to resolve this.

Lastly, just wanted to mention that are a few more python 3 compatibility issues. They mainly have to do with the fact that calls to values() and keys() on `dict`s don't return lists (ex. lines 181, 182, 184). Adding `list` wrappers to these calls resolved the compatibility issues for me.