### PR TITLE
Disallow upgrade to python-rtmidi 1.2 since it breaks Travis.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ REQUIRED_PACKAGES = [
     'pandas >= 0.18.1',
     'pretty_midi >= 0.2.6',
     'protobuf',
-    'python-rtmidi',
+    'python-rtmidi >= 1.1, < 1.2',  # 1.2 breaks us
     'scipy >= 0.18.1',
     'sk-video',
     'sonnet',


### PR DESCRIPTION
Error message:
```
Searching for python-rtmidi
Reading https://pypi.org/simple/python-rtmidi/
Downloading https://files.pythonhosted.org/packages/13/14/007a87de6b097fe0c46535d5f83f960baa16da5d33ea0020d5e9f0b6aa89/python-rtmidi-1.2.0.tar.gz#sha256=8e7a50fff1b0bab16b71e19af17dfc91aad580d46ceb0bf36307555413a44d06
Best match: python-rtmidi 1.2.0
Processing python-rtmidi-1.2.0.tar.gz
Writing /tmp/easy_install-zurz61ys/python-rtmidi-1.2.0/setup.cfg
Running python-rtmidi-1.2.0/setup.py -q bdist_egg --dist-dir /tmp/easy_install-zurz61ys/python-rtmidi-1.2.0/egg-dist-tmp-mxm7vovm
warning: no previously-included files found matching '.appveyor.yml'
warning: no previously-included files found matching '.travis.yml'
warning: no previously-included files found matching '*.rst.in'
warning: no previously-included files found matching 'deploy.sh'
warning: no previously-included files found matching '*.sh'
warning: no previously-included files matching '__pycache__' found under directory '*'
warning: no previously-included files matching '*.py[co]' found under directory '*'
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++ [enabled by default]
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++ [enabled by default]
src/rtmidi/RtMidi.cpp: In member function ‘virtual void MidiInJack::setPortName(const string&)’:
src/rtmidi/RtMidi.cpp:3152:64: error: ‘jack_port_rename’ was not declared in this scope
   jack_port_rename( data->client, data->port, portName.c_str() );
                                                                ^
src/rtmidi/RtMidi.cpp: In member function ‘virtual void MidiOutJack::setPortName(const string&)’:
src/rtmidi/RtMidi.cpp:3376:64: error: ‘jack_port_rename’ was not declared in this scope
   jack_port_rename( data->client, data->port, portName.c_str() );
                                                                ^
error: Setup script exited with error: command 'gcc' failed with exit status 1
```