### PR TITLE
require pylint < 2.0 for py2 envs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ REQUIRED_PACKAGES = [
     'pretty_midi >= 0.2.6',
     'protobuf',
     'pygtrie >= 2.3',
+    'pylint < 2.0.0;python_version=="2.7"',
     'python-rtmidi >= 1.1, < 1.2',  # 1.2 breaks us
     'scipy >= 0.18.1',
     'sk-video',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ REQUIRED_PACKAGES = [
     'pretty_midi >= 0.2.6',
     'protobuf',
     'pygtrie >= 2.3',
-    'pylint < 2.0.0;python_version=="2.7"',
     'python-rtmidi >= 1.1, < 1.2',  # 1.2 breaks us
     'scipy >= 0.18.1',
     'sk-video',
@@ -151,5 +150,5 @@ setup(
         'magenta': ['models/image_stylization/evaluation_images/*.jpg'],
     },
     setup_requires=['pytest-runner', 'pytest-pylint'],
-    tests_require=['pytest', 'pylint'],
+    tests_require=['pytest', 'pylint < 2.0.0;python_version=="2.7"'],
 )

--- a/setup.py
+++ b/setup.py
@@ -150,5 +150,9 @@ setup(
         'magenta': ['models/image_stylization/evaluation_images/*.jpg'],
     },
     setup_requires=['pytest-runner', 'pytest-pylint'],
-    tests_require=['pytest', 'pylint < 2.0.0;python_version=="2.7"'],
+    tests_require=[
+        'pytest',
+        'pylint < 2.0.0;python_version<"3"',
+        'pylint >= 2.0.0;python_version>="3"',
+    ],
 )


### PR DESCRIPTION
## Description
pylint >= 2.x breaks when `setup.py test` runs against a py2 environment

## Solution
force `setup.py` to use pylint < 2.0 for py2 envs 

Closes issue [#1420](https://github.com/tensorflow/magenta/issues/1420)