### PR TITLE
Use six for Py2 and Py3 compatible urlretrieve and BytesIO (Continues PR #1345)

### DIFF
--- a/magenta/models/sketch_rnn/sketch_rnn_train.py
+++ b/magenta/models/sketch_rnn/sketch_rnn_train.py
@@ -21,7 +21,6 @@ from __future__ import print_function
 import json
 import os
 import time
-import urllib
 import zipfile
 
 from magenta.models.sketch_rnn import model as sketch_rnn_model
@@ -29,7 +28,7 @@ from magenta.models.sketch_rnn import utils
 import numpy as np
 import requests
 import six
-from six.moves import cStringIO as StringIO
+from six.moves.urllib.request import urlretrieve
 import tensorflow as tf
 
 tf.logging.set_verbosity(tf.logging.INFO)
@@ -103,7 +102,7 @@ def download_pretrained_models(
   else:
     tf.logging.info('Downloading pretrained models from %s...',
                     pretrained_models_url)
-    urllib.urlretrieve(pretrained_models_url, zip_path)
+    urlretrieve(pretrained_models_url, zip_path)
     tf.logging.info('Download complete.')
   tf.logging.info('Unzipping %s...', zip_path)
   with zipfile.ZipFile(zip_path) as models_zip:
@@ -131,7 +130,7 @@ def load_dataset(data_dir, model_params, inference_mode=False):
     if data_dir.startswith('http://') or data_dir.startswith('https://'):
       tf.logging.info('Downloading %s', data_filepath)
       response = requests.get(data_filepath)
-      data = np.load(StringIO(response.content))
+      data = np.load(six.BytesIO(response.content), encoding='latin')
     else:
       if six.PY3:
         data = np.load(data_filepath, encoding='latin1')


### PR DESCRIPTION
Just finishing up the desired changes for #1345 which should make sketch_rnn_train.py work for both Python 2 and 3.