### PR TITLE
sketch_rnn_train backslash problem when passing url to data_dir on Windows

### DIFF
--- a/magenta/models/sketch_rnn/sketch_rnn_train.py
+++ b/magenta/models/sketch_rnn/sketch_rnn_train.py
@@ -126,12 +126,13 @@ def load_dataset(data_dir, model_params, inference_mode=False):
   test_strokes = None
 
   for dataset in datasets:
-    data_filepath = os.path.join(data_dir, dataset)
     if data_dir.startswith('http://') or data_dir.startswith('https://'):
+      data_filepath = '/'.join([data_dir, dataset])
       tf.logging.info('Downloading %s', data_filepath)
       response = requests.get(data_filepath)
       data = np.load(six.BytesIO(response.content), encoding='latin')
     else:
+      data_filepath = os.path.join(data_dir, dataset)
       if six.PY3:
         data = np.load(data_filepath, encoding='latin1')
       else:


### PR DESCRIPTION
I get a `_pickle.UnpicklingError: invalid load key, '<'.` when running `sketch_rnn_train` with default params on Windows, Py 3.

It seems the issue is that the [line that constructs the url](https://github.com/tensorflow/magenta/blob/983b66d0d860de954718c39290b9e2f0fb872414/magenta/models/sketch_rnn/sketch_rnn_train.py#L129)
```
data_filepath = os.path.join(data_dir, dataset)
```
uses os.path.join, which results in a backslash before the dataset name on Windows, like so
```
https://github.com/hardmaru/sketch-rnn-datasets/raw/master/aaron_sheep\aaron_sheep.npz
```
So when the next line runs `request.get(data_filepath)`, the `response.content` is not the `aaron_sheep.npz` data, but instead the [github 404 page](https://github.com/404).