### PR TITLE
Set decoder S_0 more concisely when padding batch in sketch_rnn DataLoader

### DIFF
--- a/magenta/models/sketch_rnn/utils.py
+++ b/magenta/models/sketch_rnn/utils.py
@@ -327,8 +327,5 @@ class DataLoader(object):
       result[i, l:, 4] = 1
       # put in the first token, as described in sketch-rnn methodology
       result[i, 1:, :] = result[i, :-1, :]
-      result[i, 0, :] = 0
-      result[i, 0, 2] = self.start_stroke_token[2]  # setting S_0 from paper.
-      result[i, 0, 3] = self.start_stroke_token[3]
-      result[i, 0, 4] = self.start_stroke_token[4]
+      result[i, 0, :] = self.start_stroke_token[:]  # setting S_0 from paper.
     return result


### PR DESCRIPTION
AFAIU, the starting token S_0 for the decoder RNN in sketch_rnn is always `[0,0,1,0,0]`. 

So I thought it would be more concise to just set the first element of the padded `result` equal to `self.start_stroke_token`, which is already initialized as `[0,0,1,0,0]` in the [DataLoader constructor](https://github.com/tensorflow/magenta/blob/01b59d352dd2928fb94630b751d2c8e893c8701c/magenta/models/sketch_rnn/utils.py#L221).