### PR TITLE
Update performance_model.py

### DIFF
--- a/magenta/models/performance_rnn/performance_model.py
+++ b/magenta/models/performance_rnn/performance_model.py
@@ -215,7 +215,7 @@ default_configs = {
 
     'performance_with_dynamics_compact': PerformanceRnnConfig(
         magenta.protobuf.generator_pb2.GeneratorDetails(
-            id='performance_with_dynamics',
+            id='performance_with_dynamics_compact',
             description='Performance RNN with dynamics (compact input)'),
         magenta.music.OneHotIndexEventSequenceEncoderDecoder(
             magenta.music.PerformanceOneHotEncoding(


### PR DESCRIPTION
In README.md, there's a description "If you are training an unconditioned model with note velocities, we recommend using the performance_with_dynamics_compact config", but doesn't work.