### PR TITLE
Fix bug in download_dataset in sketch_rnn_train

### DIFF
--- a/magenta/models/sketch_rnn/sketch_rnn_train.py
+++ b/magenta/models/sketch_rnn/sketch_rnn_train.py
@@ -130,7 +130,7 @@ def load_dataset(data_dir, model_params, inference_mode=False):
       data_filepath = '/'.join([data_dir, dataset])
       tf.logging.info('Downloading %s', data_filepath)
       response = requests.get(data_filepath)
-      data = np.load(six.BytesIO(response.content), encoding='latin')
+      data = np.load(six.BytesIO(response.content), encoding='latin1')
     else:
       data_filepath = os.path.join(data_dir, dataset)
       if six.PY3:


### PR DESCRIPTION
Use 'latin1' encoding instead of 'latin' because np.load expected 'ASCII', 'latin1', or 'bytes' encoding.

The reason why I'm proposing this fix is that I ran into the following problem when I tried to run `sketch_rnn_train.py` with the default settings:

```
INFO:tensorflow:Downloading https://github.com/hardmaru/sketch-rnn-datasets/raw/master/aaron_sheep/aaron_sheep.npz
Traceback (most recent call last):
  File "sketch_rnn_train.py", line 478, in <module>
    console_entry_point()
  File "sketch_rnn_train.py", line 474, in console_entry_point
    tf.app.run(main)
  File "C:\Users\Iver\Anaconda3\envs\magenta-playground\lib\site-packages\tensorflow\python\platform\app.py", line 125, in run
    _sys.exit(main(argv))
  File "sketch_rnn_train.py", line 470, in main
    trainer(model_params)
  File "sketch_rnn_train.py", line 438, in trainer
    datasets = load_dataset(FLAGS.data_dir, model_params)
  File "sketch_rnn_train.py", line 133, in load_dataset
    data = np.load(six.BytesIO(response.content), encoding='latin')
  File "C:\Users\Iver\Anaconda3\envs\magenta-playground\lib\site-packages\numpy\lib\npyio.py", line 404, in load
    raise ValueError("encoding must be 'ASCII', 'latin1', or 'bytes'")
ValueError: encoding must be 'ASCII', 'latin1', or 'bytes'
```