### PR TITLE
Adds config that produces exact model from paper

### DIFF
--- a/magenta/models/piano_genie/configs.py
+++ b/magenta/models/piano_genie/configs.py
@@ -372,6 +372,19 @@ class StpVqSeqFreeAutoDtVs(BasePianoGenieConfig):
     self.dec_aux_feats = ["delta_times_int", "velocities"]
 
 
+class PianoGeniePaper(BasePianoGenieConfig):
+
+  def __init__(self):
+    super(PianoGeniePaper, self).__init__()
+
+    self.enc_aux_feats = ["delta_times_int"]
+    self.dec_autoregressive = True
+    self.dec_aux_feats = ["delta_times_int"]
+    self.stp_emb_iq = True
+    self.stp_emb_iq_contour_margin = 1.
+    self.stp_emb_iq_deviate_exp = 1
+
+
 _named_configs = {
     "stp_free": StpFree(),
     "stp_vq": StpVq(),
@@ -401,6 +414,7 @@ _named_configs = {
     "stp_vq_seq_free_auto_vs": StpVqSeqFreeAutoVs(),
     "stp_vq_seq_vae_auto_dt_vs": StpVqSeqVaeAutoDtVs(),
     "stp_vq_seq_vae_free_dt_vs": StpVqSeqFreeAutoDtVs(),
+    "piano_genie_paper": PianoGeniePaper(),
 }
 
 

--- a/magenta/models/piano_genie/eval.py
+++ b/magenta/models/piano_genie/eval.py
@@ -36,7 +36,8 @@ flags.DEFINE_string("dataset_fp", "./data/valid*.tfrecord",
                     "Path to dataset containing TFRecords of NoteSequences.")
 flags.DEFINE_string("train_dir", "", "The directory for this experiment.")
 flags.DEFINE_string("eval_dir", "", "The directory for evaluation output.")
-flags.DEFINE_string("model_cfg", "stp_iq_auto", "Hyperparameter configuration.")
+flags.DEFINE_string("model_cfg", "piano_genie_paper",
+                    "Hyperparameter configuration.")
 flags.DEFINE_string("model_cfg_overrides", "",
                     "E.g. rnn_nlayers=4,rnn_nunits=256")
 flags.DEFINE_string("ckpt_fp", None,

--- a/magenta/models/piano_genie/model.py
+++ b/magenta/models/piano_genie/model.py
@@ -19,7 +19,6 @@ from __future__ import division
 from __future__ import print_function
 
 from magenta.models.piano_genie import util
-import sonnet as snt
 import tensorflow as tf
 
 
@@ -195,6 +194,7 @@ def build_genie_model(feat_dict,
 
   # Quantized step embeddings with VQ-VAE
   if cfg.stp_emb_vq:
+    import sonnet as snt
     with tf.variable_scope("stp_emb_vq"):
       with tf.variable_scope("pre_vq"):
         # pre_vq_encoding is tf.float32 of [batch_size, seq_len, embedding_dim]

--- a/magenta/models/piano_genie/train.py
+++ b/magenta/models/piano_genie/train.py
@@ -32,7 +32,8 @@ FLAGS = flags.FLAGS
 flags.DEFINE_string("dataset_fp", "./data/train*.tfrecord",
                     "Path to dataset containing TFRecords of NoteSequences.")
 flags.DEFINE_string("train_dir", "", "The directory for this experiment")
-flags.DEFINE_string("model_cfg", "stp_iq_auto", "Hyperparameter configuration.")
+flags.DEFINE_string("model_cfg", "piano_genie_paper",
+                    "Hyperparameter configuration.")
 flags.DEFINE_string("model_cfg_overrides", "",
                     "E.g. rnn_nlayers=4,rnn_nunits=256")
 flags.DEFINE_integer("summary_every_nsecs", 60,


### PR DESCRIPTION
Small maintenance tasks that I've been meaning to get around to. Adds a config that reproduces exact model from paper. Moves `sonnet` import to only happen if needed, since it has caused some people issues.