### PR TITLE
Lock tensorflow to working 1.13.1 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,9 @@ REQUIRED_PACKAGES = [
 ]
 
 if gpu_mode:
-  REQUIRED_PACKAGES.append('tensorflow-gpu >= 1.12.0')
+  REQUIRED_PACKAGES.append('tensorflow-gpu == 1.13.1')
 else:
-  REQUIRED_PACKAGES.append('tensorflow >= 1.12.0')
+  REQUIRED_PACKAGES.append('tensorflow == 1.13.1')
 
 # pylint:disable=line-too-long
 CONSOLE_SCRIPTS = [


### PR DESCRIPTION
When following the "Development Environment" instructions in a clean environment (tested on Ubuntu 18.04, MacOS, py3 and py2), we were consistently getting 62 failures, mostly with the traceback `AttributeError: module 'tensorflow' has no attribute 'contrib'`. It looks like this module was removed in Tensorflow 2.0, which is currently pulled in by `python setup.py install`. Locking the `tensorflow` and/or `tensorflow-gpu` versions to 1.13.1 fixes the issue.