### PR TITLE
Towards an independent magenta.music

### DIFF
--- a/magenta/common/__init__.py
+++ b/magenta/common/__init__.py
@@ -21,5 +21,4 @@ from .nade import Nade
 from .sequence_example_lib import count_records
 from .sequence_example_lib import flatten_maybe_padded_sequences
 from .sequence_example_lib import get_padded_batch
-from .sequence_example_lib import make_sequence_example
 from .tf_utils import merge_hparams

--- a/magenta/common/sequence_example_lib.py
+++ b/magenta/common/sequence_example_lib.py
@@ -15,39 +15,11 @@
 """Utility functions for working with tf.train.SequenceExamples."""
 
 import math
-import numbers
 
 import tensorflow as tf
 
 QUEUE_CAPACITY = 500
 SHUFFLE_MIN_AFTER_DEQUEUE = QUEUE_CAPACITY // 5
-
-
-def make_sequence_example(inputs, labels):
-  """Returns a SequenceExample for the given inputs and labels.
-
-  Args:
-    inputs: A list of input vectors. Each input vector is a list of floats.
-    labels: A list of ints.
-
-  Returns:
-    A tf.train.SequenceExample containing inputs and labels.
-  """
-  input_features = [
-      tf.train.Feature(float_list=tf.train.FloatList(value=input_))
-      for input_ in inputs]
-  label_features = []
-  for label in labels:
-    if isinstance(label, numbers.Number):
-      label = [label]
-    label_features.append(
-        tf.train.Feature(int64_list=tf.train.Int64List(value=label)))
-  feature_list = {
-      'inputs': tf.train.FeatureList(feature=input_features),
-      'labels': tf.train.FeatureList(feature=label_features)
-  }
-  feature_lists = tf.train.FeatureLists(feature_list=feature_list)
-  return tf.train.SequenceExample(feature_lists=feature_lists)
 
 
 def _shuffle_inputs(input_tensors, capacity, min_after_dequeue, num_threads):

--- a/magenta/models/drums_rnn/drums_rnn_pipeline.py
+++ b/magenta/models/drums_rnn/drums_rnn_pipeline.py
@@ -15,7 +15,7 @@
 """Pipeline to create DrumsRNN dataset."""
 
 import magenta
-from magenta.music import encoder_decoder
+from magenta.pipelines import event_sequence_pipeline
 from magenta.pipelines import dag_pipeline
 from magenta.pipelines import drum_pipelines
 from magenta.pipelines import note_sequence_pipelines
@@ -46,7 +46,7 @@ def get_pipeline(config, eval_ratio):
         steps_per_quarter=config.steps_per_quarter, name='Quantizer_' + mode)
     drums_extractor = drum_pipelines.DrumsExtractor(
         min_bars=7, max_steps=512, gap_bars=1.0, name='DrumsExtractor_' + mode)
-    encoder_pipeline = encoder_decoder.EncoderPipeline(
+    encoder_pipeline = event_sequence_pipeline.EncoderPipeline(
         magenta.music.DrumTrack, config.encoder_decoder,
         name='EncoderPipeline_' + mode)
 

--- a/magenta/models/pianoroll_rnn_nade/pianoroll_rnn_nade_pipeline.py
+++ b/magenta/models/pianoroll_rnn_nade/pianoroll_rnn_nade_pipeline.py
@@ -15,6 +15,7 @@
 """Pipeline to create Pianoroll RNN-NADE dataset."""
 
 import magenta.music as mm
+from magenta.pipelines import event_sequence_pipeline
 from magenta.pipelines import dag_pipeline
 from magenta.pipelines import note_sequence_pipelines
 from magenta.pipelines import pipeline
@@ -73,7 +74,7 @@ def get_pipeline(config, min_steps, max_steps, eval_ratio):
     pianoroll_extractor = PianorollSequenceExtractor(
         min_steps=min_steps, max_steps=max_steps,
         name='PianorollExtractor_' + mode)
-    encoder_pipeline = mm.EncoderPipeline(
+    encoder_pipeline = event_sequence_pipeline.EncoderPipeline(
         mm.PianorollSequence, config.encoder_decoder,
         name='EncoderPipeline_' + mode)
 

--- a/magenta/models/polyphony_rnn/polyphony_rnn_pipeline.py
+++ b/magenta/models/polyphony_rnn/polyphony_rnn_pipeline.py
@@ -15,7 +15,7 @@
 """Pipeline to create PolyphonyRNN dataset."""
 
 from magenta.models.polyphony_rnn import polyphony_lib
-from magenta.music import encoder_decoder
+from magenta.pipelines import event_sequence_pipeline
 from magenta.pipelines import dag_pipeline
 from magenta.pipelines import note_sequence_pipelines
 from magenta.pipelines import pipeline
@@ -76,7 +76,7 @@ def get_pipeline(config, min_steps, max_steps, eval_ratio):
         transposition_range, name='TranspositionPipeline_' + mode)
     poly_extractor = PolyphonicSequenceExtractor(
         min_steps=min_steps, max_steps=max_steps, name='PolyExtractor_' + mode)
-    encoder_pipeline = encoder_decoder.EncoderPipeline(
+    encoder_pipeline = event_sequence_pipeline.EncoderPipeline(
         polyphony_lib.PolyphonicSequence, config.encoder_decoder,
         name='EncoderPipeline_' + mode)
 

--- a/magenta/music/__init__.py
+++ b/magenta/music/__init__.py
@@ -47,7 +47,6 @@ from magenta.music.drums_lib import extract_drum_tracks
 from magenta.music.drums_lib import midi_file_to_drum_track
 
 from magenta.music.encoder_decoder import ConditionalEventSequenceEncoderDecoder
-from magenta.music.encoder_decoder import EncoderPipeline
 from magenta.music.encoder_decoder import EventSequenceEncoderDecoder
 from magenta.music.encoder_decoder import LookbackEventSequenceEncoderDecoder
 from magenta.music.encoder_decoder import MultipleEventSequenceEncoder

--- a/magenta/music/abc_parser_test.py
+++ b/magenta/music/abc_parser_test.py
@@ -21,10 +21,10 @@ from __future__ import print_function
 import copy
 import os.path
 
-from magenta.common import testing_lib as common_testing_lib
 from magenta.music import abc_parser
 from magenta.music import midi_io
 from magenta.music import sequences_lib
+from magenta.music import testing_lib
 from magenta.protobuf import music_pb2
 import six
 import tensorflow as tf
@@ -211,7 +211,7 @@ class AbcParserTest(tf.test.TestCase):
                                abc_parser.VariantEndingError))
     self.assertTrue(isinstance(exceptions[1], abc_parser.PartError))
 
-    expected_metadata1 = common_testing_lib.parse_test_proto(
+    expected_metadata1 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220
@@ -260,7 +260,7 @@ class AbcParserTest(tf.test.TestCase):
           num_times: 2
         }
         """)
-    expected_expanded_metadata1 = common_testing_lib.parse_test_proto(
+    expected_expanded_metadata1 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220
@@ -308,7 +308,7 @@ class AbcParserTest(tf.test.TestCase):
         expected_expanded_metadata1, tunes[1])
 
     # TODO(fjord): re-enable once we support variant endings.
-    # expected_ns2_metadata = common_testing_lib.parse_test_proto(
+    # expected_ns2_metadata = testing_lib.parse_test_proto(
     #     music_pb2.NoteSequence,
     #     """
     #     ticks_per_quarter: 220
@@ -331,7 +331,7 @@ class AbcParserTest(tf.test.TestCase):
     #     'testdata/english2.mid', expected_ns2_metadata, tunes[1])
 
     # TODO(fjord): re-enable once we support parts.
-    # expected_ns3_metadata = common_testing_lib.parse_test_proto(
+    # expected_ns3_metadata = testing_lib.parse_test_proto(
     #     music_pb2.NoteSequence,
     #     """
     #     ticks_per_quarter: 220
@@ -363,7 +363,7 @@ class AbcParserTest(tf.test.TestCase):
     self.assertEqual(1, len(tunes))
     self.assertEqual(0, len(exceptions))
 
-    expected_ns1 = common_testing_lib.parse_test_proto(
+    expected_ns1 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220
@@ -494,7 +494,7 @@ class AbcParserTest(tf.test.TestCase):
     self.assertEqual(3, len(tunes))
     self.assertEqual(0, len(exceptions))
 
-    expected_ns1 = common_testing_lib.parse_test_proto(
+    expected_ns1 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220
@@ -569,7 +569,7 @@ class AbcParserTest(tf.test.TestCase):
     self.assertEqual(1, len(tunes))
     self.assertEqual(0, len(exceptions))
 
-    expected_ns1 = common_testing_lib.parse_test_proto(
+    expected_ns1 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220
@@ -702,7 +702,7 @@ class AbcParserTest(tf.test.TestCase):
     self.assertTrue(isinstance(exceptions[0], abc_parser.RepeatParseError))
     self.assertTrue(isinstance(exceptions[1], abc_parser.RepeatParseError))
     self.assertTrue(isinstance(exceptions[2], abc_parser.RepeatParseError))
-    expected_ns1 = common_testing_lib.parse_test_proto(
+    expected_ns1 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220
@@ -793,7 +793,7 @@ class AbcParserTest(tf.test.TestCase):
     expected_ns6.section_groups[-1].num_times = 2
     self.assertProtoEquals(expected_ns6, tunes[6])
 
-    expected_ns7 = common_testing_lib.parse_test_proto(
+    expected_ns7 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220
@@ -927,7 +927,7 @@ class AbcParserTest(tf.test.TestCase):
         """)
     self.assertEqual(1, len(tunes))
     self.assertEqual(0, len(exceptions))
-    expected_ns1 = common_testing_lib.parse_test_proto(
+    expected_ns1 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220
@@ -1027,7 +1027,7 @@ class AbcParserTest(tf.test.TestCase):
         """)
     self.assertEqual(1, len(tunes))
     self.assertEqual(0, len(exceptions))
-    expected_ns1 = common_testing_lib.parse_test_proto(
+    expected_ns1 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220
@@ -1075,7 +1075,7 @@ class AbcParserTest(tf.test.TestCase):
         """)
     self.assertEqual(1, len(tunes))
     self.assertEqual(0, len(exceptions))
-    expected_ns1 = common_testing_lib.parse_test_proto(
+    expected_ns1 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220

--- a/magenta/music/chords_lib_test.py
+++ b/magenta/music/chords_lib_test.py
@@ -20,7 +20,6 @@ from __future__ import print_function
 
 import copy
 
-from magenta.common import testing_lib as common_testing_lib
 from magenta.music import chord_symbols_lib
 from magenta.music import chords_lib
 from magenta.music import constants
@@ -37,7 +36,7 @@ class ChordsLibTest(tf.test.TestCase):
 
   def setUp(self):
     self.steps_per_quarter = 1
-    self.note_sequence = common_testing_lib.parse_test_proto(
+    self.note_sequence = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {

--- a/magenta/music/drums_lib_test.py
+++ b/magenta/music/drums_lib_test.py
@@ -14,7 +14,6 @@
 
 """Tests for drums_lib."""
 
-from magenta.common import testing_lib as common_testing_lib
 from magenta.music import drums_lib
 from magenta.music import sequences_lib
 from magenta.music import testing_lib
@@ -29,7 +28,7 @@ class DrumsLibTest(tf.test.TestCase):
 
   def setUp(self):
     self.steps_per_quarter = 4
-    self.note_sequence = common_testing_lib.parse_test_proto(
+    self.note_sequence = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {

--- a/magenta/music/encoder_decoder.py
+++ b/magenta/music/encoder_decoder.py
@@ -52,7 +52,6 @@ import abc
 import numbers
 
 from magenta.music import constants
-from magenta.pipelines import pipeline
 import numpy as np
 from six.moves import range  # pylint: disable=redefined-builtin
 import tensorflow as tf
@@ -1009,28 +1008,6 @@ class MultipleEventSequenceEncoder(EventSequenceEncoderDecoder):
 
   def class_index_to_event(self, class_index, events):
     raise NotImplementedError
-
-
-class EncoderPipeline(pipeline.Pipeline):
-  """A pipeline that converts an EventSequence to a model encoding."""
-
-  def __init__(self, input_type, encoder_decoder, name=None):
-    """Constructs an EncoderPipeline.
-
-    Args:
-      input_type: The type this pipeline expects as input.
-      encoder_decoder: An EventSequenceEncoderDecoder.
-      name: A unique pipeline name.
-    """
-    super(EncoderPipeline, self).__init__(
-        input_type=input_type,
-        output_type=tf.train.SequenceExample,
-        name=name)
-    self._encoder_decoder = encoder_decoder
-
-  def transform(self, seq):
-    encoded = self._encoder_decoder.encode(seq)
-    return [encoded]
 
 
 def make_sequence_example(inputs, labels):

--- a/magenta/music/encoder_decoder_test.py
+++ b/magenta/music/encoder_decoder_test.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from magenta.common import sequence_example_lib
 from magenta.music import encoder_decoder
 from magenta.music import testing_lib
 import numpy as np
@@ -71,7 +70,7 @@ class OneHotEventSequenceEncoderDecoderTest(tf.test.TestCase):
                        [1.0, 0.0, 0.0],
                        [0.0, 0.0, 1.0]]
     expected_labels = [1, 0, 2, 0]
-    expected_sequence_example = sequence_example_lib.make_sequence_example(
+    expected_sequence_example = encoder_decoder.make_sequence_example(
         expected_inputs, expected_labels)
     self.assertEqual(sequence_example, expected_sequence_example)
 
@@ -142,7 +141,7 @@ class OneHotIndexEventSequenceEncoderDecoderTest(tf.test.TestCase):
     sequence_example = self.enc.encode(events)
     expected_inputs = [[0], [1], [0], [2]]
     expected_labels = [1, 0, 2, 0]
-    expected_sequence_example = sequence_example_lib.make_sequence_example(
+    expected_sequence_example = encoder_decoder.make_sequence_example(
         expected_inputs, expected_labels)
     self.assertEqual(sequence_example, expected_sequence_example)
 
@@ -330,7 +329,7 @@ class ConditionalEventSequenceEncoderDecoderTest(tf.test.TestCase):
                        [1.0, 0.0, 1.0, 0.0, 0.0],
                        [1.0, 0.0, 0.0, 0.0, 1.0]]
     expected_labels = [1, 0, 2, 0]
-    expected_sequence_example = sequence_example_lib.make_sequence_example(
+    expected_sequence_example = encoder_decoder.make_sequence_example(
         expected_inputs, expected_labels)
     self.assertEqual(sequence_example, expected_sequence_example)
 

--- a/magenta/music/lead_sheets_lib_test.py
+++ b/magenta/music/lead_sheets_lib_test.py
@@ -16,7 +16,6 @@
 
 import copy
 
-from magenta.common import testing_lib as common_testing_lib
 from magenta.music import chords_lib
 from magenta.music import constants
 from magenta.music import lead_sheets_lib
@@ -35,7 +34,7 @@ class LeadSheetsLibTest(tf.test.TestCase):
 
   def setUp(self):
     self.steps_per_quarter = 4
-    self.note_sequence = common_testing_lib.parse_test_proto(
+    self.note_sequence = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {

--- a/magenta/music/melodies_lib_test.py
+++ b/magenta/music/melodies_lib_test.py
@@ -16,7 +16,6 @@
 
 import os
 
-from magenta.common import testing_lib as common_testing_lib
 from magenta.music import constants
 from magenta.music import melodies_lib
 from magenta.music import sequences_lib
@@ -32,7 +31,7 @@ class MelodiesLibTest(tf.test.TestCase):
 
   def setUp(self):
     self.steps_per_quarter = 4
-    self.note_sequence = common_testing_lib.parse_test_proto(
+    self.note_sequence = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {

--- a/magenta/music/melody_encoder_decoder_test.py
+++ b/magenta/music/melody_encoder_decoder_test.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from magenta.common import sequence_example_lib
 from magenta.music import constants
 from magenta.music import encoder_decoder
 from magenta.music import melodies_lib
@@ -108,7 +107,7 @@ class MelodyOneHotEventSequenceEncoderDecoderTest(tf.test.TestCase):
         [0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
         [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]
     expected_labels = [2, 9, 13, 0, 13, 2, 1, 0]
-    expected_sequence_example = sequence_example_lib.make_sequence_example(
+    expected_sequence_example = encoder_decoder.make_sequence_example(
         expected_inputs, expected_labels)
     self.assertEqual(sequence_example, expected_sequence_example)
 

--- a/magenta/music/musicxml_parser_test.py
+++ b/magenta/music/musicxml_parser_test.py
@@ -24,9 +24,9 @@ import os.path
 import tempfile
 import zipfile
 
-from magenta.common import testing_lib as common_testing_lib
 from magenta.music import musicxml_parser
 from magenta.music import musicxml_reader
+from magenta.music import testing_lib
 from magenta.protobuf import music_pb2
 import tensorflow as tf
 
@@ -245,7 +245,7 @@ class MusicXMLParserTest(tf.test.TestCase):
       part_name: name of the part the sequence is expected to contain.
     """
 
-    expected_ns = common_testing_lib.parse_test_proto(
+    expected_ns = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220
@@ -363,7 +363,7 @@ class MusicXMLParserTest(tf.test.TestCase):
     """Verify properties of the flute scale."""
     ns = musicxml_reader.musicxml_file_to_sequence_proto(
         self.flute_scale_filename)
-    expected_ns = common_testing_lib.parse_test_proto(
+    expected_ns = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220
@@ -414,7 +414,7 @@ class MusicXMLParserTest(tf.test.TestCase):
     """
     ns = musicxml_reader.musicxml_file_to_sequence_proto(
         self.atonal_transposition_filename)
-    expected_ns = common_testing_lib.parse_test_proto(
+    expected_ns = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220
@@ -477,7 +477,7 @@ class MusicXMLParserTest(tf.test.TestCase):
     """
     ns = musicxml_reader.musicxml_file_to_sequence_proto(
         self.unmetered_filename)
-    expected_ns = common_testing_lib.parse_test_proto(
+    expected_ns = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220
@@ -554,7 +554,7 @@ class MusicXMLParserTest(tf.test.TestCase):
     """
     ns = musicxml_reader.musicxml_file_to_sequence_proto(
         self.st_anne_filename)
-    expected_ns = common_testing_lib.parse_test_proto(
+    expected_ns = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220
@@ -825,7 +825,7 @@ class MusicXMLParserTest(tf.test.TestCase):
       ns = musicxml_reader.musicxml_file_to_sequence_proto(
           temp_file.name)
 
-    expected_ns = common_testing_lib.parse_test_proto(
+    expected_ns = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220
@@ -866,7 +866,7 @@ class MusicXMLParserTest(tf.test.TestCase):
       ns = musicxml_reader.musicxml_file_to_sequence_proto(
           temp_file.name)
 
-    expected_ns = common_testing_lib.parse_test_proto(
+    expected_ns = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220
@@ -905,7 +905,7 @@ class MusicXMLParserTest(tf.test.TestCase):
       ns = musicxml_reader.musicxml_file_to_sequence_proto(
           temp_file.name)
 
-    expected_ns = common_testing_lib.parse_test_proto(
+    expected_ns = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220
@@ -991,7 +991,7 @@ class MusicXMLParserTest(tf.test.TestCase):
     """
     ns = musicxml_reader.musicxml_file_to_sequence_proto(
         self.whole_measure_rest_forward_filename)
-    expected_ns = common_testing_lib.parse_test_proto(
+    expected_ns = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220
@@ -1066,7 +1066,7 @@ class MusicXMLParserTest(tf.test.TestCase):
     """
     ns = musicxml_reader.musicxml_file_to_sequence_proto(
         self.meter_test_filename)
-    expected_ns = common_testing_lib.parse_test_proto(
+    expected_ns = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         ticks_per_quarter: 220

--- a/magenta/music/pianoroll_lib_test.py
+++ b/magenta/music/pianoroll_lib_test.py
@@ -16,7 +16,6 @@
 
 import copy
 
-from magenta.common import testing_lib as common_testing_lib
 from magenta.music import pianoroll_lib
 from magenta.music import sequences_lib
 from magenta.music import testing_lib
@@ -29,7 +28,7 @@ class PianorollLibTest(tf.test.TestCase):
   def setUp(self):
     self.maxDiff = None  # pylint:disable=invalid-name
 
-    self.note_sequence = common_testing_lib.parse_test_proto(
+    self.note_sequence = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         tempos: {

--- a/magenta/music/sequences_lib_test.py
+++ b/magenta/music/sequences_lib_test.py
@@ -16,7 +16,6 @@
 
 import copy
 
-from magenta.common import testing_lib as common_testing_lib
 from magenta.music import constants
 from magenta.music import sequences_lib
 from magenta.music import testing_lib
@@ -35,7 +34,7 @@ class SequencesLibTest(tf.test.TestCase):
     self.maxDiff = None  # pylint:disable=invalid-name
 
     self.steps_per_quarter = 4
-    self.note_sequence = common_testing_lib.parse_test_proto(
+    self.note_sequence = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -317,7 +316,7 @@ class SequencesLibTest(tf.test.TestCase):
 
   def testSplitNoteSequenceWithHopSize(self):
     # Tests splitting a NoteSequence at regular hop size, truncating notes.
-    sequence = common_testing_lib.parse_test_proto(
+    sequence = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -332,7 +331,7 @@ class SequencesLibTest(tf.test.TestCase):
     testing_lib.add_chords_to_sequence(
         sequence, [('C', 1.0), ('G7', 2.0), ('F', 4.0)])
 
-    expected_subsequence_1 = common_testing_lib.parse_test_proto(
+    expected_subsequence_1 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -348,7 +347,7 @@ class SequencesLibTest(tf.test.TestCase):
     expected_subsequence_1.total_time = 3.0
     expected_subsequence_1.subsequence_info.end_time_offset = 5.0
 
-    expected_subsequence_2 = common_testing_lib.parse_test_proto(
+    expected_subsequence_2 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -365,7 +364,7 @@ class SequencesLibTest(tf.test.TestCase):
     expected_subsequence_2.subsequence_info.start_time_offset = 3.0
     expected_subsequence_2.subsequence_info.end_time_offset = 3.0
 
-    expected_subsequence_3 = common_testing_lib.parse_test_proto(
+    expected_subsequence_3 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -388,7 +387,7 @@ class SequencesLibTest(tf.test.TestCase):
 
   def testSplitNoteSequenceAtTimes(self):
     # Tests splitting a NoteSequence at specified times, truncating notes.
-    sequence = common_testing_lib.parse_test_proto(
+    sequence = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -403,7 +402,7 @@ class SequencesLibTest(tf.test.TestCase):
     testing_lib.add_chords_to_sequence(
         sequence, [('C', 1.0), ('G7', 2.0), ('F', 4.0)])
 
-    expected_subsequence_1 = common_testing_lib.parse_test_proto(
+    expected_subsequence_1 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -419,7 +418,7 @@ class SequencesLibTest(tf.test.TestCase):
     expected_subsequence_1.total_time = 3.0
     expected_subsequence_1.subsequence_info.end_time_offset = 5.0
 
-    expected_subsequence_2 = common_testing_lib.parse_test_proto(
+    expected_subsequence_2 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -433,7 +432,7 @@ class SequencesLibTest(tf.test.TestCase):
     expected_subsequence_2.subsequence_info.start_time_offset = 3.0
     expected_subsequence_2.subsequence_info.end_time_offset = 5.0
 
-    expected_subsequence_3 = common_testing_lib.parse_test_proto(
+    expected_subsequence_3 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -460,7 +459,7 @@ class SequencesLibTest(tf.test.TestCase):
   def testSplitNoteSequenceSkipSplitsInsideNotes(self):
     # Tests splitting a NoteSequence at regular hop size, skipping splits that
     # would have occurred inside a note.
-    sequence = common_testing_lib.parse_test_proto(
+    sequence = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -475,7 +474,7 @@ class SequencesLibTest(tf.test.TestCase):
     testing_lib.add_chords_to_sequence(
         sequence, [('C', 0.0), ('G7', 3.0), ('F', 4.5)])
 
-    expected_subsequence_1 = common_testing_lib.parse_test_proto(
+    expected_subsequence_1 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -491,7 +490,7 @@ class SequencesLibTest(tf.test.TestCase):
     expected_subsequence_1.total_time = 3.50
     expected_subsequence_1.subsequence_info.end_time_offset = 1.5
 
-    expected_subsequence_2 = common_testing_lib.parse_test_proto(
+    expected_subsequence_2 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -536,7 +535,7 @@ class SequencesLibTest(tf.test.TestCase):
   def testSplitNoteSequenceDuplicateTimeChanges(self):
     # Tests splitting a NoteSequence on time changes for a NoteSequence that has
     # duplicate time changes.
-    sequence = common_testing_lib.parse_test_proto(
+    sequence = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -567,7 +566,7 @@ class SequencesLibTest(tf.test.TestCase):
   def testSplitNoteSequenceCoincidentTimeChanges(self):
     # Tests splitting a NoteSequence on time changes for a NoteSequence that has
     # two time changes occurring simultaneously.
-    sequence = common_testing_lib.parse_test_proto(
+    sequence = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -589,7 +588,7 @@ class SequencesLibTest(tf.test.TestCase):
     testing_lib.add_chords_to_sequence(
         sequence, [('C', 1.5), ('G7', 3.0), ('F', 4.8)])
 
-    expected_subsequence_1 = common_testing_lib.parse_test_proto(
+    expected_subsequence_1 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -605,7 +604,7 @@ class SequencesLibTest(tf.test.TestCase):
     expected_subsequence_1.total_time = 2.0
     expected_subsequence_1.subsequence_info.end_time_offset = 8.0
 
-    expected_subsequence_2 = common_testing_lib.parse_test_proto(
+    expected_subsequence_2 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -630,7 +629,7 @@ class SequencesLibTest(tf.test.TestCase):
   def testSplitNoteSequenceMultipleTimeChangesSkipSplitsInsideNotes(self):
     # Tests splitting a NoteSequence on time changes skipping splits that occur
     # inside notes.
-    sequence = common_testing_lib.parse_test_proto(
+    sequence = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -652,7 +651,7 @@ class SequencesLibTest(tf.test.TestCase):
     testing_lib.add_chords_to_sequence(
         sequence, [('C', 1.5), ('G7', 3.0), ('F', 4.8)])
 
-    expected_subsequence_1 = common_testing_lib.parse_test_proto(
+    expected_subsequence_1 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -673,7 +672,7 @@ class SequencesLibTest(tf.test.TestCase):
     expected_subsequence_1.total_time = 4.01
     expected_subsequence_1.subsequence_info.end_time_offset = 0.99
 
-    expected_subsequence_2 = common_testing_lib.parse_test_proto(
+    expected_subsequence_2 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -697,7 +696,7 @@ class SequencesLibTest(tf.test.TestCase):
   def testSplitNoteSequenceMultipleTimeChanges(self):
     # Tests splitting a NoteSequence on time changes, truncating notes on splits
     # that occur inside notes.
-    sequence = common_testing_lib.parse_test_proto(
+    sequence = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -719,7 +718,7 @@ class SequencesLibTest(tf.test.TestCase):
     testing_lib.add_chords_to_sequence(
         sequence, [('C', 1.5), ('G7', 3.0), ('F', 4.8)])
 
-    expected_subsequence_1 = common_testing_lib.parse_test_proto(
+    expected_subsequence_1 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -735,7 +734,7 @@ class SequencesLibTest(tf.test.TestCase):
     expected_subsequence_1.total_time = 2.0
     expected_subsequence_1.subsequence_info.end_time_offset = 8.0
 
-    expected_subsequence_2 = common_testing_lib.parse_test_proto(
+    expected_subsequence_2 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -752,7 +751,7 @@ class SequencesLibTest(tf.test.TestCase):
     expected_subsequence_2.subsequence_info.start_time_offset = 2.0
     expected_subsequence_2.subsequence_info.end_time_offset = 5.99
 
-    expected_subsequence_3 = common_testing_lib.parse_test_proto(
+    expected_subsequence_3 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -777,7 +776,7 @@ class SequencesLibTest(tf.test.TestCase):
 
   def testSplitNoteSequenceWithStatelessEvents(self):
     # Tests splitting a NoteSequence at specified times with stateless events.
-    sequence = common_testing_lib.parse_test_proto(
+    sequence = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -791,7 +790,7 @@ class SequencesLibTest(tf.test.TestCase):
          (55, 120, 4.0, 4.01), (52, 99, 4.75, 5.0)])
     testing_lib.add_beats_to_sequence(sequence, [1.0, 2.0, 4.0])
 
-    expected_subsequence_1 = common_testing_lib.parse_test_proto(
+    expected_subsequence_1 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -806,7 +805,7 @@ class SequencesLibTest(tf.test.TestCase):
     expected_subsequence_1.total_time = 3.0
     expected_subsequence_1.subsequence_info.end_time_offset = 5.0
 
-    expected_subsequence_2 = common_testing_lib.parse_test_proto(
+    expected_subsequence_2 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {
@@ -818,7 +817,7 @@ class SequencesLibTest(tf.test.TestCase):
     expected_subsequence_2.subsequence_info.start_time_offset = 3.0
     expected_subsequence_2.subsequence_info.end_time_offset = 5.0
 
-    expected_subsequence_3 = common_testing_lib.parse_test_proto(
+    expected_subsequence_3 = testing_lib.parse_test_proto(
         music_pb2.NoteSequence,
         """
         time_signatures: {

--- a/magenta/music/testing_lib.py
+++ b/magenta/music/testing_lib.py
@@ -14,6 +14,8 @@
 
 """Testing support code."""
 
+from google.protobuf import text_format
+
 from magenta.music import encoder_decoder
 from magenta.protobuf import music_pb2
 
@@ -127,3 +129,9 @@ class TrivialOneHotEncoding(encoder_decoder.OneHotEncoding):
       return self._num_steps[event]
     else:
       return 1
+
+
+def parse_test_proto(proto_type, proto_string):
+  instance = proto_type()
+  text_format.Merge(proto_string, instance)
+  return instance

--- a/magenta/pipelines/README.md
+++ b/magenta/pipelines/README.md
@@ -9,7 +9,7 @@ Files:
 * [dag_pipeline.py](/magenta/pipelines/dag_pipeline.py) defines a `Pipeline` subclass `DAGPipeline` which connects arbitrary pipelines together inside it. These `Pipelines` can be connected into any directed acyclic graph (DAG).
 * [statistics.py](/magenta/pipelines/statistics.py) defines the `Statistic` abstract class and implementations. Statistics are useful for reporting about data processing.
 * [note_sequence_pipelines.py](/magenta/pipelines/note_sequence_pipelines.py) contains pipelines that operate on NoteSequences.
-* [chord_pipelines.py](/magenta/pipelines/chord_pipelines.py), [drum_pipelines.py](/magenta/pipelines/drum_pipelines.py), [melody_pipelines.py](/magenta/pipelines/melody_pipelines.py), and [lead_sheet_pipelines.py](/magenta/pipelines/lead_sheet_pipelines.py) define extractor pipelines for different types of musical event sequences.
+* [event_sequence_pipeline.py](/magenta/pipelines/event_sequence_pipeline.py), [chord_pipelines.py](/magenta/pipelines/chord_pipelines.py), [drum_pipelines.py](/magenta/pipelines/drum_pipelines.py), [melody_pipelines.py](/magenta/pipelines/melody_pipelines.py), and [lead_sheet_pipelines.py](/magenta/pipelines/lead_sheet_pipelines.py) define extractor pipelines for different types of musical event sequences.
 
 ## Pipeline
 

--- a/magenta/pipelines/event_sequence_pipeline.py
+++ b/magenta/pipelines/event_sequence_pipeline.py
@@ -1,0 +1,24 @@
+from magenta.pipelines import pipeline
+import tensorflow as tf
+
+
+class EncoderPipeline(pipeline.Pipeline):
+  """A pipeline that converts an EventSequence to a model encoding."""
+
+  def __init__(self, input_type, encoder_decoder, name=None):
+    """Constructs an EncoderPipeline.
+
+    Args:
+      input_type: The type this pipeline expects as input.
+      encoder_decoder: An EventSequenceEncoderDecoder.
+      name: A unique pipeline name.
+    """
+    super(EncoderPipeline, self).__init__(
+        input_type=input_type,
+        output_type=tf.train.SequenceExample,
+        name=name)
+    self._encoder_decoder = encoder_decoder
+
+  def transform(self, seq):
+    encoded = self._encoder_decoder.encode(seq)
+    return [encoded]


### PR DESCRIPTION
Untangling some dependencies to clear the way for factoring out `magenta.music` as a separate package (#1360):

* Moving `music.encoder_decoder.EncoderPipeline` to `pipelines.event_sequence_pipeline` (maybe it could be renamed to `GenericEncoderPipeline` or something and moved to `pipelines_common` instead)
* Moving `make_sequence_example` from `common.sequence_example_lib` to `music.encoder_decoder`
* Copying `parse_test_proto` from `common.testing_lib` to `music.testing_lib`