### PR TITLE
Fix issue #1527

### DIFF
--- a/magenta/interfaces/midi/midi_hub.py
+++ b/magenta/interfaces/midi/midi_hub.py
@@ -901,32 +901,30 @@ class MidiHub(object):
 
     # Open MIDI ports.
 
+    inports = []
     if input_midi_ports:
       for port in input_midi_ports:
-        if isinstance(port, mido.ports.BaseInput):
-          inport = port
-        else:
-          virtual = port not in get_available_input_ports()
-          if virtual:
-            tf.logging.info(
+        virtual = port not in get_available_input_ports()
+        if virtual:
+          tf.logging.info(
                 "Opening '%s' as a virtual MIDI port for input.", port)
-          inport = mido.open_input(port, virtual=virtual)
+        inport = mido.open_input(port, virtual=virtual)
         # Start processing incoming messages.
         inport.callback = self._timestamp_and_handle_message
+        inports.append(inport)
+      # Keep references to input ports to prevent deletion.
+      self._inports = inports
     else:
       tf.logging.warn('No input port specified. Capture disabled.')
-      self._inport = None
+      self._inports = None
 
     outports = []
     for port in output_midi_ports:
-      if isinstance(port, mido.ports.BaseInput):
-        outports.append(port)
-      else:
-        virtual = port not in get_available_output_ports()
-        if virtual:
-          tf.logging.info(
+      virtual = port not in get_available_output_ports()
+      if virtual:
+        tf.logging.info(
               "Opening '%s' as a virtual MIDI port for output.", port)
-        outports.append(mido.open_output(port, virtual=virtual))
+      outports.append(mido.open_output(port, virtual=virtual))
     self._outport = mido.ports.MultiPort(outports)
 
   def __del__(self):

--- a/magenta/interfaces/midi/midi_hub.py
+++ b/magenta/interfaces/midi/midi_hub.py
@@ -907,7 +907,7 @@ class MidiHub(object):
         virtual = port not in get_available_input_ports()
         if virtual:
           tf.logging.info(
-                "Opening '%s' as a virtual MIDI port for input.", port)
+              "Opening '%s' as a virtual MIDI port for input.", port)
         inport = mido.open_input(port, virtual=virtual)
         # Start processing incoming messages.
         inport.callback = self._timestamp_and_handle_message
@@ -923,7 +923,7 @@ class MidiHub(object):
       virtual = port not in get_available_output_ports()
       if virtual:
         tf.logging.info(
-              "Opening '%s' as a virtual MIDI port for output.", port)
+            "Opening '%s' as a virtual MIDI port for output.", port)
       outports.append(mido.open_output(port, virtual=virtual))
     self._outport = mido.ports.MultiPort(outports)
 

--- a/magenta/interfaces/midi/midi_hub.py
+++ b/magenta/interfaces/midi/midi_hub.py
@@ -904,11 +904,14 @@ class MidiHub(object):
     inports = []
     if input_midi_ports:
       for port in input_midi_ports:
-        virtual = port not in get_available_input_ports()
-        if virtual:
-          tf.logging.info(
-              "Opening '%s' as a virtual MIDI port for input.", port)
-        inport = mido.open_input(port, virtual=virtual)
+        if isinstance(port, mido.ports.BaseInput):
+          inport = port
+        else:
+          virtual = port not in get_available_input_ports()
+          if virtual:
+            tf.logging.info(
+                "Opening '%s' as a virtual MIDI port for input.", port)
+          inport = mido.open_input(port, virtual=virtual)
         # Start processing incoming messages.
         inport.callback = self._timestamp_and_handle_message
         inports.append(inport)
@@ -920,11 +923,14 @@ class MidiHub(object):
 
     outports = []
     for port in output_midi_ports:
-      virtual = port not in get_available_output_ports()
-      if virtual:
-        tf.logging.info(
-            "Opening '%s' as a virtual MIDI port for output.", port)
-      outports.append(mido.open_output(port, virtual=virtual))
+      if isinstance(port, mido.ports.BaseOutput):
+        outports.append(port)
+      else:
+        virtual = port not in get_available_output_ports()
+        if virtual:
+          tf.logging.info(
+              "Opening '%s' as a virtual MIDI port for output.", port)
+        outports.append(mido.open_output(port, virtual=virtual))
     self._outport = mido.ports.MultiPort(outports)
 
   def __del__(self):


### PR DESCRIPTION
- Open input ports in `MidiHub` are no longer prematurely deleted.
- Determination of port existence has been corrected, so only names referring to non-existing ones result in the creation of new virtual ports.


