### PR TITLE
Specify the exact version of tensorflow-probability (0.7.0)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ REQUIRED_PACKAGES = [
     'sonnet',
     'sox >= 1.3.7',
     'tensorflow-datasets >= 1.0.2',
-    'tensorflow-probability >= 0.7.0rc0',
+    'tensorflow-probability == 0.7.0rc0',
     'tensor2tensor >= 1.13.4',
     'wheel',
     'futures;python_version=="2.7"',


### PR DESCRIPTION
They have released `tensorflow-probabilitys`  version 0.8.0, which is not compatible with the current `tensorflow` release, so we need to specify the exact version of `tensorflow-probability` to avoid the below error when using `melody-rnn` models:

>Traceback (most recent call last):
  File "/Users/dainguyen/anaconda3/envs/magenta/bin/melody_rnn_generate", line 6, in <module>
    from magenta.models.melody_rnn.melody_rnn_generate import console_entry_point
  File "/Users/dainguyen/anaconda3/envs/magenta/lib/python2.7/site-packages/magenta/__init__.py", line 26, in <module>
    import magenta.common.beam_search
  File "/Users/dainguyen/anaconda3/envs/magenta/lib/python2.7/site-packages/magenta/common/__init__.py", line 20, in <module>
    from .nade import Nade
  File "/Users/dainguyen/anaconda3/envs/magenta/lib/python2.7/site-packages/magenta/common/nade.py", line 24, in <module>
    import tensorflow_probability as tfp
  File "/Users/dainguyen/anaconda3/envs/magenta/lib/python2.7/site-packages/tensorflow_probability/__init__.py", line 68, in <module>
    _ensure_tf_install()
  File "/Users/dainguyen/anaconda3/envs/magenta/lib/python2.7/site-packages/tensorflow_probability/__init__.py", line 65, in _ensure_tf_install
    present=tf.__version__))
ImportError: This version of TensorFlow Probability requires TensorFlow version >= 1.15; Detected an installation of version 1.14.0. Please upgrade TensorFlow to proceed.

The ImportError said that we need to upgrade `tensorflow` to 1.15.0. However there's no version 1.15.0 of `tensorflow` yet, so the best way is to specify the `tensorflow-probability` package