### PR TITLE
apache beam now supports python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 build/
 *.DS_Store
 .vscode/*
+.idea/

--- a/conftest.py
+++ b/conftest.py
@@ -17,5 +17,3 @@
 import sys
 
 collect_ignore = []
-if sys.version_info.major != 2:
-  collect_ignore.append('magenta/models/score2perf/datagen_beam_test.py')

--- a/magenta/models/score2perf/README.md
+++ b/magenta/models/score2perf/README.md
@@ -35,9 +35,6 @@ music transformer, you'll probably want to use Cloud Dataflow or some other
 platform that supports Apache Beam. You can also run datagen locally, but it
 will be very slow due to the NoteSequence preprocessing.
 
-Unfortunately, as Apache Beam does not currently support Python 3, you'll need
-to use Python 2 here.
-
 Anyway, to prepare the dataset, do the following:
 
 1. Set up Google Cloud Dataflow. The quickest way to do this is described in [this guide](https://cloud.google.com/dataflow/docs/quickstarts/quickstart-python).

--- a/magenta/models/score2perf/datagen_beam.py
+++ b/magenta/models/score2perf/datagen_beam.py
@@ -23,9 +23,7 @@ import functools
 import hashlib
 import logging
 import os
-import sys
 import random
-from absl import flags
 import apache_beam as beam
 from apache_beam import typehints
 from apache_beam.metrics import Metrics
@@ -41,11 +39,11 @@ import typing
 # TODO(iansimon): this should probably be defined in the problem
 SCORE_BPM = 120.0
 
+FLAGS = tf.app.flags.FLAGS
+flags = tf.app.flags
 flags.DEFINE_string(
     'pipeline_options', '',
     'Command line flags to use in constructing the Beam pipeline options.')
-FLAGS = flags.FLAGS
-FLAGS(sys.argv)
 
 # TODO(iansimon): Figure out how to avoid explicitly serializing and
 # deserializing NoteSequence protos.

--- a/magenta/models/score2perf/datagen_beam.py
+++ b/magenta/models/score2perf/datagen_beam.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: skip-file
-# TODO(iansimon): Enable when Apache Beam supports Python 3.
 """Beam pipeline to generate examples for a Score2Perf dataset."""
 
 from __future__ import absolute_import
@@ -25,6 +23,7 @@ import functools
 import hashlib
 import logging
 import os
+import sys
 import random
 from absl import flags
 import apache_beam as beam
@@ -42,10 +41,11 @@ import typing
 # TODO(iansimon): this should probably be defined in the problem
 SCORE_BPM = 120.0
 
-FLAGS = flags.FLAGS
 flags.DEFINE_string(
     'pipeline_options', '',
     'Command line flags to use in constructing the Beam pipeline options.')
+FLAGS = flags.FLAGS
+FLAGS(sys.argv)
 
 # TODO(iansimon): Figure out how to avoid explicitly serializing and
 # deserializing NoteSequence protos.
@@ -72,7 +72,7 @@ class ReadNoteSequencesFromTFRecord(beam.PTransform):
 def select_split(cumulative_splits, kv, unused_num_partitions):
   """Select split for an `(id, _)` tuple using a hash of `id`."""
   key, _ = kv
-  m = hashlib.md5(key)
+  m = hashlib.md5(key.encode('utf-8'))
   r = int(m.hexdigest(), 16) / (2 ** (8 * m.digest_size))
   for i, (name, p) in enumerate(cumulative_splits):
     if r < p:
@@ -163,7 +163,7 @@ class ExtractExamplesDoFn(beam.DoFn):
     # Seed random number generator based on key so that hop times are
     # deterministic.
     key, ns_str = kv
-    m = hashlib.md5(key)
+    m = hashlib.md5(key.encode('utf-8'))
     random.seed(int(m.hexdigest(), 16))
 
     # Deserialize NoteSequence proto.
@@ -394,7 +394,7 @@ def generate_examples(input_transform, output_dir, problem_name, splits,
       raise ValueError(
           'Split probabilities must be provided if input is not presplit.')
     split_names, split_probabilities = zip(*splits.items())
-    cumulative_splits = zip(split_names, np.cumsum(split_probabilities))
+    cumulative_splits = list(zip(split_names, np.cumsum(split_probabilities)))
     if cumulative_splits[-1][1] != 1.0:
       raise ValueError('Split probabilities must sum to 1; got %f' %
                        cumulative_splits[-1][1])

--- a/magenta/models/score2perf/datagen_beam_test.py
+++ b/magenta/models/score2perf/datagen_beam_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: skip-file
-# TODO(iansimon): Enable when Apache Beam supports Python 3.
 """Tests for Score2Perf datagen using beam."""
 
 from __future__ import absolute_import

--- a/magenta/models/score2perf/score2perf.py
+++ b/magenta/models/score2perf/score2perf.py
@@ -24,6 +24,7 @@ import sys
 
 from magenta.models.score2perf import modalities
 from magenta.models.score2perf import music_encoders
+from magenta.models.score2perf import datagen_beam
 from magenta.music import chord_symbols_lib
 from magenta.music import sequences_lib
 from tensor2tensor.data_generators import problem
@@ -32,8 +33,6 @@ from tensor2tensor.models import transformer
 from tensor2tensor.utils import registry
 import tensorflow as tf
 
-if sys.version_info.major == 2:
-  from magenta.models.score2perf import datagen_beam  # pylint:disable=g-import-not-at-top,ungrouped-imports
 
 # TODO(iansimon): figure out the best way not to hard-code these constants
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ REQUIRED_PACKAGES = [
     'tensor2tensor >= 1.13.4',
     'wheel',
     'futures;python_version=="2.7"',
-    'apache-beam[gcp] >= 2.8.0;python_version=="2.7"',
+    'apache-beam[gcp] >= 2.14.0',
 ]
 
 # Magenta library is not yet TF2 compatible.


### PR DESCRIPTION
https://beam.apache.org/roadmap/python-sdk/#python-3-support

python 3.5 supported since 2.11.0 and python 3.6/3.7 supported since 2.14.0

this pr removes the python 2 conditionals for beam