### PR TITLE
SavedModel export script for Music VAE

### DIFF
--- a/magenta/models/music_vae/configs.py
+++ b/magenta/models/music_vae/configs.py
@@ -245,6 +245,11 @@ trio_16bar_converter = data.TrioConverter(
     steps_per_quarter=4,
     slice_bars=16,
     gap_bars=2)
+trio_4bar_converter = data.TrioConverter(
+    steps_per_quarter=4,
+    slice_bars=4,
+    gap_bars=2)
+
 
 CONFIG_MAP['flat-trio_16bar'] = Config(
     model=MusicVAE(
@@ -413,6 +418,40 @@ CONFIG_MAP['hier-mel_16bar'] = Config(
     train_examples_path=None,
     eval_examples_path=None,
 )
+
+CONFIG_MAP['hierdec-trio_4bar'] = Config(
+    model=MusicVAE(
+        lstm_models.BidirectionalLstmEncoder(),
+        lstm_models.HierarchicalLstmDecoder(
+            lstm_models.SplitMultiOutLstmDecoder(
+                core_decoders=[
+                    lstm_models.CategoricalLstmDecoder(),
+                    lstm_models.CategoricalLstmDecoder(),
+                    lstm_models.CategoricalLstmDecoder()],
+                output_depths=[
+                    90,  # melody
+                    90,  # bass
+                    512,  # drums
+                ]),
+            level_lengths=[8, 8],
+            disable_autoregression=True)),
+    hparams=merge_hparams(
+        lstm_models.get_default_hparams(),
+        HParams(
+            batch_size=128,
+            max_seq_len=64,
+            z_size=512,
+            enc_rnn_size=[1024, 1024],
+            dec_rnn_size=[512, 512],
+            free_bits=256,
+            max_beta=0.2,
+        )),
+    note_sequence_augmenter=None,
+    data_converter=trio_4bar_converter,
+    train_examples_path=None,
+    eval_examples_path=None,
+)
+
 
 # Multitrack
 multiperf_encoder = lstm_models.HierarchicalLstmEncoder(

--- a/magenta/models/music_vae/lstm_models.py
+++ b/magenta/models/music_vae/lstm_models.py
@@ -917,7 +917,7 @@ class HierarchicalLstmDecoder(base_model.BaseDecoder):
                hierarchical_encoder=None):
     """Initializer for HierarchicalLstmDecoder.
 
-    Hierarchicaly decodes a sequence across time.
+    Hierarchically decodes a sequence across time.
 
     Each sequence is padded per-segment. For example, a sequence with
     three segments [1, 2, 3], [4, 5], [6, 7, 8 ,9] and a `max_seq_len` of 12

--- a/magenta/models/music_vae/music_vae_export.py
+++ b/magenta/models/music_vae/music_vae_export.py
@@ -1,0 +1,219 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import json
+import tensorflow as tf
+from collections import namedtuple
+from tensorflow.python import saved_model
+from magenta.models.music_vae import configs
+
+
+# Function builds the VAE graph from a configuration object for exporting as a saved model
+def build_vae_graph(vae_config, batch_size, **sample_kwargs):
+    vae_graph = tf.Graph()
+    with vae_graph.as_default():
+        model = vae_config.model
+        model.build(
+            vae_config.hparams,
+            vae_config.data_converter.output_depth,
+            is_training=False)
+
+        # Define nodes for the model inputs
+        InputTensors = namedtuple(
+            "VAEInputTensors",
+            ["inputs", "controls", "inputs_length",
+             "c_input", "z_input", "temperature", "max_length"]
+        )
+        temperature = tf.placeholder(tf.float32, shape=())
+
+        if vae_config.hparams.z_size:
+            z_input = tf.placeholder(tf.float32, shape=[batch_size, vae_config.hparams.z_size])
+        else:
+            z_input = None
+
+        if vae_config.data_converter.control_depth > 0:
+            c_input = tf.placeholder(tf.float32, shape=[None, vae_config.data_converter.control_depth])
+        else:
+            c_input = None
+
+        inputs = tf.placeholder(
+            tf.float32,
+            shape=[batch_size, None, vae_config.data_converter.input_depth])
+        controls = tf.placeholder(
+            tf.float32,
+            shape=[batch_size, None, vae_config.data_converter.control_depth])
+        inputs_length = tf.placeholder(
+            tf.int32,
+            shape=[batch_size] + list(vae_config.data_converter.length_shape))
+
+        max_length = tf.placeholder(tf.int32, shape=())
+        input_tensors = InputTensors(inputs, controls, inputs_length, c_input, z_input, temperature, max_length)
+
+        # used in the trained_model decode functions, run in the stored session
+        OutputTensors = namedtuple(
+            "VAEOutputTensors",
+            ["outputs", "decoder_results", "mu", "sigma", "z"]
+        )
+        outputs, decoder_results = model.sample(
+            batch_size,
+            max_length=max_length,
+            z=z_input,
+            c_input=c_input,
+            temperature=temperature,
+            **sample_kwargs)
+
+        if vae_config.hparams.z_size:
+            q_z = model.encode(inputs, inputs_length, controls)
+            mu = q_z.loc
+            sigma = q_z.scale.diag
+            z = q_z.sample()
+        output_tensors = OutputTensors(outputs, decoder_results, mu, sigma, z)
+
+        signature_defs = build_signature_defs(input_tensors, output_tensors)
+
+    return vae_graph, signature_defs
+
+
+# This function has too many arguments, pass a data structure later
+def build_signature_defs(input_tensors, output_tensors):
+    sample_signature_def = build_sample_signature(input_tensors, output_tensors)
+    encode_signature_def = build_encode_signature(input_tensors, output_tensors)
+    decode_signature_def = build_decode_signature(input_tensors, output_tensors)
+
+    signature_def_map = {
+        'sample': sample_signature_def,
+        'encode': encode_signature_def,
+        'decode': decode_signature_def
+    }
+
+    return signature_def_map
+
+
+# TODO create a named registry of signature def builders keyed by name for better type safety
+# Sample seems almost exactly like decode from the trained model code, possibly redundant
+def build_sample_signature(input_tensors, output_tensors):
+    sample_inputs = {
+        'temperature': saved_model.utils.build_tensor_info(input_tensors.temperature),
+        'max_length': saved_model.utils.build_tensor_info(input_tensors.max_length)
+    }
+    if input_tensors.c_input is not None:
+        sample_inputs['c_input'] = saved_model.utils.build_tensor_info(input_tensors.c_input)
+    if input_tensors.z_input is not None:
+        sample_inputs['z_input'] = saved_model.utils.build_tensor_info(input_tensors.z_input)
+
+    sample_outputs = {
+        'outputs': saved_model.utils.build_tensor_info(output_tensors.outputs)
+
+    }
+
+    sample_signature_def = saved_model.signature_def_utils.build_signature_def(
+        inputs=sample_inputs,
+        outputs=sample_outputs,
+        method_name="sample"
+    )
+
+    return sample_signature_def
+
+
+def build_encode_signature(input_tensors, output_tensors):
+    # define the signature for the encoding operation
+    encode_inputs = {
+        'inputs': saved_model.utils.build_tensor_info(input_tensors.inputs),
+        'controls': saved_model.utils.build_tensor_info(input_tensors.controls),
+        'inputs_length': saved_model.utils.build_tensor_info(input_tensors.inputs_length)
+    }
+    encode_outputs = {
+        'mu': saved_model.utils.build_tensor_info(output_tensors.mu),
+        'sigma': saved_model.utils.build_tensor_info(output_tensors.sigma),
+        'z': saved_model.utils.build_tensor_info(output_tensors.z)
+    }
+
+    encode_signature_def = saved_model.signature_def_utils.build_signature_def(
+        inputs=encode_inputs,
+        outputs=encode_outputs,
+        method_name="encode"
+    )
+
+    return encode_signature_def
+
+
+def build_decode_signature(input_tensors, output_tensors):
+    decode_inputs = {
+        'temperature': saved_model.utils.build_tensor_info(input_tensors.temperature),
+        'max_length': saved_model.utils.build_tensor_info(input_tensors.max_length),
+        'z_input': saved_model.utils.build_tensor_info(input_tensors.z_input)
+    }
+    if input_tensors.c_input:
+        decode_inputs["c_input"] = saved_model.utils.build_tensor_info(input_tensors.c_input)
+
+    # Question for magenta team about this, appears in trained model as a return value from decode,
+    # but is not actually a tensor or operation
+    decode_outputs = {
+        'outputs': saved_model.utils.build_tensor_info(output_tensors.outputs),
+        # 'decoder_results': saved_model.utils.build_tensor_info(decoder_results)
+
+    }
+
+    decode_signature_def = saved_model.signature_def_utils.build_signature_def(
+        inputs=decode_inputs,
+        outputs=decode_outputs,
+        method_name='decode'
+    )
+
+    return decode_signature_def
+
+
+def export_saved_model(checkpoint_path, output_dir, config, batch_size, **sample_kwargs):
+    graph, signature_defs = build_vae_graph(config, batch_size, **sample_kwargs)
+
+    if tf.io.gfile.isdir(checkpoint_path):
+        checkpoint_path = tf.train.latest_checkpoint(checkpoint_path)
+        tf.logging.info('loading VAE checkpoint at: {}'.format(checkpoint_path))
+    elif not tf.io.gfile.exists(checkpoint_path + ".index"):
+        raise ValueError('Invalid checkpoint path specified: {}'.format(checkpoint_path))
+
+    builder = saved_model.builder.SavedModelBuilder(output_dir)
+
+    with tf.Session(graph=graph) as session:
+        saver = tf.train.Saver()
+        session.run([tf.local_variables_initializer(), tf.tables_initializer()])
+        saver.restore(session, checkpoint_path)
+        builder.add_meta_graph_and_variables(
+            session,
+            tags=[saved_model.tag_constants.SERVING],
+            signature_def_map=signature_defs
+        )
+
+    builder.save()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--checkpoint',
+        required=True,
+        help='Path to the checkpoint file'
+    )
+    parser.add_argument(
+        '--output-dir',
+        required=True,
+        help='output directory for the saved model'
+    )
+    parser.add_argument(
+        '--config',
+        required=True,
+        default=None,
+        help="""name of the VAE config to use """
+    )
+    parser.add_argument(
+        '--batch-size',
+        type=json.loads,
+        help="""batch size the model was trained with"""
+    )
+    args = parser.parse_args()
+    if args.config not in configs.CONFIG_MAP:
+        raise ValueError('Invalid config name: %s' % args.config)
+    config = configs.CONFIG_MAP[args.config]
+    export_saved_model(args.checkpoint, args.output_dir, config, args.batch_size)

--- a/magenta/models/music_vae/music_vae_train.py
+++ b/magenta/models/music_vae/music_vae_train.py
@@ -158,8 +158,7 @@ def train(train_dir,
         config.hparams, config.train_examples_path or config.tfds_name,
         train_dir)
   with tf.Graph().as_default():
-    with tf.device(tf.train.replica_device_setter(
-        num_ps_tasks, merge_devices=True)):
+    with tf.device(tf.train.replica_device_setter(num_ps_tasks, merge_devices=True)):
 
       model = config.model
       model.build(config.hparams,

--- a/magenta/models/music_vae/trained_model.py
+++ b/magenta/models/music_vae/trained_model.py
@@ -93,6 +93,7 @@ class TrainedModel(object):
           tf.int32,
           shape=[batch_size] + list(self._config.data_converter.length_shape))
       self._max_length = tf.placeholder(tf.int32, shape=())
+
       # Outputs
       self._outputs, self._decoder_results = model.sample(
           batch_size,

--- a/magenta/models/music_vae/trained_model.py
+++ b/magenta/models/music_vae/trained_model.py
@@ -93,7 +93,6 @@ class TrainedModel(object):
           tf.int32,
           shape=[batch_size] + list(self._config.data_converter.length_shape))
       self._max_length = tf.placeholder(tf.int32, shape=())
-
       # Outputs
       self._outputs, self._decoder_results = model.sample(
           batch_size,


### PR DESCRIPTION
Script exports a saved model.pb with 3 signature defs, sample/encode/decode based on the interface in trained_model.py. Not sure if sample signature def is necessary as it is basically the same thing as decode, except z is not optional. 

TrainedModel's decode optionally returns decoder_results, but this is not a tensor so I'm confused as to what this is/if it is used. Will remove that comment after clarification

Upcoming PR will include a ServableVAEModel class which can be imported to query an instance of this savedmodel running in TF serving