### PR TITLE
avoid CLOP by removing unwrap

### DIFF
--- a/magenta/models/gansynth/lib/spectral_ops.py
+++ b/magenta/models/gansynth/lib/spectral_ops.py
@@ -196,10 +196,10 @@ def unwrap(p, discont=np.pi, axis=-1):
   return unwrapped
 
 
-def instantaneous_frequency(phase_angle, time_axis=-2, use_unwrap=False):
+def instantaneous_frequency(phase_angle, time_axis=-2, use_unwrap=True):
   """Transform a fft tensor from phase angle to instantaneous frequency.
 
-  Take the finite difference of the phase. Pad with initial phase to
+  (Unwrap and) Take the finite difference of the phase. Pad with initial phase to
   keep the tensor the same size.
   Args:
     phase_angle: Tensor of angles in radians. [Batch, Time, Freqs]
@@ -207,6 +207,9 @@ def instantaneous_frequency(phase_angle, time_axis=-2, use_unwrap=False):
 
   Returns:
     dphase: Instantaneous frequency (derivative of phase). Same size as input.
+    
+  use_unwrap=True preserves original GANSynth behavior, whereas
+  use_unwrap=False will guard against loss of precision.
   """
   if use_unwrap:  # can lead to loss of precision
     phase_unwrapped = unwrap(phase_angle, axis=time_axis)


### PR DESCRIPTION
phase unwrapping is not necessary to obtain instantaneous frequency, and/but can lead to catastrophic loss of precision (CLOP), i.e. errors that grow with time; especially noticeable for long audio clips.
In tests, this proposed change led to better waveform reconstruction accuracy and faster execution. 
Note that when reconstructing phase from dphase, cumsum should also be avoided as this too can lead to CLOP. 
cf. https://gist.github.com/drscotthawley/3c812fde932c649cd3cd41ea8a29803c