### PR TITLE
The value of out is 128 if x is 1.0, but it should be 127

### DIFF
--- a/magenta/models/nsynth/utils.py
+++ b/magenta/models/nsynth/utils.py
@@ -80,7 +80,7 @@ def mu_law(x, mu=255, int8=False):
   """
   sign = tf.sign(x)
   out = sign * tf.math.log(1 + mu * tf.abs(x)) / np.log(1 + mu)
-  out = tf.math.floor(out * 127 - sign * (sign - 1.0) / 2.0)
+  out = tf.math.floor(out * 127 - sign * (sign - 1) / 2)
   if int8:
     out = tf.cast(out, tf.int8)
   return out

--- a/magenta/models/nsynth/utils.py
+++ b/magenta/models/nsynth/utils.py
@@ -80,7 +80,7 @@ def mu_law(x, mu=255, int8=False):
   """
   sign = tf.sign(x)
   out = sign * tf.math.log(1 + mu * tf.abs(x)) / np.log(1 + mu)
-  out = tf.math.floor(out * 127 + (sign - 1.0) / 2.0)
+  out = tf.math.floor(out * 127 - sign * (sign - 1.0) / 2.0)
   if int8:
     out = tf.cast(out, tf.int8)
   return out

--- a/magenta/models/nsynth/utils.py
+++ b/magenta/models/nsynth/utils.py
@@ -78,8 +78,9 @@ def mu_law(x, mu=255, int8=False):
   Returns:
     out: The Mu-Law encoded int8 data.
   """
-  out = tf.sign(x) * tf.log(1 + mu * tf.abs(x)) / np.log(1 + mu)
-  out = tf.floor(out * 128)
+  sign = tf.sign(x)
+  out = sign * tf.math.log(1 + mu * tf.abs(x)) / np.log(1 + mu)
+  out = tf.math.floor(out * 127 + (sign - 1.0) / 2.0)
   if int8:
     out = tf.cast(out, tf.int8)
   return out


### PR DESCRIPTION
The value of out is 128 if x is 1.0, but the mu-law value should be -128~127, get -128 if cast to int8 or  get Nan when compute loss if x is 1.0