### PR TITLE
Fix #1638: moved import read_bundle_file

### DIFF
--- a/magenta/interfaces/midi/magenta_midi.py
+++ b/magenta/interfaces/midi/magenta_midi.py
@@ -34,6 +34,7 @@ from magenta.models.melody_rnn import melody_rnn_sequence_generator
 from magenta.models.performance_rnn import performance_sequence_generator
 from magenta.models.pianoroll_rnn_nade import pianoroll_rnn_nade_sequence_generator
 from magenta.models.polyphony_rnn import polyphony_sequence_generator
+from magenta.models.shared import sequence_generator_bundle
 from six.moves import input  # pylint: disable=redefined-builtin
 import tensorflow as tf
 
@@ -272,9 +273,8 @@ def _validate_flags():
 def _load_generator_from_bundle_file(bundle_file):
   """Returns initialized generator from bundle file path or None if fails."""
   try:
-    bundle = magenta.music.sequence_generator_bundle.read_bundle_file(
-        bundle_file)
-  except magenta.music.sequence_generator_bundle.GeneratorBundleParseError:
+    bundle = sequence_generator_bundle.read_bundle_file(bundle_file)
+  except sequence_generator_bundle.GeneratorBundleParseError:
     print('Failed to parse bundle file: %s' % FLAGS.bundle_file)
     return None
 

--- a/magenta/models/drums_rnn/drums_rnn_generate.py
+++ b/magenta/models/drums_rnn/drums_rnn_generate.py
@@ -25,6 +25,8 @@ import magenta
 from magenta.models.drums_rnn import drums_rnn_config_flags
 from magenta.models.drums_rnn import drums_rnn_model
 from magenta.models.drums_rnn import drums_rnn_sequence_generator
+from magenta.models.shared import sequence_generator
+from magenta.models.shared import sequence_generator_bundle
 from magenta.music.protobuf import generator_pb2
 from magenta.music.protobuf import music_pb2
 import tensorflow as tf
@@ -102,7 +104,7 @@ def get_checkpoint():
   """Get the training dir or checkpoint path to be used by the model."""
   if ((FLAGS.run_dir or FLAGS.checkpoint_file) and
       FLAGS.bundle_file and not FLAGS.save_generator_bundle):
-    raise magenta.music.SequenceGeneratorError(
+    raise sequence_generator.SequenceGeneratorError(
         'Cannot specify both bundle_file and run_dir or checkpoint_file')
   if FLAGS.run_dir:
     train_dir = os.path.join(os.path.expanduser(FLAGS.run_dir), 'train')
@@ -125,7 +127,7 @@ def get_bundle():
   if FLAGS.bundle_file is None:
     return None
   bundle_file = os.path.expanduser(FLAGS.bundle_file)
-  return magenta.music.read_bundle_file(bundle_file)
+  return sequence_generator_bundle.read_bundle_file(bundle_file)
 
 
 def run_with_flags(generator):

--- a/magenta/models/improv_rnn/improv_rnn_generate.py
+++ b/magenta/models/improv_rnn/improv_rnn_generate.py
@@ -22,6 +22,8 @@ import magenta
 from magenta.models.improv_rnn import improv_rnn_config_flags
 from magenta.models.improv_rnn import improv_rnn_model
 from magenta.models.improv_rnn import improv_rnn_sequence_generator
+from magenta.models.shared import sequence_generator
+from magenta.models.shared import sequence_generator_bundle
 from magenta.music.protobuf import generator_pb2
 from magenta.music.protobuf import music_pb2
 import tensorflow as tf
@@ -109,7 +111,7 @@ tf.app.flags.DEFINE_string(
 def get_checkpoint():
   """Get the training dir to be used by the model."""
   if FLAGS.run_dir and FLAGS.bundle_file and not FLAGS.save_generator_bundle:
-    raise magenta.music.SequenceGeneratorError(
+    raise sequence_generator.SequenceGeneratorError(
         'Cannot specify both bundle_file and run_dir')
   if FLAGS.run_dir:
     train_dir = os.path.join(os.path.expanduser(FLAGS.run_dir), 'train')
@@ -130,7 +132,7 @@ def get_bundle():
   if FLAGS.bundle_file is None:
     return None
   bundle_file = os.path.expanduser(FLAGS.bundle_file)
-  return magenta.music.read_bundle_file(bundle_file)
+  return sequence_generator_bundle.read_bundle_file(bundle_file)
 
 
 def run_with_flags(generator):

--- a/magenta/models/melody_rnn/melody_rnn_generate.py
+++ b/magenta/models/melody_rnn/melody_rnn_generate.py
@@ -22,6 +22,8 @@ import magenta
 from magenta.models.melody_rnn import melody_rnn_config_flags
 from magenta.models.melody_rnn import melody_rnn_model
 from magenta.models.melody_rnn import melody_rnn_sequence_generator
+from magenta.models.shared import sequence_generator
+from magenta.models.shared import sequence_generator_bundle
 from magenta.music.protobuf import generator_pb2
 from magenta.music.protobuf import music_pb2
 import tensorflow as tf
@@ -99,7 +101,7 @@ def get_checkpoint():
   """Get the training dir or checkpoint path to be used by the model."""
   if ((FLAGS.run_dir or FLAGS.checkpoint_file) and
       FLAGS.bundle_file and not FLAGS.save_generator_bundle):
-    raise magenta.music.SequenceGeneratorError(
+    raise sequence_generator.SequenceGeneratorError(
         'Cannot specify both bundle_file and run_dir or checkpoint_file')
   if FLAGS.run_dir:
     train_dir = os.path.join(os.path.expanduser(FLAGS.run_dir), 'train')
@@ -122,7 +124,7 @@ def get_bundle():
   if FLAGS.bundle_file is None:
     return None
   bundle_file = os.path.expanduser(FLAGS.bundle_file)
-  return magenta.music.read_bundle_file(bundle_file)
+  return sequence_generator_bundle.read_bundle_file(bundle_file)
 
 
 def run_with_flags(generator):

--- a/magenta/models/performance_rnn/performance_rnn_generate.py
+++ b/magenta/models/performance_rnn/performance_rnn_generate.py
@@ -24,6 +24,8 @@ import time
 import magenta
 from magenta.models.performance_rnn import performance_model
 from magenta.models.performance_rnn import performance_sequence_generator
+from magenta.models.shared import sequence_generator
+from magenta.models.shared import sequence_generator_bundle
 from magenta.music import constants
 from magenta.music.protobuf import generator_pb2
 from magenta.music.protobuf import music_pb2
@@ -114,7 +116,7 @@ for control_signal_cls in magenta.music.all_performance_control_signals:
 def get_checkpoint():
   """Get the training dir or checkpoint path to be used by the model."""
   if FLAGS.run_dir and FLAGS.bundle_file and not FLAGS.save_generator_bundle:
-    raise magenta.music.SequenceGeneratorError(
+    raise sequence_generator.SequenceGeneratorError(
         'Cannot specify both bundle_file and run_dir')
   if FLAGS.run_dir:
     train_dir = os.path.join(os.path.expanduser(FLAGS.run_dir), 'train')
@@ -135,7 +137,7 @@ def get_bundle():
   if FLAGS.bundle_file is None:
     return None
   bundle_file = os.path.expanduser(FLAGS.bundle_file)
-  return magenta.music.read_bundle_file(bundle_file)
+  return sequence_generator_bundle.read_bundle_file(bundle_file)
 
 
 def run_with_flags(generator):

--- a/magenta/models/pianoroll_rnn_nade/pianoroll_rnn_nade_generate.py
+++ b/magenta/models/pianoroll_rnn_nade/pianoroll_rnn_nade_generate.py
@@ -24,6 +24,8 @@ import time
 import magenta
 from magenta.models.pianoroll_rnn_nade import pianoroll_rnn_nade_model
 from magenta.models.pianoroll_rnn_nade.pianoroll_rnn_nade_sequence_generator import PianorollRnnNadeSequenceGenerator
+from magenta.models.shared import sequence_generator
+from magenta.models.shared import sequence_generator_bundle
 from magenta.music import constants
 from magenta.music.protobuf import generator_pb2
 from magenta.music.protobuf import music_pb2
@@ -99,7 +101,7 @@ tf.app.flags.DEFINE_string(
 def get_checkpoint():
   """Get the training dir or checkpoint path to be used by the model."""
   if FLAGS.run_dir and FLAGS.bundle_file and not FLAGS.save_generator_bundle:
-    raise magenta.music.SequenceGeneratorError(
+    raise sequence_generator.SequenceGeneratorError(
         'Cannot specify both bundle_file and run_dir')
   if FLAGS.run_dir:
     train_dir = os.path.join(os.path.expanduser(FLAGS.run_dir), 'train')
@@ -120,7 +122,7 @@ def get_bundle():
   if FLAGS.bundle_file is None:
     return None
   bundle_file = os.path.expanduser(FLAGS.bundle_file)
-  return magenta.music.read_bundle_file(bundle_file)
+  return sequence_generator_bundle.read_bundle_file(bundle_file)
 
 
 def run_with_flags(generator):

--- a/magenta/models/polyphony_rnn/polyphony_rnn_generate.py
+++ b/magenta/models/polyphony_rnn/polyphony_rnn_generate.py
@@ -24,6 +24,8 @@ import time
 import magenta
 from magenta.models.polyphony_rnn import polyphony_model
 from magenta.models.polyphony_rnn import polyphony_sequence_generator
+from magenta.models.shared import sequence_generator
+from magenta.models.shared import sequence_generator_bundle
 from magenta.music import constants
 from magenta.music.protobuf import generator_pb2
 from magenta.music.protobuf import music_pb2
@@ -115,7 +117,7 @@ tf.app.flags.DEFINE_string(
 def get_checkpoint():
   """Get the training dir or checkpoint path to be used by the model."""
   if FLAGS.run_dir and FLAGS.bundle_file and not FLAGS.save_generator_bundle:
-    raise magenta.music.SequenceGeneratorError(
+    raise sequence_generator.SequenceGeneratorError(
         'Cannot specify both bundle_file and run_dir')
   if FLAGS.run_dir:
     train_dir = os.path.join(os.path.expanduser(FLAGS.run_dir), 'train')
@@ -136,7 +138,7 @@ def get_bundle():
   if FLAGS.bundle_file is None:
     return None
   bundle_file = os.path.expanduser(FLAGS.bundle_file)
-  return magenta.music.read_bundle_file(bundle_file)
+  return sequence_generator_bundle.read_bundle_file(bundle_file)
 
 
 def run_with_flags(generator):


### PR DESCRIPTION
I don't know what is your import policy so I've used the one in "magenta/scripts/unpack_bundle.py:22". Let me know if you prefer something else:

```python
from magenta.models.shared import sequence_generator_bundle
return sequence_generator_bundle.read_bundle_file(bundle_file)
```

I've also fixed other Exception imports from `magenta.models.shared.sequence_generator`