### PR TITLE
Fix import in read_bundle_file

### DIFF
--- a/magenta/models/shared/sequence_generator_bundle.py
+++ b/magenta/models/shared/sequence_generator_bundle.py
@@ -14,7 +14,7 @@
 
 """Utility functions for handling bundle files."""
 
-from magenta.protobuf import generator_pb2
+from magenta.music.protobuf import generator_pb2
 import tensorflow as tf
 from google.protobuf import message
 


### PR DESCRIPTION
Importing `magenta.protobuf` throws an error, changed to `magenta.music.protobuf`.