### PR TITLE
polyphony_rnn_train parameter fixed in README.md

### DIFF
--- a/magenta/models/polyphony_rnn/README.md
+++ b/magenta/models/polyphony_rnn/README.md
@@ -119,7 +119,7 @@ polyphony_rnn_train \
 --run_dir=/tmp/polyphony_rnn/logdir/run1 \
 --sequence_example_file=/tmp/polyphony_rnn/sequence_examples/eval_poly_tracks.tfrecord \
 --hparams="batch_size=64,rnn_layer_sizes=[64,64]" \
---num_training_steps=20000 \
+----num_eval_examples=20000 \
 --eval
 ```
 


### PR DESCRIPTION
polyphony_rnn_train example parameter is wrong
instead of num_training_set, it has to provide num_eval_example
if not, it will produce an error giving batch_size is not greater than 0