### PR TITLE
removing unnecessary - in readme.md on polyphony_rnn modelel

### DIFF
--- a/magenta/models/polyphony_rnn/README.md
+++ b/magenta/models/polyphony_rnn/README.md
@@ -119,7 +119,7 @@ polyphony_rnn_train \
 --run_dir=/tmp/polyphony_rnn/logdir/run1 \
 --sequence_example_file=/tmp/polyphony_rnn/sequence_examples/eval_poly_tracks.tfrecord \
 --hparams="batch_size=64,rnn_layer_sizes=[64,64]" \
-----num_eval_examples=20000 \
+--num_eval_examples=20000 \
 --eval
 ```
 


### PR DESCRIPTION
There is too many "-" on example; (readme.md on models polyphonyy_rnn)