### PR TITLE
Update magenta-install.sh

### DIFF
--- a/magenta/tools/magenta-install.sh
+++ b/magenta/tools/magenta-install.sh
@@ -92,14 +92,14 @@ conda create -n magenta python=3.7
 # In order to determine if any errors occurred while executing it, we verify
 # that the environment changed afterward.
 set +e
-source activate magenta
+conda activate magenta
 set -e
 if [[ $(conda info --envs | grep "*" | awk '{print $1}') != "magenta" ]]; then
   err 'Did not successfully activate the magenta conda environment'
 fi
 
 # Install other dependencies
-pip3 install jupyter magenta
+pip install jupyter magenta
 
 # Install rtmidi for realtime midi IO
 if [[ $(which apt-get) ]]; then
@@ -111,7 +111,7 @@ if [[ $(which apt-get) ]]; then
     echo ""
     sudo apt-get install build-essential libasound2-dev libjack-dev
 fi
-pip3 install --pre python-rtmidi
+pip install --pre python-rtmidi
 
 echo ""
 echo "=============================="


### PR DESCRIPTION
As of Anaconda version 4.4, it is advised to use `conda activate ...` instead of `source activate. `
Another change is that the pip3 is replaced by pip as we are already specifying the python version while creating the environment.