### PR TITLE
Bugfix: Fix out of bounds error for getting z notes

### DIFF
--- a/magenta/models/gansynth/lib/generate_util.py
+++ b/magenta/models/gansynth/lib/generate_util.py
@@ -62,6 +62,10 @@ def get_z_notes(start_times, z_instruments, t_instruments):
   z_notes = []
   for t in start_times:
     idx = np.searchsorted(t_instruments, t, side='left') - 1
+    
+    if idx.item() == t_instruments.size - 1:
+      idx -= 1
+    
     t_left = t_instruments[idx]
     t_right = t_instruments[idx + 1]
     interp = (t - t_left) / (t_right - t_left)


### PR DESCRIPTION
Fixes this out of bounds error by reducing the index number by 1 when
the index produced by searchsorted is equal to the last index of
t_instruments