### PR TITLE
Minor code fixes

### DIFF
--- a/magenta/models/sketch_rnn/sketch_rnn_train.py
+++ b/magenta/models/sketch_rnn/sketch_rnn_train.py
@@ -131,9 +131,9 @@ def load_dataset(data_dir, model_params, inference_mode=False):
     else:
       data_filepath = os.path.join(data_dir, dataset)
       if six.PY3:
-        data = np.load(data_filepath, encoding='latin1')
+        data = np.load(data_filepath, encoding='latin1',allow_pickle=True)
       else:
-        data = np.load(data_filepath)
+        data = np.load(data_filepath,allow_pickle=True)
     tf.logging.info('Loaded {}/{}/{} from {}'.format(
         len(data['train']), len(data['valid']), len(data['test']),
         dataset))
@@ -429,7 +429,7 @@ def trainer(model_params):
 
   tf.logging.info('sketch-rnn')
   tf.logging.info('Hyperparams:')
-  for key, val in six.iteritems(list(model_params.values())):
+  for key, val in six.iteritems(model_params.values()):
     tf.logging.info('%s = %s', key, str(val))
   tf.logging.info('Loading data files.')
   datasets = load_dataset(FLAGS.data_dir, model_params)


### PR DESCRIPTION
1. `allow_pickle=True` flag is added for loading `npz` in order to avoid `Object arrays cannot be loaded when allow_pickle=False` error.
2. List does not have `.items()` as an attribute.