### PR TITLE
`mm.plot_sequence()` changed Bokeh plotting tool "previewsave" to "save" (issue: #1697)

### DIFF
--- a/magenta/music/notebook_utils.py
+++ b/magenta/music/notebook_utils.py
@@ -147,7 +147,7 @@ def plot_sequence(sequence,
   # These are hard-coded reasonable values, but the user can override them
   # by updating the figure if need be.
   fig = bokeh.plotting.figure(
-      tools='hover,pan,box_zoom,reset,previewsave')
+      tools='hover,pan,box_zoom,reset,save')
   fig.plot_width = 500
   fig.plot_height = 200
   fig.xaxis.axis_label = 'time (sec)'


### PR DESCRIPTION
Bokeh plotting tool does not support the name "previewsave".
Tooling option has now been changed to "save". 

Refer to issue #1697 