### PR TITLE
Fixed bug in music VAE training script with make_one_shot_iterator

### DIFF
--- a/magenta/models/music_vae/music_vae_train.py
+++ b/magenta/models/music_vae/music_vae_train.py
@@ -120,7 +120,7 @@ def _trial_summary(hparams, examples_path, output_dir):
 def _get_input_tensors(dataset, config):
   """Get input tensors from dataset."""
   batch_size = config.hparams.batch_size
-  iterator = dataset.make_one_shot_iterator()
+  iterator = tf.data.make_one_shot_iterator(dataset)
   (input_sequence, output_sequence, control_sequence,
    sequence_length) = iterator.get_next()
   input_sequence.set_shape(


### PR DESCRIPTION
`tf.data.Dataset.make_one_shot_iterator()` was deprecated in V1 and removed from V2, replaced with `tf.compat.v1.data.make_one_shot_iterator()`

See [this issue](https://github.com/tensorflow/tensorflow/issues/29252) for more details

Closes #1699 