### PR TITLE
sketch_rnn: Fixed an attribute error due to "six" module in python 3 and fixed loading of .npz datasets.

### DIFF
--- a/magenta/models/sketch_rnn/sketch_rnn_train.py
+++ b/magenta/models/sketch_rnn/sketch_rnn_train.py
@@ -130,10 +130,7 @@ def load_dataset(data_dir, model_params, inference_mode=False):
       data = np.load(six.BytesIO(response.content), encoding='latin1')
     else:
       data_filepath = os.path.join(data_dir, dataset)
-      if six.PY3:
-        data = np.load(data_filepath, encoding='latin1', allow_pickle=True)
-      else:
-        data = np.load(data_filepath, allow_pickle=True)
+      data = np.load(data_filepath, encoding='latin1', allow_pickle=True)
     tf.logging.info('Loaded {}/{}/{} from {}'.format(
         len(data['train']), len(data['valid']), len(data['test']),
         dataset))

--- a/magenta/models/sketch_rnn/sketch_rnn_train.py
+++ b/magenta/models/sketch_rnn/sketch_rnn_train.py
@@ -131,9 +131,9 @@ def load_dataset(data_dir, model_params, inference_mode=False):
     else:
       data_filepath = os.path.join(data_dir, dataset)
       if six.PY3:
-        data = np.load(data_filepath, encoding='latin1')
+        data = np.load(data_filepath, encoding='latin1', allow_pickle=True)
       else:
-        data = np.load(data_filepath)
+        data = np.load(data_filepath, allow_pickle=True)
     tf.logging.info('Loaded {}/{}/{} from {}'.format(
         len(data['train']), len(data['valid']), len(data['test']),
         dataset))
@@ -429,8 +429,8 @@ def trainer(model_params):
 
   tf.logging.info('sketch-rnn')
   tf.logging.info('Hyperparams:')
-  for key, val in six.iteritems(list(model_params.values())):
-    tf.logging.info('%s = %s', key, str(val))
+  # for key, val in six.iteritems(list(model_params.values())):
+  #   tf.logging.info('%s = %s', key, str(val))
   tf.logging.info('Loading data files.')
   datasets = load_dataset(FLAGS.data_dir, model_params)
 

--- a/magenta/models/sketch_rnn/sketch_rnn_train.py
+++ b/magenta/models/sketch_rnn/sketch_rnn_train.py
@@ -429,8 +429,6 @@ def trainer(model_params):
 
   tf.logging.info('sketch-rnn')
   tf.logging.info('Hyperparams:')
-  # for key, val in six.iteritems(list(model_params.values())):
-  #   tf.logging.info('%s = %s', key, str(val))
   tf.logging.info('Loading data files.')
   datasets = load_dataset(FLAGS.data_dir, model_params)
 


### PR DESCRIPTION
Referencing this issue - #1708 

As discussed with @hardmaru , fixed 2 things - 
1. Commented these [two lines](https://github.com/tensorflow/magenta/blob/master/magenta/models/sketch_rnn/sketch_rnn_train.py#L432) to get rid of the attribute error which was occurring because of "six" module. Mostly a python2/3 issue
2. Added `allow_pickle=True`  parameter to the `np.load()` function without which training wouldn't proceed.

Trained successfully after making these changes :)
