### PR TITLE
nsynth save embeddings fix extension strip

### DIFF
--- a/magenta/models/nsynth/wavenet/nsynth_save_embeddings.py
+++ b/magenta/models/nsynth/wavenet/nsynth_save_embeddings.py
@@ -110,7 +110,7 @@ def main(unused_argv=None):
       tf.logging.info("Sample length: %d" % sample_length)
 
       for num, (wavfile, enc) in enumerate(zip(wavefiles_batch, encoding)):
-        filename = "%s_embeddings.npy" % wavfile.split("/")[-1].strip(".wav")
+        filename = "%s_embeddings.npy" % wavfile.split("/")[-1].rsplit( ".", 1 )[ 0 ] 
         with tf.gfile.Open(os.path.join(save_path, filename), "w") as f:
           np.save(f, enc)
 


### PR DESCRIPTION
If the wavfile contains 'w', 'a' or 'v' in the filename the strip would remove them before. 
Current implementation:
filename = example-aaaa.wav 
output filename = example-_embeddings.npy
Fixed implementation:
filename = example-aaaa.wav 
output filename = example-aaaa_embeddings.npy